### PR TITLE
fix: vakit sayacı ve iftar sayacı bildirimlerinin release APK'da çalışmamasını düzelt

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -142,13 +142,13 @@ const arkaplanMuhafiziBildirimleriniPlanla = async () => {
       await VakitBildirimYoneticiServisi.getInstance().bildirimleriGuncelle();
     }
 
-    // Vakit sayaci bildirimlerini planla
+    // Vakit sayaci bildirimlerini planla (muhafiz ilk bildirimle eş zamanlı)
     await store.dispatch(vakitSayacAyarlariniYukle());
     const sayacState = store.getState().vakitSayac;
     await VakitSayacBildirimServisi.getInstance().yapilandirVePlanla({
       aktif: sayacState.ayarlar.aktif,
       koordinatlar: konumState.koordinatlar,
-      seviye2Esik: muhafizAyarlari.esikler.seviye2,
+      baslangicEsikDk: muhafizAyarlari.esikler.seviye1,
     });
 
     console.log('[App] Arka plan muhafiz, vakit bildirimleri ve sayaç planlandi');

--- a/app.json
+++ b/app.json
@@ -45,6 +45,7 @@
     },
     "plugins": [
       "expo-audio",
+      "@notifee/react-native",
       [
         "expo-notifications",
         {

--- a/src/domain/services/IftarSayacBildirimServisi.ts
+++ b/src/domain/services/IftarSayacBildirimServisi.ts
@@ -11,7 +11,7 @@
  * - Zamanlanmış bildirimler (her dk tetiklenen) KULLANMAZ, tek chronometer yeterli
  */
 
-import notifee, { TriggerType, AndroidImportance, TimestampTrigger } from '@notifee/react-native';
+import notifee, { TriggerType, AndroidImportance, TimestampTrigger, AndroidStyle } from '@notifee/react-native';
 import { Platform } from 'react-native';
 import { Coordinates, CalculationMethod, PrayerTimes } from 'adhan';
 import { BILDIRIM_SABITLERI } from '../../core/constants/UygulamaSabitleri';
@@ -167,7 +167,7 @@ export class IftarSayacBildirimServisi {
     return {
       id: bildirimId,
       title: '🌙 İftar Sayacı',
-      body: 'Akşam namazı vaktine kalan süre — Ezanı duymadan orucunuzu açmayınız!',
+      body: 'İftar vaktine kalan süre',
       android: {
         channelId: BILDIRIM_SABITLERI.KANALLAR.IFTAR_SAYAC,
         ongoing: true,
@@ -175,8 +175,11 @@ export class IftarSayacBildirimServisi {
         showChronometer: true,
         chronometerCountDown: true,
         timestamp: aksamVaktiMs,
-        smallIcon: 'ic_notification',
         pressAction: { id: 'default' },
+        style: {
+          type: AndroidStyle.BIGTEXT as const,
+          text: 'İftar vaktine kalan süre\n\n⚠️ Ezanı duymadan orucunuzu açmayınız!',
+        },
       },
     };
   }
@@ -224,18 +227,21 @@ export class IftarSayacBildirimServisi {
    */
   private vakitGirdiBildirimIcerigi(bildirimId: string, aksamVaktiMs: number) {
     return {
-      id: bildirimId, // Aynı ID - geri sayımı replace eder
+      id: bildirimId,
       title: '🌙 İftar Vakti Girdi!',
-      body: 'Hayırlı iftarlar! — Ezanı duymadan orucunuzu açmayınız!',
+      body: 'Hayırlı iftarlar!',
       android: {
         channelId: BILDIRIM_SABITLERI.KANALLAR.IFTAR_SAYAC,
         ongoing: true,
         autoCancel: false,
         showChronometer: true,
-        chronometerCountDown: false, // Yukarı sayar (geçen süre)
+        chronometerCountDown: false,
         timestamp: aksamVaktiMs,
-        smallIcon: 'ic_notification',
         pressAction: { id: 'default' },
+        style: {
+          type: AndroidStyle.BIGTEXT as const,
+          text: 'Hayırlı iftarlar!\n\n⚠️ Ezanı duymadan orucunuzu açmayınız!',
+        },
       },
     };
   }
@@ -255,15 +261,14 @@ export class IftarSayacBildirimServisi {
 
       await notifee.createTriggerNotification(
         {
-          id: bildirimId, // Aynı ID - replace eder
+          id: bildirimId,
           title: '',
           body: '',
           android: {
             channelId: BILDIRIM_SABITLERI.KANALLAR.IFTAR_SAYAC,
             ongoing: false,
             autoCancel: true,
-            timeoutAfter: 100, // 100ms sonra otomatik kapan
-            smallIcon: 'ic_notification',
+            timeoutAfter: 100,
           },
         },
         trigger

--- a/src/domain/services/__tests__/IftarSayacBildirimServisi.test.ts
+++ b/src/domain/services/__tests__/IftarSayacBildirimServisi.test.ts
@@ -15,6 +15,7 @@ jest.mock('@notifee/react-native', () => ({
     },
     TriggerType: { TIMESTAMP: 0 },
     AndroidImportance: { LOW: 2, DEFAULT: 3, HIGH: 4 },
+    AndroidStyle: { BIGTEXT: 0 },
 }));
 
 jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));

--- a/src/domain/services/__tests__/VakitSayacBildirimServisi.test.ts
+++ b/src/domain/services/__tests__/VakitSayacBildirimServisi.test.ts
@@ -15,6 +15,7 @@ jest.mock('@notifee/react-native', () => ({
     },
     TriggerType: { TIMESTAMP: 0 },
     AndroidImportance: { LOW: 2, DEFAULT: 3, HIGH: 4 },
+    AndroidStyle: { BIGTEXT: 0 },
 }));
 
 jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
@@ -61,7 +62,7 @@ describe('VakitSayacBildirimServisi', () => {
     await servis.yapilandirVePlanla({
       aktif: true,
       koordinatlar: { lat: 41, lng: 29 },
-      seviye2Esik: 30,
+      baslangicEsikDk: 30,
     });
 
     expect(notifee.deleteChannel).toHaveBeenCalledWith('vakit_sayac');
@@ -91,7 +92,7 @@ describe('VakitSayacBildirimServisi', () => {
     await servis.yapilandirVePlanla({
       aktif: true,
       koordinatlar: { lat: 41, lng: 29 },
-      seviye2Esik: 30,
+      baslangicEsikDk: 30,
     });
 
     const createCalls = (notifee.createTriggerNotification as jest.Mock).mock.calls;

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -308,7 +308,7 @@ export const AnaSayfa: React.FC = () => {
             await VakitSayacBildirimServisi.getInstance().yapilandirVePlanla({
               aktif: true,
               koordinatlar: konumState.koordinatlar,
-              seviye2Esik: muhafizState.esikler.seviye2,
+              baslangicEsikDk: muhafizState.esikler.seviye1,
             });
           }
         } catch (e) { }

--- a/src/presentation/screens/BildirimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/BildirimAyarlariSayfasi.tsx
@@ -177,7 +177,7 @@ export const BildirimAyarlariSayfasi: React.FC<any> = ({ navigation }) => {
     await VakitSayacBildirimServisi.getInstance().yapilandirVePlanla({
       aktif: yeniDeger,
       koordinatlar: konumState.koordinatlar,
-      seviye2Esik: muhafizState.esikler.seviye2,
+      baslangicEsikDk: muhafizState.esikler.seviye1,
     });
   };
 


### PR DESCRIPTION
Ana sorun: smallIcon: 'ic_notification' referansı Expo managed workflow'da
var olmayan bir drawable'a işaret ediyordu - notifee bildirim oluşturmayı
sessizce başarısız yapıyordu.

Yapılan değişiklikler:
- Tüm notifee bildirimlerinden smallIcon referansı kaldırıldı (varsayılan
  launcher ikonu kullanılacak)
- @notifee/react-native app.json plugins dizisine eklendi (native modül
  bağlantısını garanti altına almak için)
- Vakit sayacı muhafız seviye2 yerine seviye1 ile eş zamanlı başlayacak
  şekilde güncellendi (ilk muhafız bildirimiyle eş zamanlı)
- AndroidStyle.BIGTEXT eklenerek Duolingo tarzı büyük bildirim görünümü
  sağlandı
- İftar sayacı body metni düzenlendi ve uyarı BigTextStyle içine taşındı

https://claude.ai/code/session_01PiSv2uhdR535VBQrUBnTYS