### PR TITLE
feat: bildirim izni UX iyileştirmeleri ve seri eşiği düzenlemeleri

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,8 @@ import { namazlariYukle, namazDurumunuDegistir } from './src/presentation/store/
 import { KonumTakipServisi } from './src/domain/services/KonumTakipServisi';
 import { guncellemeKontrolEt } from './src/presentation/store/guncellemeSlice';
 import { PlayStoreModulu } from './src/domain/services/PlayStoreGuncellemeModulu';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DEPOLAMA_ANAHTARLARI } from './src/core/constants/UygulamaSabitleri';
 import { Logger } from './src/core/utils/Logger';
 
 // Bildirim aksiyonu callback'ini ayarla (domain → presentation koprusu)
@@ -140,12 +142,15 @@ const arkaplanMuhafiziBildirimleriniPlanla = async () => {
     }
 
     // 2. Servis ayarlarini ve bildirim iznini paralel yukle (birbirinden bagimsiz)
+    // Bildirim izni yalnizca kurulum tamamlandiktan sonra istenir;
+    // sihirbaz acikken OS dialog'u gostermemek icin bu kontrol gereklidir.
+    const kurulumTamamlandi = await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.ILK_KURULUM_TAMAMLANDI);
     await Promise.all([
       store.dispatch(muhafizAyarlariniYukle()).unwrap(),
       store.dispatch(vakitSayacAyarlariniYukle()),
       store.dispatch(iftarSayacAyarlariniYukle()),
       store.dispatch(sahurSayacAyarlariniYukle()),
-      BildirimServisi.getInstance().izinIste(),
+      kurulumTamamlandi ? BildirimServisi.getInstance().izinIste() : Promise.resolve(),
     ]);
 
     const state = store.getState();

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Bu proje, ticari bir kaygı güdülmeden, **"Sadaka-i Cariye"** niyetiyle geliş
 
 ### 📍 Akıllı Vakit Takibi
 *   **Tamamen Çevrimdışı:** İnternet gerektirmez. `Adhan.js` kütüphanesi ile koordinatlarınız üzerinden astronomik hesaplama yapar (Diyanet uyumlu).
-*   **Otomatik Konum:** Tek seferlik konum izni ile çalışır, gittiğiniz her yerde vakitleri otomatik günceller.
+*   **Otomatik Konum:** Tek seferlik konum izni ile çalışır, gittiğiniz her yerde vakitleri otomatik günceller. Konum modu (GPS / Manuel) ana ekranda etiketle gösterilir.
+*   **Kerahat Vakti:** Güneş doğuşu saatlerinde öğle namazı kartı pasif gösterilir, kerahat vakti ana ekranda belirtilir.
+*   **Canlı Vakit Sayacı:** Bir sonraki namaza veya vaktin bitimine kalan süreyi gerçek zamanlı olarak gösterir.
 
 ### 🔔 'Muhafız' Bildirim Sistemi
 Sıradan bir alarm değil, sizi namaza kaldıran akıllı bir sistem:
@@ -34,13 +36,25 @@ Sıradan bir alarm değil, sizi namaza kaldıran akıllı bir sistem:
 *   **İnteraktif Bildirimler:** Uygulamayı açmadan bildirim üzerinden **"Kıldım"** diyerek vakti işaretleyin.
 *   **Akıllı Temizlik:** Namazı kıldığınızda veya yeni vakit girdiğinde eski bildirimler otomatik temizlenir.
 *   **Esnek Ayarlar:** Her aşama için sıklık (örn: son 15 dk kala her dakika uyar) ayarlanabilir.
+*   **Geri Sayım Bildirimleri:** İftar ve sahur için native Android geri sayım bildirimleri; ekran kilitliyken dahi kalan süreyi gösterir.
+
+### 🕋 Kıble Pusulası
+*   **Gerçek Zamanlı Kıble:** Cihaz sensörleri ile Kabe yönünü anlık gösterir.
+
+### 📅 Ramazan Modülü
+*   **İftar & Sahur Sayacı:** İftara veya sahura kalan süreyi ana ekranda takip edin.
+*   **Özel Sahur Teması:** Sahur sayacı için mor gradient teması ve özel görsel.
 
 ### 📿 İbadet Takibi & Motivasyon
 *   **Kaza Hesaplayıcı:** Kılınmayan namazları otomatik tespit eder ve kaza çetelenizi tutar.
+*   **Kaza Defteri:** Kılınamayan namazları tarihe göre kayıt altına alır; geçmişe dönük kaza takibi yapar.
 *   **Seri (Streak) Sistemi:** İbadet devamlılığınızı Zinciri Kırma metoduyla görselleştirin.
-*   **Oyunlaştırma:** İbadet performansınıza göre seviye atlayın ve rozetler kazanın.
+*   **Oyunlaştırma:** İbadet performansınıza göre seviye atlayın ve rozetler kazanın. Vakit kartlarında puan göstergesi bulunur.
+*   **Paylaşım:** Rozet ve seri başarılarınızı, kutlama ekranından arkadaşlarınızla paylaşın.
 
 ### 🌙 Modern & Kullanıcı Dostu
+*   **Kurulum Sihirbazı:** İlk açılışta konum izni ve bildirim ayarlarını adım adım yapılandırır.
+*   **Otomatik Güncelleme:** Play Store'da yeni sürüm çıktığında uygulama içinden güncelleme teklif eder.
 *   **Göz Yormayan Arayüz:** Gece kullanıma uygun, şık Karanlık Mod.
 *   **Reklamsız & Sade:** Sizi ibadetten alıkoyacak hiçbir reklam veya dikkat dağıtıcı unsur içermez.
 
@@ -50,7 +64,7 @@ Sıradan bir alarm değil, sizi namaza kaldıran akıllı bir sistem:
 
 Modern mobil geliştirme standartları ile inşa edilmiştir:
 
-*   **Core:** React Native (Expo SDK 50+), TypeScript
+*   **Core:** React Native (Expo SDK 54), TypeScript
 *   **State:** Redux Toolkit
 *   **Storage:** AsyncStorage (Yerel Veri Tabanı)
 *   **Styling:** NativeWind (TailwindCSS)

--- a/src/core/types/SeriTipleri.ts
+++ b/src/core/types/SeriTipleri.ts
@@ -212,7 +212,7 @@ export const VARSAYILAN_SERI_AYARLARI: SeriAyarlari = {
   tamGunEsigi: 5,
   gunBitisSaati: '05:00', // DEPRECATED - artık otomatik hesaplanıyor
   bildirimlerAktif: true,
-  toparlanmaGunSayisi: 5,
+  toparlanmaGunSayisi: 3,
   gunSonuBildirimAktif: true,
   gunSonuBildirimDk: 60, // DEPRECATED
   // Yeni gün sonu bildirim ayarları

--- a/src/domain/services/SeriHesaplayiciServisi.ts
+++ b/src/domain/services/SeriHesaplayiciServisi.ts
@@ -380,24 +380,38 @@ export const seriHesapla = (
       // Yeni hedef kontrolu
       sonuc.yeniHedefTamamlandi = tamamlananHedefiBul(eskiSeri, yeniSeri);
     } else if (sonTamGun && gunFarkiniHesapla(sonTamGun, bugun) > 1) {
-      // Arada gun(ler) kacti - toparlanma moduna gec
-      // Ama bugun tam kilindigi icin toparlanmanin ilk gunu sayilir
-
-      sonuc.seriDurumu = {
-        ...durum,
-        toparlanmaDurumu: {
-          tamamlananGun: 1, // Bugun ilk gun
-          baslangicTarihi: bugun,
-          hedefGunSayisi: ayarlar.toparlanmaGunSayisi,
-          oncekiSeri: durum.mevcutSeri,
-        },
-        sonTamGun: bugun,
-        sonGuncelleme: new Date().toISOString(),
-      };
-
+      // Arada gun(ler) kacti - seri bozuldu
+      if (durum.mevcutSeri >= 7) {
+        // 7+ gunluk seri: toparlanma moduna gec
+        // Bugun tam kilindigi icin toparlanmanin ilk gunu sayilir
+        sonuc.seriDurumu = {
+          ...durum,
+          toparlanmaDurumu: {
+            tamamlananGun: 1, // Bugun ilk gun
+            baslangicTarihi: bugun,
+            hedefGunSayisi: ayarlar.toparlanmaGunSayisi,
+            oncekiSeri: durum.mevcutSeri,
+          },
+          sonTamGun: bugun,
+          sonGuncelleme: new Date().toISOString(),
+        };
+        sonuc.kazanilanPuan = 5; // Dusuk puan - seri bozuldu ama toparlanma basladi
+      } else {
+        // 7 gunun altinda seri: toparlanma yok, sifirdan yeni seri baslat
+        sonuc.seriDurumu = {
+          mevcutSeri: 1,
+          enUzunSeri: Math.max(durum.enUzunSeri, 1),
+          sonTamGun: bugun,
+          seriBaslangici: bugun,
+          toparlanmaDurumu: null,
+          dondurulduMu: false,
+          dondurulmaTarihi: null,
+          sonGuncelleme: new Date().toISOString(),
+        };
+        sonuc.kazanilanPuan = 10;
+      }
       sonuc.seriDegisti = true;
       sonuc.seriBozuldu = true;
-      sonuc.kazanilanPuan = 5; // Dusuk puan - seri bozuldu ama toparlanma basladi
     }
   } else {
     // Bugun tam kilinmadi

--- a/src/presentation/screens/KurulumSihirbaziSayfasi.tsx
+++ b/src/presentation/screens/KurulumSihirbaziSayfasi.tsx
@@ -80,7 +80,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
   const slideAnim = useRef(new Animated.Value(0)).current;
 
   // Bildirim izni
-  const [bildirimIzni, setBildirimIzni] = useState<'bekliyor' | 'verildi' | 'reddedildi'>('bekliyor');
+  const [bildirimIzni, setBildirimIzni] = useState<'bekliyor' | 'isteniyor' | 'verildi' | 'reddedildi'>('bekliyor');
 
   // Konum
   const [konumDurumu, setKonumDurumu] = useState<KonumDurumu>('bekliyor');
@@ -127,9 +127,14 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
   // ─── Bildirim İzni ───────────────────────────────────────────────────────
 
   const bildirimIzniIste = useCallback(async () => {
+    setBildirimIzni('isteniyor');
     const { status } = await Notifications.requestPermissionsAsync();
-    setBildirimIzni(status === 'granted' ? 'verildi' : 'reddedildi');
-    ilerle();
+    if (status === 'granted') {
+      setBildirimIzni('verildi');
+      setTimeout(() => ilerle(), 1400);
+    } else {
+      setBildirimIzni('reddedildi');
+    }
   }, [ilerle]);
 
   // ─── Konum İzni + GPS ────────────────────────────────────────────────────
@@ -244,7 +249,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
   const renderAdim = () => {
     switch (adim) {
       case ADIM.HOSGELDINIZ: return <HosgeldinizAdimi />;
-      case ADIM.BILDIRIM_IZNI: return <BildirimIzniAdimi />;
+      case ADIM.BILDIRIM_IZNI: return <BildirimIzniAdimi bildirimIzni={bildirimIzni} />;
       case ADIM.KONUM: return (
         <KonumAdimi
           konumDurumu={konumDurumu}
@@ -298,6 +303,18 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
       );
     }
     if (adim === ADIM.BILDIRIM_IZNI) {
+      if (bildirimIzni === 'isteniyor' || bildirimIzni === 'verildi') return null;
+      if (bildirimIzni === 'reddedildi') {
+        return (
+          <TouchableOpacity
+            style={[styles.buton, styles.butonBirincil, { backgroundColor: palet.birincil }]}
+            onPress={ilerle}
+          >
+            <FontAwesome5 name="arrow-right" size={16} color="#fff" />
+            <Text style={styles.butonMetin}>Şimdilik Geç</Text>
+          </TouchableOpacity>
+        );
+      }
       return (
         <>
           <TouchableOpacity
@@ -476,21 +493,82 @@ const HosgeldinizAdimi: React.FC = () => {
 
 // ─── Adım 1: Bildirim İzni ───────────────────────────────────────────────────
 
-const BildirimIzniAdimi: React.FC = () => {
+const BildirimIzniAdimi: React.FC<{
+  bildirimIzni: 'bekliyor' | 'isteniyor' | 'verildi' | 'reddedildi';
+}> = ({ bildirimIzni }) => {
   const bellAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.6)).current;
 
   useEffect(() => {
-    Animated.loop(Animated.sequence([
-      Animated.timing(bellAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
-      Animated.timing(bellAnim, { toValue: -1, duration: 200, useNativeDriver: true }),
-      Animated.timing(bellAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
-      Animated.timing(bellAnim, { toValue: 0, duration: 200, useNativeDriver: true }),
-      Animated.delay(2000),
-    ])).start();
-  }, []);
+    if (bildirimIzni === 'bekliyor') {
+      Animated.loop(Animated.sequence([
+        Animated.timing(bellAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
+        Animated.timing(bellAnim, { toValue: -1, duration: 200, useNativeDriver: true }),
+        Animated.timing(bellAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
+        Animated.timing(bellAnim, { toValue: 0, duration: 200, useNativeDriver: true }),
+        Animated.delay(2000),
+      ])).start();
+    }
+  }, [bildirimIzni]);
+
+  useEffect(() => {
+    if (bildirimIzni === 'verildi') {
+      Animated.spring(scaleAnim, { toValue: 1, friction: 4, useNativeDriver: true }).start();
+    }
+  }, [bildirimIzni]);
 
   const rotate = bellAnim.interpolate({ inputRange: [-1, 1], outputRange: ['-15deg', '15deg'] });
 
+  // ── İsteniyor (loading) ──
+  if (bildirimIzni === 'isteniyor') {
+    return (
+      <View style={styles.merkezliIcerik}>
+        <ActivityIndicator size="large" color="#f59e0b" style={{ marginBottom: 20 }} />
+        <Text style={styles.adimBaslik}>İzin Bekleniyor...</Text>
+        <Text style={styles.adimAltBaslik}>Açılan sistem ekranında izin verin</Text>
+      </View>
+    );
+  }
+
+  // ── Verildi (başarı) ──
+  if (bildirimIzni === 'verildi') {
+    return (
+      <View style={styles.merkezliIcerik}>
+        <Animated.View style={[styles.buyukIkonCember, { backgroundColor: '#fef3c720', transform: [{ scale: scaleAnim }] }]}>
+          <FontAwesome5 name="check-circle" size={52} color="#10b981" />
+        </Animated.View>
+        <Text style={styles.adimBaslik}>Bildirimler Açık!</Text>
+        <Text style={styles.adimAltBaslik}>Namaz vakitleri yaklaştığında sizi bilgilendireceğiz.</Text>
+        <Text style={{ color: '#9ca3af', fontSize: 13, textAlign: 'center', marginTop: 8 }}>
+          Bir sonraki adıma geçiliyor...
+        </Text>
+      </View>
+    );
+  }
+
+  // ── Reddedildi (fallback) ──
+  if (bildirimIzni === 'reddedildi') {
+    return (
+      <View style={styles.merkezliIcerik}>
+        <View style={[styles.buyukIkonCember, { backgroundColor: '#fef2f220' }]}>
+          <FontAwesome5 name="bell-slash" size={44} color="#ef4444" />
+        </View>
+        <Text style={styles.adimBaslik}>İzin Verilmedi</Text>
+        <Text style={styles.adimAltBaslik}>
+          Bildirimler olmadan da uygulamayı kullanabilirsiniz.
+          {'\n'}Daha sonra Ayarlar → Bildirimler bölümünden açabilirsiniz.
+        </Text>
+        <View style={[styles.bilgiKutu, { marginTop: 16 }]}>
+          <FontAwesome5 name="info-circle" size={14} color="#3b82f6" />
+          <Text style={styles.bilgiKutuMetin}>
+            Bildirimleri açmak için telefonunuzun uygulama ayarlarından izin verebilirsiniz.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  // ── Bekliyor (varsayılan) ──
   return (
     <ScrollView style={styles.scrollAdim} contentContainerStyle={styles.scrollIcerik} showsVerticalScrollIndicator={false}>
       <Animated.View style={[styles.buyukIkonCember, { backgroundColor: '#fef3c720' }, { transform: [{ rotate }] }]}>
@@ -648,7 +726,16 @@ const TemaAdimi: React.FC<{
   mod: string;
   paletiDegistir: (id: string) => void;
   moduDegistir: (mod: TemaModu) => void;
-}> = ({ palet, mod, paletiDegistir, moduDegistir }) => (
+}> = ({ palet, mod, paletiDegistir, moduDegistir }) => {
+  const { koyuMu } = useTema();
+  // Önizleme için seçili moda göre dark/light hesapla
+  const onizlemeKoyu = mod === 'koyu' ? true : mod === 'acik' ? false : koyuMu;
+  const onizlemeBg = onizlemeKoyu ? '#1f2937' : '#fff';
+  const onizlemeMetin = onizlemeKoyu ? '#f9fafb' : '#111';
+  const onizlemeMetinIkincil = onizlemeKoyu ? '#9ca3af' : '#6b7280';
+  const onizlemeSinir = onizlemeKoyu ? '#374151' : '#e5e7eb';
+
+  return (
   <ScrollView style={styles.scrollAdim} contentContainerStyle={styles.scrollIcerik} showsVerticalScrollIndicator={false}>
     <View style={[styles.buyukIkonCember, { backgroundColor: palet.birincil + '25', alignSelf: 'center' }]}>
       <FontAwesome5 name="palette" size={44} color={palet.birincil} />
@@ -656,8 +743,8 @@ const TemaAdimi: React.FC<{
     <Text style={styles.adimBaslik}>Tema Seçin</Text>
     <Text style={styles.adimAltBaslik}>Renk paleti seçin — uygulama anlık olarak değişir</Text>
 
-    {/* Canlı önizleme */}
-    <View style={[styles.onizlemeKart, { borderColor: palet.birincil + '40' }]}>
+    {/* Canlı önizleme — seçili moda göre dark/light */}
+    <View style={[styles.onizlemeKart, { borderColor: palet.birincil + '40', backgroundColor: onizlemeBg }]}>
       <View style={[styles.onizlemeBaslik, { backgroundColor: palet.birincil }]}>
         <FontAwesome5 name="mosque" size={14} color="#fff" />
         <Text style={styles.onizlemeBaslikMetin}>Namaz Akışı</Text>
@@ -665,14 +752,14 @@ const TemaAdimi: React.FC<{
       <View style={styles.onizlemeIcerik}>
         <View style={[styles.onizlemeVakitSatir, { borderLeftColor: palet.birincil }]}>
           <Text style={[styles.onizlemeVakitAdi, { color: palet.birincil }]}>Öğle</Text>
-          <Text style={styles.onizlemeVakitSaat}>13:24</Text>
+          <Text style={[styles.onizlemeVakitSaat, { color: onizlemeMetinIkincil }]}>13:24</Text>
           <View style={[styles.onizlemeBadge, { backgroundColor: palet.birincilAcik }]}>
             <Text style={[styles.onizlemeBadgeMetin, { color: palet.birincilKoyu }]}>Aktif</Text>
           </View>
         </View>
-        <View style={[styles.onizlemeVakitSatir, { borderLeftColor: '#e5e7eb' }]}>
-          <Text style={styles.onizlemeVakitAdiPasif}>İkindi</Text>
-          <Text style={styles.onizlemeVakitSaat}>16:42</Text>
+        <View style={[styles.onizlemeVakitSatir, { borderLeftColor: onizlemeSinir }]}>
+          <Text style={[styles.onizlemeVakitAdiPasif, { color: onizlemeMetinIkincil }]}>İkindi</Text>
+          <Text style={[styles.onizlemeVakitSaat, { color: onizlemeMetinIkincil }]}>16:42</Text>
         </View>
       </View>
     </View>
@@ -725,7 +812,8 @@ const TemaAdimi: React.FC<{
         : 'Her zaman karanlık görünüm kullanılır'}
     </Text>
   </ScrollView>
-);
+  );
+};
 
 // ─── Adım 4: Vakit Bildirimleri ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Bildirim izni gecikmesi:** Kurulum sihirbazı açıkken app başlangıcında OS bildirim dialog'u açılmıyordu; `ILK_KURULUM_TAMAMLANDI` kontrolü ile düzeltildi
- **BildirimIzniAdimi UX:** `isteniyor` (spinner) / `verildi` (animasyonlu başarı, 1.4s sonra otomatik ilerleme) / `reddedildi` (hata + "Şimdilik Geç" butonu) durum ekranları eklendi
- **Seri eşiği:** Seri bozulduğunda yalnızca 7+ günlük seriler toparlanma moduna girer; 7 günün altı sıfırdan yeni seri başlatır
- **toparlanmaGunSayisi:** Varsayılan 5 → 3 güncellendi
- **Tema önizleme:** Sihirbaz tema adımındaki önizleme kartı artık seçili moda (koyu/açık/sistem) göre doğru renkleniyor
- **README:** Kıble pusulası, Ramazan modülü, kaza defteri, canlı sayaç, SDK 54 eklendi

## Test plan

- [ ] İlk kurulumda (storage boş) uygulama başlarken bildirim dialog'unun açılmadığını doğrula
- [ ] Sihirbaz bildirim adımında "İzin Ver" → spinner → yeşil başarı ekranı → otomatik ilerleme akışını test et
- [ ] "Reddet" → kırmızı reddedildi ekranı → "Şimdilik Geç" butonu akışını test et
- [ ] 7 günlük serisi olan kullanıcıda bozulma → toparlanma modu aktifleşiyor
- [ ] 3-6 günlük serisi olan kullanıcıda bozulma → toparlanma yok, seri 1'den başlıyor
- [ ] Tema sihirbazında mod değiştirince önizleme kartı arka planı değişiyor

🤖 Generated with [Claude Code](https://claude.com/claude-code)