### PR TITLE
feat: muhafız bildirimleri her yeni bildirimde öncekini temizler

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -209,6 +209,8 @@ const AppIcerik: React.FC = () => {
 
         // Arkaplan muhafiz bildirimlerini planla (Logger hazir olduktan sonra)
         arkaplanMuhafiziBildirimleriniPlanla();
+        // Arka planda birikmis eski muhafiz bildirimlerini temizle
+        BildirimServisi.getInstance().sunulanEskiMuhafizBildirimleriniTemizle();
       })
       .catch(err => Logger.error('App', 'Logger baslatilamadi', err));
 
@@ -226,6 +228,9 @@ const AppIcerik: React.FC = () => {
       if (nextAppState === 'active') {
         // Uygulama on plana geldi, bildirimleri yenile
         arkaplanMuhafiziBildirimleriniPlanla();
+        // Arka planda birikmis eski muhafiz bildirimlerini temizle
+        // (her vakit icin yalnizca en son bildirimi bildirim merkezinde tut)
+        BildirimServisi.getInstance().sunulanEskiMuhafizBildirimleriniTemizle();
         // Konum takibini senkronize et ve yeniden baslat
         konumTakibiniSenkronizeEt();
         // Guncelleme kontrolu (onbellek gecerlilik surecine uyar)

--- a/src/domain/services/BildirimServisi.ts
+++ b/src/domain/services/BildirimServisi.ts
@@ -263,18 +263,11 @@ export class BildirimServisi {
         }
       }
 
-      // Bu vakit icin kalan tum bildirimleri iptal et
-      // ArkaplanMuhafizServisi uzerinden iptal et (boylece kilinanlar listesine de eklenir)
-      if (isVakitAdi(vakit)) {
-        await ArkaplanMuhafizServisi.getInstance().vakitBildirimleriniIptalEt(vakit);
-        // Vakit sayaci bildirimini de iptal et
-        await VakitSayacBildirimServisi.getInstance().vakitSayaciniIptalEt(vakit);
-      } else {
+      if (!isVakitAdi(vakit)) {
         Logger.warn('BildirimServisi', 'Vakit adı doğrulanamadı, iptal işlemi atlandı:', vakit);
       }
-
-      // Bildirim merkezinde sadece bu vakte ait muhafiz bildirimlerini kapat
-      await this.vakitBildirimleriniKapat(vakit, tarih);
+      // Zamanlanmış/aktif tüm vakit bildirimlerini temizle
+      await this.vakitKilindiTemizle(vakit, tarih);
 
       Logger.info('BildirimServisi', `${vakit} icin kalan bildirimler iptal edildi`);
     } catch (error) {
@@ -284,11 +277,24 @@ export class BildirimServisi {
   }
 
   /**
+   * Namaz kılındığında tüm vakit bildirimlerini temizler:
+   * zamanlanmış muhafız bildirimleri, vakit sayacı ve bildirim merkezindeki aktif bildirimler.
+   * AnaSayfa (uygulama içi toggle) ve kildimAksiyonunuIsle (bildirimden "Kıldım") tarafından kullanılır.
+   */
+  public async vakitKilindiTemizle(vakit: string, tarih: string): Promise<void> {
+    const gorevler: Promise<void>[] = [this.vakitBildirimleriniKapat(vakit, tarih)];
+    if (isVakitAdi(vakit)) {
+      gorevler.push(ArkaplanMuhafizServisi.getInstance().vakitBildirimleriniIptalEt(vakit));
+      gorevler.push(VakitSayacBildirimServisi.getInstance().vakitSayaciniIptalEt(vakit));
+    }
+    await Promise.allSettled(gorevler);
+  }
+
+  /**
    * Sadece belirli bir vakte ait muhafiz bildirimlerini bildirim merkezinden kapat
    * Diger vakitlerin bildirimleri korunur
-   * Uygulama ici "kilindi" isaretlendiginde veya bildirimden "Kildim" tiklandiginda cagrilir
    */
-  public async vakitBildirimleriniKapat(vakit: string, tarih: string): Promise<void> {
+  private async vakitBildirimleriniKapat(vakit: string, tarih: string): Promise<void> {
     try {
       const mevcutBildirimler = await Notifications.getPresentedNotificationsAsync();
       // Timezone-safe: gunEkle YYYY-MM-DD string uzerinde calisir, new Date() UTC sorununa yol acmaz
@@ -298,12 +304,11 @@ export class BildirimServisi {
       const bugunOneki = `${BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ}${tarih}${BILDIRIM_SABITLERI.ONEKLEME.VAKIT}${vakit}`;
       const dunOneki = `${BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ}${dunStr}${BILDIRIM_SABITLERI.ONEKLEME.VAKIT}${vakit}`;
 
-      for (const bildirim of mevcutBildirimler) {
-        const id = bildirim.request.identifier;
-        if (id.startsWith(bugunOneki) || id.startsWith(dunOneki)) {
-          await Notifications.dismissNotificationAsync(id);
-        }
-      }
+      const kapatilacaklar = mevcutBildirimler
+        .map(b => b.request.identifier)
+        .filter(id => id.startsWith(bugunOneki) || id.startsWith(dunOneki));
+
+      await Promise.all(kapatilacaklar.map(id => Notifications.dismissNotificationAsync(id)));
     } catch (error) {
       Logger.error('BildirimServisi', 'Vakit bildirimleri kapatilirken hata:', error);
     }

--- a/src/domain/services/BildirimServisi.ts
+++ b/src/domain/services/BildirimServisi.ts
@@ -59,6 +59,17 @@ async function oncekiMuhafizBildirimleriniTemizle(yeniBildirimId: string): Promi
 }
 
 /**
+ * Vakit onekini bildirim ID'sinden cikar
+ * Ornek: "muhafiz_2026-03-10_vakit_ikindi_seviye_2_dk_15" → "muhafiz_2026-03-10_vakit_ikindi"
+ */
+function vakitOnekiniCikar(bildirimId: string): string | null {
+  const eslesme = bildirimId.match(
+    new RegExp(`^(${BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ}\\d{4}-\\d{2}-\\d{2}${BILDIRIM_SABITLERI.ONEKLEME.VAKIT}[a-z]+)`)
+  );
+  return eslesme ? eslesme[1] : null;
+}
+
+/**
  * Bildirim ayarlarini yapilandir
  */
 Notifications.setNotificationHandler({
@@ -294,6 +305,50 @@ export class BildirimServisi {
       }
     } catch (error) {
       Logger.error('BildirimServisi', 'Vakit bildirimleri kapatilirken hata:', error);
+    }
+  }
+
+  /**
+   * Bildirim merkezindeki eski muhafiz bildirimlerini temizle
+   * Her vakit icin yalnizca en son gosterilen bildirimi tutar, daha eskileri siler
+   * Uygulama on plana geldiginde veya ilk basladiginda cagrilir (arka plan senaryosu icin)
+   */
+  public async sunulanEskiMuhafizBildirimleriniTemizle(): Promise<void> {
+    try {
+      const mevcutBildirimler = await Notifications.getPresentedNotificationsAsync();
+
+      // Muhafiz bildirimlerini vakit onekine gore grupla
+      const vakitGruplari = new Map<string, Array<{ id: string; date: number }>>();
+
+      for (const bildirim of mevcutBildirimler) {
+        const id = bildirim.request.identifier;
+        if (!id.startsWith(BILDIRIM_SABITLERI.ONEKLEME.MUHAFIZ)) continue;
+
+        const vakitOneki = vakitOnekiniCikar(id);
+        if (!vakitOneki) continue;
+
+        if (!vakitGruplari.has(vakitOneki)) {
+          vakitGruplari.set(vakitOneki, []);
+        }
+        vakitGruplari.get(vakitOneki)!.push({ id, date: bildirim.date });
+      }
+
+      // Her vakit grubu icin en son bildirimi tut, daha eskileri sil
+      for (const [, bildirimler] of vakitGruplari) {
+        if (bildirimler.length <= 1) continue;
+
+        // Tarihe gore sirala (buyukten kucuge) - en son = en buyuk tarih
+        bildirimler.sort((a, b) => b.date - a.date);
+
+        // Ilki (en son) haric diger bildirimleri kaldir
+        for (let i = 1; i < bildirimler.length; i++) {
+          await Notifications.dismissNotificationAsync(bildirimler[i].id);
+        }
+      }
+
+      Logger.info('BildirimServisi', 'Eski muhafiz bildirimleri temizlendi');
+    } catch (error) {
+      Logger.error('BildirimServisi', 'Eski muhafiz bildirimleri temizlenirken hata:', error);
     }
   }
 

--- a/src/domain/services/BildirimServisi.ts
+++ b/src/domain/services/BildirimServisi.ts
@@ -286,8 +286,9 @@ export class BildirimServisi {
   /**
    * Sadece belirli bir vakte ait muhafiz bildirimlerini bildirim merkezinden kapat
    * Diger vakitlerin bildirimleri korunur
+   * Uygulama ici "kilindi" isaretlendiginde veya bildirimden "Kildim" tiklandiginda cagrilir
    */
-  private async vakitBildirimleriniKapat(vakit: string, tarih: string): Promise<void> {
+  public async vakitBildirimleriniKapat(vakit: string, tarih: string): Promise<void> {
     try {
       const mevcutBildirimler = await Notifications.getPresentedNotificationsAsync();
       // Timezone-safe: gunEkle YYYY-MM-DD string uzerinde calisir, new Date() UTC sorununa yol acmaz

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -329,12 +329,9 @@ export const AnaSayfa: React.FC = () => {
       }
       try { NamazMuhafiziServisi.getInstance().namazKilindiIsaretle(namazAdi); setMuhafizDurumu({ mesaj: '', seviye: 0 }); } catch (e) { }
 
-      // Arka plan bildirimlerini iptal et
+      // Zamanlanmış/aktif tüm vakit bildirimlerini temizle
       if (vakitAdi) {
-        try { await ArkaplanMuhafizServisi.getInstance().vakitBildirimleriniIptalEt(vakitAdi); } catch (e) { }
-        try { await VakitSayacBildirimServisi.getInstance().vakitSayaciniIptalEt(vakitAdi); } catch (e) { }
-        // Bildirim merkezinde bekleyen muhafiz bildirimlerini temizle
-        try { await BildirimServisi.getInstance().vakitBildirimleriniKapat(vakitAdi, mevcutTarih); } catch (e) { }
+        try { await BildirimServisi.getInstance().vakitKilindiTemizle(vakitAdi, mevcutTarih); } catch (e) { }
       }
     } else {
       // Namaz kilmadim - bildirimleri yeniden aktif et

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -23,6 +23,7 @@ import { NamazMuhafiziServisi } from '../../domain/services/NamazMuhafiziServisi
 import { NamazVaktiHesaplayiciServisi, VakitBilgisi } from '../../domain/services/NamazVaktiHesaplayiciServisi';
 import { ArkaplanMuhafizServisi } from '../../domain/services/ArkaplanMuhafizServisi';
 import { VakitSayacBildirimServisi } from '../../domain/services/VakitSayacBildirimServisi';
+import { BildirimServisi } from '../../domain/services/BildirimServisi';
 import { ArkaplanGorevServisi } from '../../domain/services/ArkaplanGorevServisi';
 import { store } from '../store/store';
 import { HaptikServisi } from '../../core/feedback/HaptikServisi';
@@ -332,6 +333,8 @@ export const AnaSayfa: React.FC = () => {
       if (vakitAdi) {
         try { await ArkaplanMuhafizServisi.getInstance().vakitBildirimleriniIptalEt(vakitAdi); } catch (e) { }
         try { await VakitSayacBildirimServisi.getInstance().vakitSayaciniIptalEt(vakitAdi); } catch (e) { }
+        // Bildirim merkezinde bekleyen muhafiz bildirimlerini temizle
+        try { await BildirimServisi.getInstance().vakitBildirimleriniKapat(vakitAdi, mevcutTarih); } catch (e) { }
       }
     } else {
       // Namaz kilmadim - bildirimleri yeniden aktif et


### PR DESCRIPTION
Namaz muhafızı arka planda çalışırken birden fazla bildirim birikiyordu.
Yeni `sunulanEskiMuhafizBildirimleriniTemizle` metodu eklenerek uygulama
ön plana her geldiğinde ve ilk başlangıçta her vakit için yalnızca en son
gönderilen muhafız bildirimi bildirim merkezinde bırakılır, daha eskiler
silinir. Ön planda iken gelen bildirimler için mevcut mekanizma korundu.

https://claude.ai/code/session_011eWxntMZp52m7Q6LhK7jTN