### PR TITLE
Add severity level 0 for clearing prayer reminder notifications

### DIFF
--- a/src/domain/services/NamazMuhafiziServisi.ts
+++ b/src/domain/services/NamazMuhafiziServisi.ts
@@ -23,7 +23,7 @@ const VARSAYILAN_YAPILANDIRMA: MuhafizYapilandirmasi = {
     seviye4SiklikDk: 1,
 };
 
-type BildirimCallback = (mesaj: string, seviye: 1 | 2 | 3 | 4) => void;
+type BildirimCallback = (mesaj: string, seviye: 0 | 1 | 2 | 3 | 4) => void;
 
 export class NamazMuhafiziServisi {
     private static instance: NamazMuhafiziServisi;
@@ -92,9 +92,14 @@ export class NamazMuhafiziServisi {
         const { vakit, kalanSureMs } = vakitBilgisi;
         const kalanDk = Math.floor(kalanSureMs / (1000 * 60));
 
-        // Eğer bu vakit zaten kılındıysa rahatsız etme
+        // Eğer bu vakit zaten kılındıysa banner'ı temizle ve rahatsız etme
         const bugun = new Date().toDateString();
-        if (this.kilinanVakitler[`${bugun}_${vakit}`]) return;
+        if (this.kilinanVakitler[`${bugun}_${vakit}`]) {
+            if (this.onBildirim) {
+                this.onBildirim('', 0);
+            }
+            return;
+        }
 
         // Seviye Kontrolü
         let aktifSeviye: 1 | 2 | 3 | 4 | 0 = 0;

--- a/src/domain/services/__tests__/NamazMuhafiziServisi.test.ts
+++ b/src/domain/services/__tests__/NamazMuhafiziServisi.test.ts
@@ -131,7 +131,7 @@ describe('NamazMuhafiziServisi Unit Testleri', () => {
         expect(bildirimSpx).toHaveBeenCalledWith(expect.any(String), 2);
     });
 
-    test('Namaz kılındı işareti bildirimleri durdurmalı', () => {
+    test('Namaz kılındı işareti banner\'ı temizlemeli', () => {
         mockHesaplayici.getSuankiVakitBilgisi.mockReturnValue({
             vakit: 'ogle',
             kalanSureMs: 5 * 60 * 1000,
@@ -139,10 +139,11 @@ describe('NamazMuhafiziServisi Unit Testleri', () => {
 
         // Önce işaretle
         muhafiz.namazKilindiIsaretle('ogle');
-        
+
         muhafiz.baslat(bildirimSpx);
-        
-        expect(bildirimSpx).not.toHaveBeenCalled();
+
+        // Banner temizleme için seviye 0 ile çağrılmalı
+        expect(bildirimSpx).toHaveBeenCalledWith('', 0);
     });
 
     test('Yapılandırma değişikliği etkili olmalı', () => {

--- a/src/domain/services/__tests__/NamazMuhafiziServisi.test.ts
+++ b/src/domain/services/__tests__/NamazMuhafiziServisi.test.ts
@@ -146,6 +146,29 @@ describe('NamazMuhafiziServisi Unit Testleri', () => {
         expect(bildirimSpx).toHaveBeenCalledWith('', 0);
     });
 
+    test('Temizleme bildirimi sadece bir kez gönderilmeli (gereksiz tekrar çağrıları önlenmeli)', () => {
+        mockHesaplayici.getSuankiVakitBilgisi.mockReturnValue({
+            vakit: 'ogle',
+            kalanSureMs: 5 * 60 * 1000,
+        });
+
+        // Önce işaretle
+        muhafiz.namazKilindiIsaretle('ogle');
+
+        muhafiz.baslat(bildirimSpx);
+
+        // Banner temizleme için seviye 0 ile bir kez çağrılmalı
+        expect(bildirimSpx).toHaveBeenCalledTimes(1);
+        expect(bildirimSpx).toHaveBeenCalledWith('', 0);
+
+        // Zaman ilerlet ve tekrar kontrol et
+        bildirimSpx.mockClear();
+        jest.advanceTimersByTime(60 * 1000);
+
+        // İkinci kez çağrılmamalı (gereksiz UI güncellemesini önlemek için)
+        expect(bildirimSpx).not.toHaveBeenCalled();
+    });
+
     test('Yapılandırma değişikliği etkili olmalı', () => {
         // Seviye 1 başlangıcını 60 dk'ya çekelim
         muhafiz.yapilandir({ seviye1BaslangicDk: 60 });

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -235,7 +235,7 @@ export const AnaSayfa: React.FC = () => {
       muhafiz.baslat((mesaj, seviye) => {
         setMuhafizDurumu({ mesaj, seviye });
         if (seviye >= 3) { HaptikServisi.gucluTitresim(); SesServisi.bildirimSesiCal(); }
-        else { HaptikServisi.uyariTitresimi(); }
+        else if (seviye > 0) { HaptikServisi.uyariTitresimi(); }
       });
     } else {
       muhafiz.durdur();


### PR DESCRIPTION
## Summary
This PR adds support for severity level 0 in the prayer reminder system to allow clearing notification banners when a prayer has already been performed, improving the user experience by preventing redundant notifications.

## Key Changes
- **Type definition update**: Extended `BildirimCallback` type to include severity level `0` (previously only supported levels 1-4)
- **Notification clearing logic**: When a prayer time is detected as already completed, the system now explicitly clears the notification banner by calling the callback with an empty message and severity level 0
- **Haptic feedback refinement**: Updated haptic feedback logic to only trigger vibration for severity levels > 0, preventing unnecessary haptic feedback when clearing notifications

## Implementation Details
- The notification clearing is implemented in `NamazMuhafiziServisi.ts` by checking if a prayer has already been performed for the current day and calling `this.onBildirim('', 0)` to clear the banner
- The UI layer in `AnaSayfa.tsx` now properly handles severity level 0 by skipping haptic feedback when the severity is 0, while still triggering it for levels 1-4
- This maintains backward compatibility while adding the new clearing functionality

https://claude.ai/code/session_01H323KTSF9JbdPVEk6Ria7w