### PR TITLE
Invalidate cache when app is updated to newer version

### DIFF
--- a/src/domain/services/GuncellemeServisi.ts
+++ b/src/domain/services/GuncellemeServisi.ts
@@ -348,6 +348,11 @@ export class GuncellemeServisi {
 
   /**
    * Onbellek hala gecerli mi?
+   *
+   * Cache gecersiz kabul edilir eger:
+   * 1. Zaman asimi gectiyse (6 saat)
+   * 2. Cache'deki "yeni versiyon" artik mevcut uygulama versiyonu ise
+   *    (kullanici uygulamayi guncelledi)
    */
   private onbellekGecerliMi(): boolean {
     if (!this.onbellek?.sonKontrolZamani) {
@@ -355,7 +360,22 @@ export class GuncellemeServisi {
     }
 
     const gecenSure = Date.now() - this.onbellek.sonKontrolZamani;
-    return gecenSure < GUNCELLEME_SABITLERI.KONTROL_ARALIGI;
+    const zamanGecerli = gecenSure < GUNCELLEME_SABITLERI.KONTROL_ARALIGI;
+
+    // Eger cache'de guncelleme mevcut ve bilgi varsa,
+    // cached "yeni versiyon" ile mevcut versiyon karsilastir
+    if (this.onbellek.sonSonuc.guncellemeMevcut && this.onbellek.sonSonuc.bilgi) {
+      const cachedYeniVersiyon = this.onbellek.sonSonuc.bilgi.yeniVersiyon;
+      const mevcutVersiyon = UYGULAMA.VERSIYON;
+
+      // Cache'deki "yeni versiyon" artik mevcut versiyon veya daha eskiyse,
+      // cache gecersiz (kullanici uygulamayi guncelledi)
+      if (versiyonKarsilastir(cachedYeniVersiyon, mevcutVersiyon) <= 0) {
+        return false;
+      }
+    }
+
+    return zamanGecerli;
   }
 
   /**

--- a/src/domain/services/GuncellemeServisi.ts
+++ b/src/domain/services/GuncellemeServisi.ts
@@ -362,17 +362,11 @@ export class GuncellemeServisi {
     const gecenSure = Date.now() - this.onbellek.sonKontrolZamani;
     const zamanGecerli = gecenSure < GUNCELLEME_SABITLERI.KONTROL_ARALIGI;
 
-    // Eger cache'de guncelleme mevcut ve bilgi varsa,
-    // cached "yeni versiyon" ile mevcut versiyon karsilastir
-    if (this.onbellek.sonSonuc.guncellemeMevcut && this.onbellek.sonSonuc.bilgi) {
-      const cachedYeniVersiyon = this.onbellek.sonSonuc.bilgi.yeniVersiyon;
-      const mevcutVersiyon = UYGULAMA.VERSIYON;
-
-      // Cache'deki "yeni versiyon" artik mevcut versiyon veya daha eskiyse,
-      // cache gecersiz (kullanici uygulamayi guncelledi)
-      if (versiyonKarsilastir(cachedYeniVersiyon, mevcutVersiyon) <= 0) {
-        return false;
-      }
+    // Eger cache'de bir guncelleme bilgisi varsa ve bu guncelleme
+    // mevcut uygulama versiyonuna esit veya daha eskiyse, cache'i gecersiz kil.
+    const { bilgi } = this.onbellek.sonSonuc;
+    if (bilgi && versiyonKarsilastir(bilgi.yeniVersiyon, UYGULAMA.VERSIYON) <= 0) {
+      return false;
     }
 
     return zamanGecerli;

--- a/src/domain/services/__tests__/GuncellemeServisi.test.ts
+++ b/src/domain/services/__tests__/GuncellemeServisi.test.ts
@@ -450,6 +450,28 @@ describe('GuncellemeServisi', () => {
     expect(sonuc.guncellemeMevcut).toBe(false);
     expect(sonuc.bilgi).toBeNull();
   });
+
+  it('uygulama guncellendiginde cache gecersiz hale gelir', async () => {
+    // Senaryo: Uygulama versiyonu ile ayni versiyonu cache'e kaydet
+    // (kullanici uygulamayi guncelledi, artik mevcut versiyon == cache'deki "yeni versiyon")
+    const mevcutVersiyon = UYGULAMA.VERSIYON;
+    mockFetch.mockResolvedValue(githubYanitiOlustur(mevcutVersiyon));
+
+    const servis = GuncellemeServisi.getInstance();
+
+    // Ilk kontrol - cache'e kaydeder
+    await servis.guncellemeKontrolEt(true);
+    const ilkFetchCount = mockFetch.mock.calls.length;
+
+    // Simdi cache'de "yeni versiyon" = UYGULAMA.VERSIYON var
+    // Bu cache gecersiz olmali cunku artik "yeni versiyon" mevcut versiyon
+
+    // Ikinci kontrol (zorla degil) - cache gecersiz oldugu icin yeniden API cagrisi yapmali
+    await servis.guncellemeKontrolEt(false);
+
+    // Yeni API cagrisi yapilmis olmali
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(ilkFetchCount);
+  });
 });
 
 describe('guvenilirBaglantiMi', () => {


### PR DESCRIPTION
## Summary
Enhanced the cache validation logic in `GuncellemeServisi` to detect when the application has been updated and invalidate the cached update check results accordingly.

## Key Changes
- **Cache invalidation logic**: Modified `onbellekGecerliMi()` method to compare the cached "new version" with the current application version
  - Cache is now considered invalid if the cached new version is less than or equal to the current version
  - This indicates the user has already updated the application
  - Prevents stale cached data from being used after an app update

- **Test coverage**: Added comprehensive test case `uygulama guncellendiginde cache gecersiz hale gelir` to verify:
  - Cache is properly invalidated when app version matches the cached "new version"
  - API is called again on subsequent checks when cache is invalidated
  - Ensures fresh update information is fetched after an app update

## Implementation Details
- Uses existing `versiyonKarsilastir()` utility function for version comparison
- Maintains backward compatibility with existing cache timeout logic (6-hour interval)
- Cache invalidation only applies when update information is available in cache
- Updated JSDoc comments to document the new invalidation criteria

https://claude.ai/code/session_016fC7ucpbJwmULCJoyqYVWC