### PR TITLE
Fix background notification actions not triggering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,9 +51,6 @@ const arkaplanMuhafiziBildirimleriniPlanla = async () => {
     // Bildirim izinlerini iste
     await BildirimServisi.getInstance().izinIste();
 
-    // Bildirim dinleyicisini baslat (Kildim aksiyonu icin)
-    await BildirimServisi.getInstance().baslatBildirimDinleyicisi();
-
     // Sıklıklar için varsayılan değerler
     const sikliklar = muhafizAyarlari.sikliklar || { seviye1: 15, seviye2: 10, seviye3: 5, seviye4: 1 };
 

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,9 @@ import { BildirimServisi } from './src/domain/services/BildirimServisi';
 
 // Bildirim dinleyicisini global olarak baslat
 // Bu, uygulama kapali veya arka plandayken gelen bildirim aksiyonlarini yakalamak icin kritiktir
-BildirimServisi.getInstance().baslatBildirimDinleyicisi();
+BildirimServisi.getInstance().baslatBildirimDinleyicisi().catch(err => {
+    console.error('[index.ts] Bildirim dinleyicisi başlatılamadı:', err);
+});
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,11 @@ configureReanimatedLogger({
 });
 
 import App from './App';
+import { BildirimServisi } from './src/domain/services/BildirimServisi';
+
+// Bildirim dinleyicisini global olarak baslat
+// Bu, uygulama kapali veya arka plandayken gelen bildirim aksiyonlarini yakalamak icin kritiktir
+BildirimServisi.getInstance().baslatBildirimDinleyicisi();
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -191,4 +191,32 @@ export const ROZET_RENKLERI = {
   ELMAS: '#B9F2FF',
 } as const;
 
+// ==================== BILDIRIM SISTEMI SABITLERI ====================
+
+/**
+ * Bildirim sistemi sabitleri
+ */
+export const BILDIRIM_SABITLERI = {
+  // Muhafiz aksiyonlari
+  AKSIYONLAR: {
+    KILDIM: 'kildim_action',
+  },
+  // Kategoriler
+  KATEGORI: {
+    MUHAFIZ: 'muhafiz_category',
+  },
+  // Bildirim ID Onekleri
+  ONEKLEME: {
+    MUHAFIZ: 'muhafiz_',
+    VAKIT: '_vakit_',
+    SEVIYE: '_seviye_',
+    DAKIKA: '_dk_',
+  },
+  // Bildirim Kanallari
+  KANALLAR: {
+    VARSAYILAN: 'default',
+    MUHAFIZ: 'muhafiz',
+    MUHAFIZ_ACIL: 'muhafiz_acil',
+  },
+} as const;
 

--- a/src/domain/services/ArkaplanMuhafizServisi.ts
+++ b/src/domain/services/ArkaplanMuhafizServisi.ts
@@ -10,13 +10,12 @@ import * as Notifications from 'expo-notifications';
 import { Coordinates, CalculationMethod, PrayerTimes } from 'adhan';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SEYTANLA_MUCADELE_ICERIGI } from '../../core/data/SeytanlaMucadeleIcerigi';
-import { DEPOLAMA_ANAHTARLARI } from '../../core/constants/UygulamaSabitleri';
-import { MUHAFIZ_KATEGORISI } from './BildirimServisi';
+import { DEPOLAMA_ANAHTARLARI, BILDIRIM_SABITLERI } from '../../core/constants/UygulamaSabitleri';
 
 /**
  * Vakit tipi (Turkce)
  */
-type VakitAdi = 'imsak' | 'gunes' | 'ogle' | 'ikindi' | 'aksam' | 'yatsi';
+export type VakitAdi = 'imsak' | 'gunes' | 'ogle' | 'ikindi' | 'aksam' | 'yatsi';
 
 /**
  * Namaz vakti bilgisi
@@ -48,16 +47,6 @@ export interface ArkaplanMuhafizAyarlari {
         seviye4Siklik: number; // siklik dk (orn: 1)
     };
 }
-
-/**
- * Bildirim ID onek sabitleri
- */
-const BILDIRIM_ONEK = {
-    MUHAFIZ: 'muhafiz_',
-    VAKIT: '_vakit_',
-    SEVIYE: '_seviye_',
-    DAKIKA: '_dk_',
-};
 
 /**
  * Arka plan muhafiz servisini yoneten sinif
@@ -335,7 +324,7 @@ export class ArkaplanMuhafizServisi {
             const mesaj = this.bildirimMesajiOlustur(vakit.vakit, veri.seviye, veri.dakika);
             // ID'ye dakikayi da ekleyelim ki uniqueness bozulmasin
             // Vakit tarihini kullan (yatsi icin onceki gun olabilir)
-            const bildirimId = this.bildirimIdOlustur(vakit.vakit, veri.seviye, vakit.tarih) + BILDIRIM_ONEK.DAKIKA + kalanDk;
+            const bildirimId = this.bildirimIdOlustur(vakit.vakit, veri.seviye, vakit.tarih) + BILDIRIM_SABITLERI.ONEKLEME.DAKIKA + kalanDk;
 
             await this.tekBildirimPlanla(
                 bildirimId,
@@ -386,7 +375,7 @@ export class ArkaplanMuhafizServisi {
                     priority: seviye >= 3
                         ? Notifications.AndroidNotificationPriority.MAX
                         : Notifications.AndroidNotificationPriority.HIGH,
-                    categoryIdentifier: MUHAFIZ_KATEGORISI,
+                    categoryIdentifier: BILDIRIM_SABITLERI.KATEGORI.MUHAFIZ,
                     data: {
                         tip: 'muhafiz',
                         seviye: seviye,
@@ -448,7 +437,7 @@ export class ArkaplanMuhafizServisi {
      * @param tarih Vaktin ait oldugu tarih (YYYY-MM-DD)
      */
     private bildirimIdOlustur(vakit: VakitAdi, seviye: number, tarih: string): string {
-        return `${BILDIRIM_ONEK.MUHAFIZ}${tarih}${BILDIRIM_ONEK.VAKIT}${vakit}${BILDIRIM_ONEK.SEVIYE}${seviye}`;
+        return `${BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ}${tarih}${BILDIRIM_SABITLERI.ONEKLEME.VAKIT}${vakit}${BILDIRIM_SABITLERI.ONEKLEME.SEVIYE}${seviye}`;
     }
 
     /**
@@ -467,7 +456,7 @@ export class ArkaplanMuhafizServisi {
         for (const bildirim of tumBildirimler) {
             // Bu vakite ait muhafiz bildirimi mi kontrol et
             for (const tarih of tarihler) {
-                const bildirimOneki = `${BILDIRIM_ONEK.MUHAFIZ}${tarih}${BILDIRIM_ONEK.VAKIT}${vakit}`;
+                const bildirimOneki = `${BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ}${tarih}${BILDIRIM_SABITLERI.ONEKLEME.VAKIT}${vakit}`;
                 if (bildirim.identifier.startsWith(bildirimOneki)) {
                     try {
                         await Notifications.cancelScheduledNotificationAsync(bildirim.identifier);
@@ -493,7 +482,7 @@ export class ArkaplanMuhafizServisi {
             const tumBildirimler = await Notifications.getAllScheduledNotificationsAsync();
 
             for (const bildirim of tumBildirimler) {
-                if (bildirim.identifier.startsWith(BILDIRIM_ONEK.MUHAFIZ)) {
+                if (bildirim.identifier.startsWith(BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ)) {
                     await Notifications.cancelScheduledNotificationAsync(bildirim.identifier);
                 }
             }
@@ -649,7 +638,7 @@ export class ArkaplanMuhafizServisi {
         console.log('[ArkaplanMuhafiz] Planlanan bildirimler:');
 
         for (const bildirim of bildirimler) {
-            if (bildirim.identifier.startsWith(BILDIRIM_ONEK.MUHAFIZ)) {
+            if (bildirim.identifier.startsWith(BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ)) {
                 console.log(`  - ${bildirim.identifier}: ${bildirim.content.title}`);
             }
         }

--- a/src/domain/services/BildirimServisi.ts
+++ b/src/domain/services/BildirimServisi.ts
@@ -17,6 +17,13 @@ const vakitAdiToNamazAdi: Record<string, NamazAdi> = {
 };
 
 /**
+ * String'in gecerli bir VakitAdi olup olmadigini kontrol et
+ */
+function isVakitAdi(vakit: string): vakit is VakitAdi {
+  return ['imsak', 'gunes', 'ogle', 'ikindi', 'aksam', 'yatsi'].includes(vakit);
+}
+
+/**
  * Onceki muhafiz bildirimlerini bildirim merkezinden temizle
  * Yeni bildirim geldiginde eski bildirimlerin birikmesini onler
  */
@@ -186,7 +193,11 @@ export class BildirimServisi {
 
       // Bu vakit icin kalan tum bildirimleri iptal et
       // ArkaplanMuhafizServisi uzerinden iptal et (boylece kilinanlar listesine de eklenir)
-      await ArkaplanMuhafizServisi.getInstance().vakitBildirimleriniIptalEt(vakit as VakitAdi);
+      if (isVakitAdi(vakit)) {
+        await ArkaplanMuhafizServisi.getInstance().vakitBildirimleriniIptalEt(vakit);
+      } else {
+        console.warn('[BildirimServisi] Vakit adı doğrulanamadı, iptal işlemi atlandı:', vakit);
+      }
 
       // Bildirim merkezindeki bu bildirimi de kapat
       await Notifications.dismissAllNotificationsAsync();


### PR DESCRIPTION
Bu değişiklik, Android cihazlarda uygulama arka planda veya tamamen kapalıyken (killed state) bildirim üzerindeki "Kıldım" butonunun çalışmaması sorununu çözer.

**Yapılan Değişiklikler:**
1.  **Global Dinleyici:** Bildirim dinleyicisi (`listener`), React bileşenlerinin (`App.tsx`) içinden çıkarılarak uygulamanın giriş noktası olan `index.ts` dosyasına taşındı. Bu sayede uygulama UI yüklenmeden önce bile aksiyonları yakalayabilir hale geldi.
2.  **Veri Tutarlılığı:** Bildirim servisindeki "Kıldım" aksiyonu, sadece arayüzü güncellemekle kalmayıp, artık `ArkaplanMuhafizServisi` ile haberleşerek ilgili vaktin "kılındı" olarak işaretlenmesini ve o vakit için planlanmış diğer hatırlatıcıların iptal edilmesini sağlıyor.
3.  **Kod Düzeni:** Bildirimlerle ilgili sabitler (ID ön ekleri, kategori isimleri vb.) merkezi bir dosya olan `UygulamaSabitleri.ts` içerisine taşındı.

Bu düzeltme ile kullanıcı bildirime tıkladığında bildirimler temizlenecek ve uygulama açıldığında vakit doğru şekilde işaretlenmiş olacaktır.

---
*PR created automatically by Jules for task [922489163305591346](https://jules.google.com/task/922489163305591346) started by @furkanisikay*