### PR TITLE
fix(release): fetch-tags eklendi, versiyon 0.11.0 olarak duzeltildi

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.build_type == 'release' && 0 || 1 }}
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📦 Setup Node.js

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Namaz Akışı",
     "slug": "namazakisi",
-    "version": "0.0.1",
+    "version": "0.11.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namazakisi",
-  "version": "0.0.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "namazakisi",
-      "version": "0.0.1",
+      "version": "0.11.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namazakisi",
-  "version": "0.0.1",
+  "version": "0.11.0",
   "description": "Free & Open Source Prayer App (Sadaqah Jariyah)",
   "license": "GPL-3.0",
   "main": "index.ts",

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -37,7 +37,7 @@ export const NAMAZ_ISIMLERI = [
 // Uygulama meta verileri
 export const UYGULAMA = {
   ADI: 'Namaz Akışı',
-  VERSIYON: '0.0.1',
+  VERSIYON: '0.11.0',
   ACIKLAMA: 'Günlük namaz takip uygulaması',
   GITHUB_REPO: 'furkanisikay/namazakisi',
 } as const;


### PR DESCRIPTION
Sorun: actions/checkout@v4 fetch-depth:0 ile tag'leri otomatik
getirmiyor. Bu nedenle paulhatch/semantic-version hicbir tag
bulamadi ve 0.0.1 degerini versiyon olarak hesapladi. Ek olarak
v0.0.1 tag'i Ocak 2023'ten beri mevcut oldugu icin tag push
islemi catisma hatasi ile patladi.

Cozum:
- checkout adimina fetch-tags: true eklendi
- Yanlis hesaplanan versiyon (0.0.1) -> dogru versiyon (0.11.0)
  olarak duzeltildi (v0.10.0'dan sonra feat: commit var = minor bump)

https://claude.ai/code/session_01Pj3p2LVDojdhH4D6BkpS28