### PR TITLE
feat: otomatik güncelleme kontrolü ve bildirim sistemi eklendi

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,8 @@ import { muhafizAyarlariniYukle } from './src/presentation/store/muhafizSlice';
 import { konumAyarlariniYukle, konumAyarlariniGuncelle } from './src/presentation/store/konumSlice';
 import { namazlariYukle } from './src/presentation/store/namazSlice';
 import { KonumTakipServisi } from './src/domain/services/KonumTakipServisi';
+import { GuncellemeBildirimi } from './src/presentation/components/guncelleme/GuncellemeBildirimi';
+import { guncellemeKontrolEt } from './src/presentation/store/guncellemeSlice';
 
 // Bildirim aksiyonu callback'ini ayarla (domain → presentation koprusu)
 // Kullanici bildirimden "Kildim" yaptiginda Redux store'u gunceller
@@ -158,6 +160,9 @@ const AppIcerik: React.FC = () => {
     // Konum takibini senkronize et ve yeniden baslat
     konumTakibiniSenkronizeEt();
 
+    // Guncelleme kontrolu (sessiz, arka planda)
+    store.dispatch(guncellemeKontrolEt(false));
+
     // Uygulama on plana geldiginde bildirimleri yeniden planla ve konum takibini senkronize et
     const appStateListener = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
       if (nextAppState === 'active') {
@@ -165,6 +170,8 @@ const AppIcerik: React.FC = () => {
         arkaplanMuhafiziBildirimleriniPlanla();
         // Konum takibini senkronize et ve yeniden baslat
         konumTakibiniSenkronizeEt();
+        // Guncelleme kontrolu (onbellek gecerlilik surecine uyar)
+        store.dispatch(guncellemeKontrolEt(false));
       }
     });
 
@@ -179,13 +186,14 @@ const AppIcerik: React.FC = () => {
   }
 
   return (
-    <>
+    <View style={styles.container}>
       <StatusBar
         backgroundColor={renkler.birincil}
         barStyle="light-content"
       />
       <AppNavigator />
-    </>
+      <GuncellemeBildirimi />
+    </View>
   );
 };
 

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -39,6 +39,28 @@ export const UYGULAMA = {
   ADI: 'Namaz Akışı',
   VERSIYON: '0.3.0',
   ACIKLAMA: 'Günlük namaz takip uygulaması',
+  GITHUB_REPO: 'furkanisikay/namazakisi',
+} as const;
+
+// ==================== GUNCELLEME SISTEMI SABITLERI ====================
+
+/**
+ * Guncelleme kontrol kaynaklari
+ */
+export type GuncellemeKaynagiTipi = 'github' | 'playstore' | 'appstore';
+
+/**
+ * Guncelleme kontrol ayarlari
+ */
+export const GUNCELLEME_SABITLERI = {
+  /** Kontroller arasi minimum bekleme suresi (milisaniye) - 6 saat */
+  KONTROL_ARALIGI: 6 * 60 * 60 * 1000,
+  /** GitHub API zaman asimi (milisaniye) */
+  API_ZAMAN_ASIMI: 10000,
+  /** Kullanicinin "Sonra" dedikten sonra tekrar gostermeden once bekleme (milisaniye) - 24 saat */
+  ERTELEME_SURESI: 24 * 60 * 60 * 1000,
+  /** AsyncStorage anahtari */
+  DEPOLAMA_ANAHTARI: '@namaz_akisi/guncelleme_durumu',
 } as const;
 
 // Renk paleti

--- a/src/domain/services/__tests__/GuncellemeServisi.test.ts
+++ b/src/domain/services/__tests__/GuncellemeServisi.test.ts
@@ -1,0 +1,490 @@
+/**
+ * GuncellemeServisi Testleri
+ *
+ * Guncelleme kontrol servisi icin kapsamli birim testleri:
+ * - Versiyon karsilastirma
+ * - GitHub API entegrasyonu
+ * - Onbellek mekanizmasi
+ * - Erteleme mantigi
+ * - Offline davranisi
+ * - Provider pattern
+ */
+
+import {
+  GuncellemeServisi,
+  GitHubGuncellemeKaynagi,
+  versiyonKarsilastir,
+  yayinTarihiniFormatla,
+  GuncellemeKaynagi,
+  GuncellemeKontrolSonucu,
+} from '../GuncellemeServisi';
+import { UYGULAMA, GUNCELLEME_SABITLERI } from '../../../core/constants/UygulamaSabitleri';
+
+// ==================== MOCKLAR ====================
+
+// AsyncStorage mock
+const asyncStorageMock: Record<string, string> = {};
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(asyncStorageMock[key] || null)),
+  setItem: jest.fn((key: string, value: string) => {
+    asyncStorageMock[key] = value;
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete asyncStorageMock[key];
+    return Promise.resolve();
+  }),
+}));
+
+// react-native Platform mock
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'android',
+  },
+}));
+
+// Global fetch mock
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// ==================== YARDIMCI FONKSIYONLAR ====================
+
+/**
+ * Mock GitHub API yaniti olustur
+ */
+function githubYanitiOlustur(versiyon: string, options: {
+  body?: string;
+  assets?: { name: string; browser_download_url: string }[];
+  published_at?: string;
+  html_url?: string;
+} = {}) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({
+      tag_name: `v${versiyon}`,
+      body: options.body || `## v${versiyon}\n- Yeni ozellikler\n- Hata duzeltmeleri`,
+      assets: options.assets || [
+        {
+          name: `NamazAkisi-v${versiyon}.apk`,
+          browser_download_url: `https://github.com/furkanisikay/namazakisi/releases/download/v${versiyon}/NamazAkisi-v${versiyon}.apk`,
+        },
+      ],
+      published_at: options.published_at || '2026-02-14T10:00:00Z',
+      html_url: options.html_url || `https://github.com/furkanisikay/namazakisi/releases/tag/v${versiyon}`,
+    }),
+  };
+}
+
+/**
+ * Basarili ag kontrolu icin fetch mock ayarla
+ */
+function agBasariliMock() {
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes('/zen')) {
+      return Promise.resolve({ ok: true });
+    }
+    return Promise.resolve(githubYanitiOlustur('1.0.0'));
+  });
+}
+
+// ==================== TESTLER ====================
+
+describe('versiyonKarsilastir', () => {
+  it('esit versiyonlar icin 0 dondurur', () => {
+    expect(versiyonKarsilastir('1.0.0', '1.0.0')).toBe(0);
+    expect(versiyonKarsilastir('0.3.0', '0.3.0')).toBe(0);
+  });
+
+  it('daha buyuk major versiyon icin pozitif dondurur', () => {
+    expect(versiyonKarsilastir('2.0.0', '1.0.0')).toBeGreaterThan(0);
+  });
+
+  it('daha kucuk major versiyon icin negatif dondurur', () => {
+    expect(versiyonKarsilastir('1.0.0', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('minor versiyon farkini dogru karsilastirir', () => {
+    expect(versiyonKarsilastir('1.2.0', '1.1.0')).toBeGreaterThan(0);
+    expect(versiyonKarsilastir('1.1.0', '1.2.0')).toBeLessThan(0);
+  });
+
+  it('patch versiyon farkini dogru karsilastirir', () => {
+    expect(versiyonKarsilastir('1.0.2', '1.0.1')).toBeGreaterThan(0);
+    expect(versiyonKarsilastir('1.0.1', '1.0.2')).toBeLessThan(0);
+  });
+
+  it('v onekini dogru isler', () => {
+    expect(versiyonKarsilastir('v1.0.0', '1.0.0')).toBe(0);
+    expect(versiyonKarsilastir('v2.0.0', 'v1.0.0')).toBeGreaterThan(0);
+  });
+
+  it('farkli uzunlukta versiyonlari karsilastirir', () => {
+    expect(versiyonKarsilastir('1.0', '1.0.0')).toBe(0);
+    expect(versiyonKarsilastir('1.0.1', '1.0')).toBeGreaterThan(0);
+  });
+
+  it('gecersiz versiyon parcalari icin 0 kullanir', () => {
+    expect(versiyonKarsilastir('1.abc.0', '1.0.0')).toBe(0);
+  });
+});
+
+describe('yayinTarihiniFormatla', () => {
+  it('ISO tarihini dd.mm.yyyy formatina cevirir', () => {
+    const sonuc = yayinTarihiniFormatla('2026-02-14T10:00:00Z');
+    expect(sonuc).toMatch(/14\.02\.2026/);
+  });
+
+  it('bos string icin bos string dondurur', () => {
+    expect(yayinTarihiniFormatla('')).toBe('');
+  });
+
+  it('gecersiz tarih icin bos string dondurur', () => {
+    expect(yayinTarihiniFormatla('gecersiz')).toBe('');
+  });
+});
+
+describe('GitHubGuncellemeKaynagi', () => {
+  let kaynak: GitHubGuncellemeKaynagi;
+
+  beforeEach(() => {
+    kaynak = new GitHubGuncellemeKaynagi('furkanisikay/namazakisi');
+    mockFetch.mockReset();
+  });
+
+  it('tum platformlarda desteklenir', () => {
+    expect(kaynak.destekleniyor()).toBe(true);
+  });
+
+  it('tip olarak github dondurur', () => {
+    expect(kaynak.tip).toBe('github');
+  });
+
+  it('yeni versiyon mevcut oldugunda guncellemeMevcut true dondurur', async () => {
+    const yeniVersiyon = '99.0.0'; // Mevcut versiyondan buyuk
+    mockFetch.mockResolvedValue(githubYanitiOlustur(yeniVersiyon));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.guncellemeMevcut).toBe(true);
+    expect(sonuc.bilgi?.yeniVersiyon).toBe(yeniVersiyon);
+    expect(sonuc.bilgi?.mevcutVersiyon).toBe(UYGULAMA.VERSIYON);
+    expect(sonuc.bilgi?.kaynak).toBe('github');
+  });
+
+  it('mevcut versiyon guncel oldugunda guncellemeMevcut false dondurur', async () => {
+    // Mevcut versiyonla ayni
+    mockFetch.mockResolvedValue(githubYanitiOlustur(UYGULAMA.VERSIYON));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+    expect(sonuc.bilgi).toBeNull();
+  });
+
+  it('eski versiyon icin guncellemeMevcut false dondurur', async () => {
+    mockFetch.mockResolvedValue(githubYanitiOlustur('0.0.1'));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+  });
+
+  it('API hatasi durumunda guncellemeMevcut false dondurur', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+    expect(sonuc.bilgi).toBeNull();
+  });
+
+  it('ag hatasi durumunda guncellemeMevcut false dondurur', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+    expect(sonuc.bilgi).toBeNull();
+  });
+
+  it('APK indirme baglantisinii dogru bulur', async () => {
+    const yeniVersiyon = '99.0.0';
+    const apkUrl = `https://example.com/NamazAkisi-v${yeniVersiyon}.apk`;
+    mockFetch.mockResolvedValue(githubYanitiOlustur(yeniVersiyon, {
+      assets: [
+        { name: `NamazAkisi-v${yeniVersiyon}.apk`, browser_download_url: apkUrl },
+      ],
+    }));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.bilgi?.indirmeBaglantisi).toBe(apkUrl);
+  });
+
+  it('APK yoksa release sayfasina yonlendirir', async () => {
+    const yeniVersiyon = '99.0.0';
+    const htmlUrl = `https://github.com/furkanisikay/namazakisi/releases/tag/v${yeniVersiyon}`;
+    mockFetch.mockResolvedValue(githubYanitiOlustur(yeniVersiyon, {
+      assets: [],
+      html_url: htmlUrl,
+    }));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.bilgi?.indirmeBaglantisi).toBe(htmlUrl);
+  });
+
+  it('degisiklik notlarini temizler ve kisaltir', async () => {
+    const uzunNot = '## Yeni Ozellikler\n\n**Birinci ozellik**: Aciklama\n\n\n\nDevam';
+    mockFetch.mockResolvedValue(githubYanitiOlustur('99.0.0', {
+      body: uzunNot,
+    }));
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    // Markdown temizlenmis olmali
+    expect(sonuc.bilgi?.degisiklikNotlari).not.toContain('##');
+    expect(sonuc.bilgi?.degisiklikNotlari).not.toContain('**');
+  });
+
+  it('zaman asimi durumunu ele alir', async () => {
+    // AbortError simule et
+    const abortError = new Error('Aborted');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValue(abortError);
+
+    const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+    expect(sonuc.bilgi).toBeNull();
+  });
+});
+
+describe('GuncellemeServisi', () => {
+  beforeEach(() => {
+    // Her test oncesi temizle
+    GuncellemeServisi.resetInstance();
+    mockFetch.mockReset();
+    // AsyncStorage temizle
+    Object.keys(asyncStorageMock).forEach(key => delete asyncStorageMock[key]);
+  });
+
+  it('singleton pattern dogru calisir', () => {
+    const a = GuncellemeServisi.getInstance();
+    const b = GuncellemeServisi.getInstance();
+    expect(a).toBe(b);
+  });
+
+  it('resetInstance yeni instance olusturur', () => {
+    const a = GuncellemeServisi.getInstance();
+    GuncellemeServisi.resetInstance();
+    const b = GuncellemeServisi.getInstance();
+    expect(a).not.toBe(b);
+  });
+
+  it('guncelleme mevcut oldugunda dogru sonuc dondurur', async () => {
+    const yeniVersiyon = '99.0.0';
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur(yeniVersiyon));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+    const sonuc = await servis.guncellemeKontrolEt(true);
+
+    expect(sonuc.guncellemeMevcut).toBe(true);
+    expect(sonuc.bilgi?.yeniVersiyon).toBe(yeniVersiyon);
+  });
+
+  it('guncelleme yokken dogru sonuc dondurur', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur(UYGULAMA.VERSIYON));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+    const sonuc = await servis.guncellemeKontrolEt(true);
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+  });
+
+  it('cevrimdisi iken kontrol atlaniyor', async () => {
+    // Ag kontrolu basarisiz
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const servis = GuncellemeServisi.getInstance();
+    const sonuc = await servis.guncellemeKontrolEt(true);
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+  });
+
+  it('onbellek gecerli iken tekrar API cagrisi yapmiyor', async () => {
+    const yeniVersiyon = '99.0.0';
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur(yeniVersiyon));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+
+    // Ilk kontrol - API cagrisi yapilir
+    await servis.guncellemeKontrolEt(true);
+    const fetchCallCount = mockFetch.mock.calls.length;
+
+    // Ikinci kontrol - onbellekten doner (zorla degil)
+    const sonuc = await servis.guncellemeKontrolEt(false);
+
+    // Ek API cagrisi yapilmamis olmali (sadece onbellek yukleme)
+    expect(mockFetch.mock.calls.length).toBe(fetchCallCount);
+    expect(sonuc.guncellemeMevcut).toBe(true);
+  });
+
+  it('zorla kontrol onbellegi atlar', async () => {
+    const yeniVersiyon = '99.0.0';
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur(yeniVersiyon));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+
+    // Ilk kontrol
+    await servis.guncellemeKontrolEt(true);
+    const fetchCallCount = mockFetch.mock.calls.length;
+
+    // Zorla kontrol - onbellek gecerli olsa bile API cagrisi yapilir
+    await servis.guncellemeKontrolEt(true);
+
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(fetchCallCount);
+  });
+
+  it('erteleme dogru calisir', async () => {
+    const yeniVersiyon = '99.0.0';
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur(yeniVersiyon));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+
+    // Ilk kontrol
+    await servis.guncellemeKontrolEt(true);
+
+    // Ertele
+    await servis.guncellemeErtele(yeniVersiyon);
+
+    // Zorla degil kontrol - erteleme icinde olmali
+    const fetchCallCountBefore = mockFetch.mock.calls.length;
+    const sonuc = await servis.guncellemeKontrolEt(false);
+
+    // API cagrisi yapilmamis olmali (erteleme sureci devam ediyor)
+    expect(mockFetch.mock.calls.length).toBe(fetchCallCountBefore);
+  });
+
+  it('ozel kaynak eklenebilir', async () => {
+    const ozelSonuc: GuncellemeKontrolSonucu = {
+      guncellemeMevcut: true,
+      bilgi: {
+        yeniVersiyon: '99.0.0',
+        mevcutVersiyon: UYGULAMA.VERSIYON,
+        degisiklikNotlari: 'Test',
+        indirmeBaglantisi: 'https://example.com',
+        yayinTarihi: '2026-01-01',
+        kaynak: 'playstore',
+        zorunluMu: false,
+      },
+    };
+
+    const ozelKaynak: GuncellemeKaynagi = {
+      tip: 'playstore',
+      destekleniyor: () => true,
+      enSonSurumuKontrolEt: jest.fn().mockResolvedValue(ozelSonuc),
+    };
+
+    // Ag kontrolu basarili
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      // GitHub kaynak basarisiz olsun
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+    servis.kaynakEkle(ozelKaynak);
+
+    const sonuc = await servis.guncellemeKontrolEt(true);
+
+    expect(ozelKaynak.enSonSurumuKontrolEt).toHaveBeenCalled();
+    expect(sonuc.guncellemeMevcut).toBe(true);
+    expect(sonuc.bilgi?.kaynak).toBe('playstore');
+  });
+
+  it('desteklenmeyen kaynak atlanir', async () => {
+    const desteklenmeyenKaynak: GuncellemeKaynagi = {
+      tip: 'appstore',
+      destekleniyor: () => false,
+      enSonSurumuKontrolEt: jest.fn(),
+    };
+
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur(UYGULAMA.VERSIYON));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+    servis.kaynakEkle(desteklenmeyenKaynak);
+
+    await servis.guncellemeKontrolEt(true);
+
+    expect(desteklenmeyenKaynak.enSonSurumuKontrolEt).not.toHaveBeenCalled();
+  });
+
+  it('onbellek AsyncStorage a kaydedilir', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/zen')) {
+        return Promise.resolve({ ok: true });
+      }
+      return Promise.resolve(githubYanitiOlustur('99.0.0'));
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+    await servis.guncellemeKontrolEt(true);
+
+    // AsyncStorage'da kayit olmali
+    expect(asyncStorageMock[GUNCELLEME_SABITLERI.DEPOLAMA_ANAHTARI]).toBeDefined();
+
+    const kayitliVeri = JSON.parse(asyncStorageMock[GUNCELLEME_SABITLERI.DEPOLAMA_ANAHTARI]);
+    expect(kayitliVeri.sonSonuc.guncellemeMevcut).toBe(true);
+    expect(kayitliVeri.sonKontrolZamani).toBeDefined();
+  });
+
+  it('hata durumunda guvenli sonuc dondurur', async () => {
+    // Beklenmedik hata
+    mockFetch.mockImplementation(() => {
+      throw new Error('Beklenmedik hata');
+    });
+
+    const servis = GuncellemeServisi.getInstance();
+    const sonuc = await servis.guncellemeKontrolEt(true);
+
+    expect(sonuc.guncellemeMevcut).toBe(false);
+    expect(sonuc.bilgi).toBeNull();
+  });
+});

--- a/src/presentation/components/guncelleme/GuncellemeBildirimi.tsx
+++ b/src/presentation/components/guncelleme/GuncellemeBildirimi.tsx
@@ -1,0 +1,342 @@
+/**
+ * Guncelleme Bildirimi Bileseni
+ *
+ * Yeni bir guncelleme mevcut oldugunda ekranin altindan
+ * kayarak cikan animasyonlu bildirim paneli.
+ *
+ * Ozellikler:
+ * - Animasyonlu giris/cikis (alttan kayma + fade)
+ * - Tema destekli (acik/koyu)
+ * - Ikon tabanli (emoji yok)
+ * - Minimal ve bilgilendirici tasarim
+ * - "Guncelle" ve "Sonra" butonlari
+ * - Versiyon bilgisi ve degisiklik notlari
+ */
+
+import * as React from 'react';
+import { useRef, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Animated,
+  Easing,
+  Linking,
+  Platform,
+} from 'react-native';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useRenkler } from '../../../core/theme';
+import { useAppSelector, useAppDispatch } from '../../store/hooks';
+import { guncellemeErtele, bildirimiKapat } from '../../store/guncellemeSlice';
+import { yayinTarihiniFormatla } from '../../../domain/services/GuncellemeServisi';
+
+/**
+ * Guncelleme bildirimi bileseni
+ * App.tsx'de NavigationContainer icine yerlestirilir
+ */
+export const GuncellemeBildirimi: React.FC = () => {
+  const renkler = useRenkler();
+  const dispatch = useAppDispatch();
+
+  const { guncellemeMevcut, bilgi, bildirimiKapatti } = useAppSelector(
+    (state) => state.guncelleme
+  );
+
+  // Animasyon degerleri
+  const slideAnim = useRef(new Animated.Value(300)).current;
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  const gosterilsinMi = guncellemeMevcut && bilgi && !bildirimiKapatti;
+
+  useEffect(() => {
+    if (gosterilsinMi) {
+      // Giris animasyonu
+      Animated.parallel([
+        Animated.spring(slideAnim, {
+          toValue: 0,
+          friction: 8,
+          tension: 40,
+          useNativeDriver: true,
+        }),
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 300,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else {
+      // Cikis animasyonu
+      Animated.parallel([
+        Animated.timing(slideAnim, {
+          toValue: 300,
+          duration: 250,
+          easing: Easing.in(Easing.cubic),
+          useNativeDriver: true,
+        }),
+        Animated.timing(fadeAnim, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [gosterilsinMi, slideAnim, fadeAnim]);
+
+  /**
+   * Guncelleme baglantisini ac
+   */
+  const guncelleBasildi = useCallback(() => {
+    if (bilgi?.indirmeBaglantisi) {
+      Linking.openURL(bilgi.indirmeBaglantisi);
+    }
+  }, [bilgi]);
+
+  /**
+   * Erteleme butonuna basildi
+   */
+  const sonraBasildi = useCallback(() => {
+    if (bilgi?.yeniVersiyon) {
+      dispatch(guncellemeErtele(bilgi.yeniVersiyon));
+    } else {
+      dispatch(bildirimiKapat());
+    }
+  }, [bilgi, dispatch]);
+
+  // Gosterilmeyecekse bos render
+  if (!guncellemeMevcut || !bilgi) {
+    return null;
+  }
+
+  const formatlananTarih = yayinTarihiniFormatla(bilgi.yayinTarihi);
+
+  return (
+    <Animated.View
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        opacity: fadeAnim,
+        transform: [{ translateY: slideAnim }],
+      }}
+      pointerEvents={gosterilsinMi ? 'auto' : 'none'}
+    >
+      {/* Yarimm saydam arka plan overlay */}
+      <View
+        style={{
+          marginHorizontal: 12,
+          marginBottom: Platform.OS === 'ios' ? 34 : 80,
+          borderRadius: 16,
+          overflow: 'hidden',
+          backgroundColor: renkler.kartArkaplan,
+          // Golge
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: -4 },
+          shadowOpacity: 0.15,
+          shadowRadius: 12,
+          elevation: 16,
+          borderWidth: 1,
+          borderColor: renkler.sinir,
+        }}
+      >
+        {/* Ust kisim - ikon ve versiyon bilgisi */}
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingHorizontal: 16,
+            paddingTop: 16,
+            paddingBottom: 8,
+          }}
+        >
+          {/* Guncelleme ikonu */}
+          <View
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: 12,
+              backgroundColor: `${renkler.bilgi}15`,
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginRight: 12,
+            }}
+          >
+            <MaterialIcons
+              name="system-update"
+              size={24}
+              color={renkler.bilgi}
+            />
+          </View>
+
+          {/* Baslik ve versiyon */}
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                fontSize: 15,
+                fontWeight: '700',
+                color: renkler.metin,
+              }}
+            >
+              Yeni Sürüm Mevcut
+            </Text>
+            <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 2 }}>
+              <FontAwesome5
+                name="code-branch"
+                size={10}
+                color={renkler.metinIkincil}
+              />
+              <Text
+                style={{
+                  fontSize: 12,
+                  color: renkler.metinIkincil,
+                  marginLeft: 4,
+                }}
+              >
+                v{bilgi.mevcutVersiyon}
+              </Text>
+              <MaterialIcons
+                name="arrow-forward"
+                size={12}
+                color={renkler.metinIkincil}
+                style={{ marginHorizontal: 4 }}
+              />
+              <Text
+                style={{
+                  fontSize: 12,
+                  fontWeight: '600',
+                  color: renkler.bilgi,
+                }}
+              >
+                v{bilgi.yeniVersiyon}
+              </Text>
+              {formatlananTarih ? (
+                <Text
+                  style={{
+                    fontSize: 11,
+                    color: renkler.metinIkincil,
+                    marginLeft: 8,
+                  }}
+                >
+                  {formatlananTarih}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+
+          {/* Kapat butonu */}
+          <TouchableOpacity
+            onPress={sonraBasildi}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 14,
+              backgroundColor: `${renkler.metinIkincil}15`,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <MaterialIcons
+              name="close"
+              size={16}
+              color={renkler.metinIkincil}
+            />
+          </TouchableOpacity>
+        </View>
+
+        {/* Degisiklik notlari (kisaltilmis) */}
+        {bilgi.degisiklikNotlari ? (
+          <View
+            style={{
+              marginHorizontal: 16,
+              marginBottom: 12,
+              paddingHorizontal: 12,
+              paddingVertical: 8,
+              backgroundColor: `${renkler.metinIkincil}08`,
+              borderRadius: 8,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 12,
+                color: renkler.metinIkincil,
+                lineHeight: 18,
+              }}
+              numberOfLines={3}
+            >
+              {bilgi.degisiklikNotlari}
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Butonlar */}
+        <View
+          style={{
+            flexDirection: 'row',
+            paddingHorizontal: 16,
+            paddingBottom: 16,
+            gap: 8,
+          }}
+        >
+          {/* Sonra butonu */}
+          <TouchableOpacity
+            onPress={sonraBasildi}
+            style={{
+              flex: 1,
+              paddingVertical: 10,
+              borderRadius: 10,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: `${renkler.metinIkincil}12`,
+            }}
+            activeOpacity={0.7}
+          >
+            <Text
+              style={{
+                fontSize: 13,
+                fontWeight: '600',
+                color: renkler.metinIkincil,
+              }}
+            >
+              Sonra
+            </Text>
+          </TouchableOpacity>
+
+          {/* Guncelle butonu */}
+          <TouchableOpacity
+            onPress={guncelleBasildi}
+            style={{
+              flex: 2,
+              flexDirection: 'row',
+              paddingVertical: 10,
+              borderRadius: 10,
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: renkler.bilgi,
+              gap: 6,
+            }}
+            activeOpacity={0.7}
+          >
+            <MaterialIcons
+              name="file-download"
+              size={16}
+              color="#FFFFFF"
+            />
+            <Text
+              style={{
+                fontSize: 13,
+                fontWeight: '700',
+                color: '#FFFFFF',
+              }}
+            >
+              Güncelle
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Animated.View>
+  );
+};

--- a/src/presentation/components/guncelleme/__tests__/GuncellemeBildirimi.test.tsx
+++ b/src/presentation/components/guncelleme/__tests__/GuncellemeBildirimi.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * GuncellemeBildirimi Bilesen Testleri
+ *
+ * Guncelleme bildirim bileseni icin testler:
+ * - Gosterim/gizleme mantigi
+ * - Versiyon bilgisi gosterimi
+ * - Buton davranislari
+ */
+
+import * as React from 'react';
+import { create, act, ReactTestRenderer } from 'react-test-renderer';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import guncellemeReducer, { bildirimiKapat } from '../../../store/guncellemeSlice';
+
+// ==================== MOCKLAR ====================
+
+// Expo vector icons mock (expo-modules-core sorununu onler)
+const MockIcon = (props: any) => React.createElement('MockIcon', props);
+jest.mock('@expo/vector-icons/FontAwesome5', () => MockIcon);
+jest.mock('@expo/vector-icons/MaterialIcons', () => MockIcon);
+jest.mock('@expo/vector-icons', () => ({
+  FontAwesome5: MockIcon,
+  MaterialIcons: MockIcon,
+}));
+
+// Tema mock
+jest.mock('../../../../core/theme', () => ({
+  useRenkler: () => ({
+    arkaplan: '#FAFAFA',
+    kartArkaplan: '#FFFFFF',
+    metin: '#212121',
+    metinIkincil: '#757575',
+    sinir: '#E0E0E0',
+    birincil: '#4CAF50',
+    birincilKoyu: '#388E3C',
+    birincilAcik: '#C8E6C9',
+    bilgi: '#2196F3',
+    basarili: '#4CAF50',
+    uyari: '#FFC107',
+    hata: '#F44336',
+    vurgu: '#00BFA5',
+  }),
+}));
+
+// GuncellemeServisi mock
+jest.mock('../../../../domain/services/GuncellemeServisi', () => ({
+  GuncellemeServisi: {
+    getInstance: () => ({
+      guncellemeKontrolEt: jest.fn(),
+      guncellemeErtele: jest.fn(),
+    }),
+  },
+  yayinTarihiniFormatla: (tarih: string) => tarih ? '14.02.2026' : '',
+}));
+
+// Linking mock
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn(),
+}));
+
+// ==================== YARDIMCI ====================
+
+function storeOlustur(preloadedState?: any) {
+  return configureStore({
+    reducer: {
+      guncelleme: guncellemeReducer,
+    },
+    preloadedState,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }),
+  });
+}
+
+// Bilesenin lazy import'u (mocklardan sonra)
+let GuncellemeBildirimi: React.FC;
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  GuncellemeBildirimi = require('../GuncellemeBildirimi').GuncellemeBildirimi;
+});
+
+// ==================== TESTLER ====================
+
+describe('GuncellemeBildirimi', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('guncelleme yokken null render eder', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: false,
+        bilgi: null,
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    expect(tree!.toJSON()).toBeNull();
+
+    act(() => { tree!.unmount(); });
+  });
+
+  it('guncelleme mevcut oldugunda render eder', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: 'Yeni ozellikler eklendi',
+          indirmeBaglantisi: 'https://example.com/app.apk',
+          yayinTarihi: '2026-02-14T10:00:00Z',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    expect(tree!.toJSON()).not.toBeNull();
+
+    act(() => { tree!.unmount(); });
+  });
+
+  it('bildirim kapatildiginda pointerEvents none olur', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: 'Test',
+          indirmeBaglantisi: 'https://example.com',
+          yayinTarihi: '2026-02-14',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: true,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    // Bilesen hala render olur ama pointerEvents="none" ile etkilesime kapali
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).toContain('"pointerEvents":"none"');
+
+    act(() => { tree!.unmount(); });
+  });
+
+  it('versiyon bilgileri dogru gosterilir', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: 'Yeni ozellikler',
+          indirmeBaglantisi: 'https://example.com/app.apk',
+          yayinTarihi: '2026-02-14T10:00:00Z',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    const json = JSON.stringify(tree!.toJSON());
+
+    // React children olarak ["v","0.3.0"] seklinde ayrilmis olabilir
+    expect(json).toContain('0.3.0');
+    expect(json).toContain('1.0.0');
+    expect(json).toContain('Yeni Sürüm Mevcut');
+
+    act(() => { tree!.unmount(); });
+  });
+
+  it('degisiklik notlari gosterilir', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: 'Hata duzeltmeleri ve performans iyilestirmeleri',
+          indirmeBaglantisi: 'https://example.com',
+          yayinTarihi: '2026-02-14',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).toContain('Hata duzeltmeleri ve performans iyilestirmeleri');
+
+    act(() => { tree!.unmount(); });
+  });
+
+  it('Sonra ve Guncelle butonlari mevcut', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: 'Test',
+          indirmeBaglantisi: 'https://example.com',
+          yayinTarihi: '2026-02-14',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).toContain('Sonra');
+    expect(json).toContain('Güncelle');
+
+    act(() => { tree!.unmount(); });
+  });
+
+  it('bildirimiKapat aksiyonu state i gunceller', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: '',
+          indirmeBaglantisi: 'https://example.com',
+          yayinTarihi: '',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    store.dispatch(bildirimiKapat());
+    expect(store.getState().guncelleme.bildirimiKapatti).toBe(true);
+  });
+
+  it('degisiklik notlari bos oldugunda bilesen hala render olur', () => {
+    const store = storeOlustur({
+      guncelleme: {
+        kontrolEdiliyor: false,
+        guncellemeMevcut: true,
+        bilgi: {
+          yeniVersiyon: '1.0.0',
+          mevcutVersiyon: '0.3.0',
+          degisiklikNotlari: '',
+          indirmeBaglantisi: 'https://example.com',
+          yayinTarihi: '',
+          kaynak: 'github',
+          zorunluMu: false,
+        },
+        bildirimiKapatti: false,
+        hata: null,
+      },
+    });
+
+    let tree: ReactTestRenderer;
+    act(() => {
+      tree = create(
+        <Provider store={store}>
+          <GuncellemeBildirimi />
+        </Provider>
+      );
+    });
+    act(() => { jest.runAllTimers(); });
+
+    expect(tree!.toJSON()).not.toBeNull();
+    const json = JSON.stringify(tree!.toJSON());
+    expect(json).toContain('Güncelle');
+
+    act(() => { tree!.unmount(); });
+  });
+});

--- a/src/presentation/screens/HakkindaSayfasi.tsx
+++ b/src/presentation/screens/HakkindaSayfasi.tsx
@@ -1,12 +1,13 @@
 /**
  * Hakkinda Sayfasi
  * Uygulama bilgileri ve versiyonu
- * 
+ * Guncelleme kontrolu dahil
+ *
  * NativeWind + Expo Vector Icons ile guncellenmis versiyon
  */
 
 import * as React from 'react';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -15,10 +16,14 @@ import {
   Easing,
   Linking,
   TouchableOpacity,
+  ActivityIndicator,
 } from 'react-native';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useRenkler } from '../../core/theme';
 import { UYGULAMA } from '../../core/constants/UygulamaSabitleri';
+import { useAppSelector, useAppDispatch } from '../store/hooks';
+import { guncellemeKontrolEt } from '../store/guncellemeSlice';
 
 /**
  * Bilgi satiri bileseni
@@ -82,6 +87,12 @@ const BilgiSatiri: React.FC<BilgiSatiriProps> = ({ etiket, deger, ikonAdi, onPre
  */
 export const HakkindaSayfasi: React.FC = () => {
   const renkler = useRenkler();
+  const dispatch = useAppDispatch();
+
+  // Guncelleme durumu
+  const { kontrolEdiliyor, guncellemeMevcut, bilgi } = useAppSelector(
+    (state) => state.guncelleme
+  );
 
   // Guncel yil
   const guncelYil = new Date().getFullYear();
@@ -111,6 +122,22 @@ export const HakkindaSayfasi: React.FC = () => {
   const handleWebSitesiAc = (url: string) => {
     Linking.openURL(url);
   };
+
+  // Manuel guncelleme kontrolu
+  const handleGuncellemeKontrol = useCallback(() => {
+    dispatch(guncellemeKontrolEt(true));
+  }, [dispatch]);
+
+  // Guncelleme butonu icerigi
+  const guncellemeDurumMetni = kontrolEdiliyor
+    ? 'Kontrol ediliyor...'
+    : guncellemeMevcut && bilgi
+      ? `v${bilgi.yeniVersiyon} mevcut`
+      : 'Güncel';
+
+  const guncellemeDurumRengi = guncellemeMevcut && bilgi
+    ? renkler.bilgi
+    : renkler.basarili;
 
   return (
     <ScrollView
@@ -181,6 +208,71 @@ export const HakkindaSayfasi: React.FC = () => {
               onPress={() => handleWebSitesiAc('https://github.com/furkanisikay/namazakisi')}
             />
           </View>
+        </View>
+
+        {/* Guncelleme Kontrolu */}
+        <View className="mb-6">
+          <Text
+            className="text-xs font-bold tracking-wider mb-3"
+            style={{ color: renkler.metinIkincil }}
+          >
+            GÜNCELLEME
+          </Text>
+
+          <TouchableOpacity
+            onPress={handleGuncellemeKontrol}
+            disabled={kontrolEdiliyor}
+            activeOpacity={0.7}
+            className="flex-row items-center py-3.5 px-4 rounded-xl"
+            style={{ backgroundColor: renkler.kartArkaplan }}
+          >
+            <View
+              className="w-11 h-11 rounded-xl items-center justify-center mr-3.5"
+              style={{ backgroundColor: `${guncellemeDurumRengi}15` }}
+            >
+              {kontrolEdiliyor ? (
+                <ActivityIndicator size="small" color={renkler.bilgi} />
+              ) : (
+                <MaterialIcons
+                  name="system-update"
+                  size={22}
+                  color={guncellemeDurumRengi}
+                />
+              )}
+            </View>
+            <View className="flex-1">
+              <Text
+                className="text-base font-semibold"
+                style={{ color: renkler.metin }}
+              >
+                Güncelleme Kontrolü
+              </Text>
+              <Text
+                className="text-xs mt-0.5"
+                style={{ color: guncellemeDurumRengi }}
+              >
+                {guncellemeDurumMetni}
+              </Text>
+            </View>
+            {guncellemeMevcut && bilgi ? (
+              <TouchableOpacity
+                onPress={() => handleWebSitesiAc(bilgi.indirmeBaglantisi)}
+                className="px-3 py-1.5 rounded-lg"
+                style={{ backgroundColor: renkler.bilgi }}
+                activeOpacity={0.7}
+              >
+                <Text className="text-xs font-bold" style={{ color: '#FFFFFF' }}>
+                  İndir
+                </Text>
+              </TouchableOpacity>
+            ) : (
+              <MaterialIcons
+                name="refresh"
+                size={20}
+                color={renkler.metinIkincil}
+              />
+            )}
+          </TouchableOpacity>
         </View>
 
         {/* Telif Hakki */}

--- a/src/presentation/store/__tests__/guncellemeSlice.test.ts
+++ b/src/presentation/store/__tests__/guncellemeSlice.test.ts
@@ -1,0 +1,227 @@
+/**
+ * guncellemeSlice Testleri
+ *
+ * Redux guncelleme state yonetimi icin birim testleri:
+ * - Baslangic durumu
+ * - Senkron aksiyonlar
+ * - Async thunk'lar (guncellemeKontrolEt, guncellemeErtele)
+ * - State gecisleri
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import guncellemeReducer, {
+  guncellemeKontrolEt,
+  guncellemeErtele,
+  bildirimiKapat,
+  bildirimiSifirla,
+} from '../guncellemeSlice';
+import { GuncellemeServisi } from '../../../domain/services/GuncellemeServisi';
+
+// ==================== MOCKLAR ====================
+
+// GuncellemeServisi mock
+jest.mock('../../../domain/services/GuncellemeServisi', () => {
+  const mockGuncellemeKontrolEt = jest.fn();
+  const mockGuncellemeErtele = jest.fn();
+
+  return {
+    GuncellemeServisi: {
+      getInstance: jest.fn(() => ({
+        guncellemeKontrolEt: mockGuncellemeKontrolEt,
+        guncellemeErtele: mockGuncellemeErtele,
+      })),
+    },
+    // Test icin mock fonksiyonlara erisim
+    __mockKontrolEt: mockGuncellemeKontrolEt,
+    __mockErtele: mockGuncellemeErtele,
+  };
+});
+
+// Mock fonksiyonlara erisim
+const { __mockKontrolEt, __mockErtele } = jest.requireMock(
+  '../../../domain/services/GuncellemeServisi'
+) as any;
+
+// ==================== YARDIMCI ====================
+
+function storeOlustur() {
+  return configureStore({
+    reducer: {
+      guncelleme: guncellemeReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }),
+  });
+}
+
+// ==================== TESTLER ====================
+
+describe('guncellemeSlice', () => {
+  beforeEach(() => {
+    __mockKontrolEt.mockReset();
+    __mockErtele.mockReset();
+  });
+
+  describe('baslangic durumu', () => {
+    it('dogru baslangic degerlerine sahip', () => {
+      const store = storeOlustur();
+      const state = store.getState().guncelleme;
+
+      expect(state.kontrolEdiliyor).toBe(false);
+      expect(state.guncellemeMevcut).toBe(false);
+      expect(state.bilgi).toBeNull();
+      expect(state.bildirimiKapatti).toBe(false);
+      expect(state.hata).toBeNull();
+    });
+  });
+
+  describe('senkron aksiyonlar', () => {
+    it('bildirimiKapat durumu dogru gunceller', () => {
+      const store = storeOlustur();
+
+      store.dispatch(bildirimiKapat());
+
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(true);
+    });
+
+    it('bildirimiSifirla durumu dogru gunceller', () => {
+      const store = storeOlustur();
+
+      store.dispatch(bildirimiKapat());
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(true);
+
+      store.dispatch(bildirimiSifirla());
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(false);
+    });
+  });
+
+  describe('guncellemeKontrolEt thunk', () => {
+    it('pending durumunda kontrolEdiliyor true olur', () => {
+      __mockKontrolEt.mockReturnValue(new Promise(() => {})); // Beklemede kal
+
+      const store = storeOlustur();
+      store.dispatch(guncellemeKontrolEt(false));
+
+      expect(store.getState().guncelleme.kontrolEdiliyor).toBe(true);
+      expect(store.getState().guncelleme.hata).toBeNull();
+    });
+
+    it('fulfilled - guncelleme mevcut oldugunda state dogru guncellenir', async () => {
+      const guncellemeBilgisi = {
+        yeniVersiyon: '99.0.0',
+        mevcutVersiyon: '0.3.0',
+        degisiklikNotlari: 'Yeni ozellikler',
+        indirmeBaglantisi: 'https://example.com/app.apk',
+        yayinTarihi: '2026-02-14',
+        kaynak: 'github' as const,
+        zorunluMu: false,
+      };
+
+      __mockKontrolEt.mockResolvedValue({
+        guncellemeMevcut: true,
+        bilgi: guncellemeBilgisi,
+      });
+
+      const store = storeOlustur();
+      await store.dispatch(guncellemeKontrolEt(false));
+
+      const state = store.getState().guncelleme;
+      expect(state.kontrolEdiliyor).toBe(false);
+      expect(state.guncellemeMevcut).toBe(true);
+      expect(state.bilgi).toEqual(guncellemeBilgisi);
+    });
+
+    it('fulfilled - guncelleme yokken state dogru guncellenir', async () => {
+      __mockKontrolEt.mockResolvedValue({
+        guncellemeMevcut: false,
+        bilgi: null,
+      });
+
+      const store = storeOlustur();
+      await store.dispatch(guncellemeKontrolEt(false));
+
+      const state = store.getState().guncelleme;
+      expect(state.kontrolEdiliyor).toBe(false);
+      expect(state.guncellemeMevcut).toBe(false);
+      expect(state.bilgi).toBeNull();
+    });
+
+    it('rejected durumunda hata mesaji set edilir', async () => {
+      __mockKontrolEt.mockRejectedValue(new Error('Test hatasi'));
+
+      const store = storeOlustur();
+      await store.dispatch(guncellemeKontrolEt(false));
+
+      const state = store.getState().guncelleme;
+      expect(state.kontrolEdiliyor).toBe(false);
+      expect(state.hata).toBeDefined();
+    });
+
+    it('zorla parametresi servise iletilir', async () => {
+      __mockKontrolEt.mockResolvedValue({
+        guncellemeMevcut: false,
+        bilgi: null,
+      });
+
+      const store = storeOlustur();
+      await store.dispatch(guncellemeKontrolEt(true));
+
+      expect(__mockKontrolEt).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('guncellemeErtele thunk', () => {
+    it('fulfilled durumunda bildirimiKapatti true olur', async () => {
+      __mockErtele.mockResolvedValue(undefined);
+
+      const store = storeOlustur();
+      await store.dispatch(guncellemeErtele('99.0.0'));
+
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(true);
+    });
+
+    it('versiyon servise iletilir', async () => {
+      __mockErtele.mockResolvedValue(undefined);
+
+      const store = storeOlustur();
+      await store.dispatch(guncellemeErtele('99.0.0'));
+
+      expect(__mockErtele).toHaveBeenCalledWith('99.0.0');
+    });
+  });
+
+  describe('state gecisleri', () => {
+    it('tam guncelleme akisi dogru calisir', async () => {
+      const bilgi = {
+        yeniVersiyon: '99.0.0',
+        mevcutVersiyon: '0.3.0',
+        degisiklikNotlari: 'Yeni',
+        indirmeBaglantisi: 'https://example.com',
+        yayinTarihi: '2026-01-01',
+        kaynak: 'github' as const,
+        zorunluMu: false,
+      };
+
+      __mockKontrolEt.mockResolvedValue({
+        guncellemeMevcut: true,
+        bilgi,
+      });
+      __mockErtele.mockResolvedValue(undefined);
+
+      const store = storeOlustur();
+
+      // 1. Kontrol et
+      await store.dispatch(guncellemeKontrolEt(false));
+      expect(store.getState().guncelleme.guncellemeMevcut).toBe(true);
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(false);
+
+      // 2. Ertele
+      await store.dispatch(guncellemeErtele('99.0.0'));
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(true);
+
+      // 3. Sifirla
+      store.dispatch(bildirimiSifirla());
+      expect(store.getState().guncelleme.bildirimiKapatti).toBe(false);
+    });
+  });
+});

--- a/src/presentation/store/guncellemeSlice.ts
+++ b/src/presentation/store/guncellemeSlice.ts
@@ -1,0 +1,108 @@
+/**
+ * Guncelleme Redux Slice
+ * Uygulama guncelleme durumunu yonetir
+ */
+
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import {
+  GuncellemeServisi,
+  GuncellemeBilgisi,
+} from '../../domain/services/GuncellemeServisi';
+
+// ==================== STATE TIPI ====================
+
+interface GuncellemeState {
+  /** Kontrol yapiliyor mu */
+  kontrolEdiliyor: boolean;
+  /** Guncelleme mevcut mu */
+  guncellemeMevcut: boolean;
+  /** Guncelleme bilgileri */
+  bilgi: GuncellemeBilgisi | null;
+  /** Kullanici bildirimi kapatti mi */
+  bildirimiKapatti: boolean;
+  /** Hata mesaji */
+  hata: string | null;
+}
+
+const baslangicDurumu: GuncellemeState = {
+  kontrolEdiliyor: false,
+  guncellemeMevcut: false,
+  bilgi: null,
+  bildirimiKapatti: false,
+  hata: null,
+};
+
+// ==================== ASYNC THUNKLAR ====================
+
+/**
+ * Guncelleme kontrol et
+ */
+export const guncellemeKontrolEt = createAsyncThunk(
+  'guncelleme/kontrolEt',
+  async (zorla: boolean = false) => {
+    const servis = GuncellemeServisi.getInstance();
+    return await servis.guncellemeKontrolEt(zorla);
+  }
+);
+
+/**
+ * Guncellemeyi ertele
+ */
+export const guncellemeErtele = createAsyncThunk(
+  'guncelleme/ertele',
+  async (versiyon: string) => {
+    const servis = GuncellemeServisi.getInstance();
+    await servis.guncellemeErtele(versiyon);
+    return versiyon;
+  }
+);
+
+// ==================== SLICE ====================
+
+const guncellemeSlice = createSlice({
+  name: 'guncelleme',
+  initialState: baslangicDurumu,
+  reducers: {
+    bildirimiKapat(state) {
+      state.bildirimiKapatti = true;
+    },
+    bildirimiSifirla(state) {
+      state.bildirimiKapatti = false;
+    },
+  },
+  extraReducers: (builder) => {
+    // Guncelleme kontrol
+    builder
+      .addCase(guncellemeKontrolEt.pending, (state) => {
+        state.kontrolEdiliyor = true;
+        state.hata = null;
+      })
+      .addCase(guncellemeKontrolEt.fulfilled, (state, action) => {
+        state.kontrolEdiliyor = false;
+        state.guncellemeMevcut = action.payload.guncellemeMevcut;
+        state.bilgi = action.payload.bilgi;
+
+        // Yeni versiyon tespit edildiyse bildirim durumunu sifirla
+        if (action.payload.guncellemeMevcut) {
+          const yeniVer = action.payload.bilgi?.yeniVersiyon;
+          const eskiVer = state.bilgi?.yeniVersiyon;
+          if (yeniVer && yeniVer !== eskiVer) {
+            state.bildirimiKapatti = false;
+          }
+        }
+      })
+      .addCase(guncellemeKontrolEt.rejected, (state, action) => {
+        state.kontrolEdiliyor = false;
+        state.hata = action.error.message || 'Guncelleme kontrol edilemedi';
+      });
+
+    // Guncelleme ertele
+    builder
+      .addCase(guncellemeErtele.fulfilled, (state) => {
+        state.bildirimiKapatti = true;
+      });
+  },
+});
+
+export const { bildirimiKapat, bildirimiSifirla } = guncellemeSlice.actions;
+export default guncellemeSlice.reducer;

--- a/src/presentation/store/store.ts
+++ b/src/presentation/store/store.ts
@@ -9,6 +9,7 @@ import seriReducer from './seriSlice';
 import muhafizReducer from './muhafizSlice';
 import konumReducer from './konumSlice';
 import vakitBildirimReducer from './vakitBildirimSlice';
+import guncellemeReducer from './guncellemeSlice';
 
 export const store = configureStore({
   reducer: {
@@ -18,6 +19,7 @@ export const store = configureStore({
     muhafiz: muhafizReducer,
     konum: konumReducer,
     vakitBildirim: vakitBildirimReducer,
+    guncelleme: guncellemeReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({


### PR DESCRIPTION
GitHub Releases API üzerinden otomatik güncelleme kontrolü yapan
provider tabanlı bir mimari eklendi. İleride Google Play ve App Store
kaynakları kolayca eklenebilir.

Özellikler:
- Uygulama açılışında ve ön plana geldiğinde sessiz güncelleme kontrolü
- Akıllı önbellekleme (6 saat) ve erteleme desteği (24 saat)
- Çevrimdışı farkındalık: ağ bağlantısı yoksa sessizce atlar
- Animasyonlu alt bildirim paneli (spring + fade)
- İkon tabanlı profesyonel tasarım (emoji yok)
- Hakkında sayfasında manuel güncelleme kontrolü butonu
- Versiyon karşılaştırma, değişiklik notları, indirme bağlantısı
- 53 yeni test (servis, Redux slice, bileşen)

https://claude.ai/code/session_012SzRCGurhsYDdFWt2BQq3N