### PR TITLE
feat(android): 1x1 ve 4x2 namaz widget'ları

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,7 @@ import { namazlariYukle, namazDurumunuDegistir } from './src/presentation/store/
 import { KonumTakipServisi } from './src/domain/services/KonumTakipServisi';
 import { guncellemeKontrolEt } from './src/presentation/store/guncellemeSlice';
 import { PlayStoreModulu } from './src/domain/services/PlayStoreGuncellemeModulu';
+import { WidgetServisi } from './src/domain/services/WidgetServisi';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DEPOLAMA_ANAHTARLARI } from './src/core/constants/UygulamaSabitleri';
 import { Logger } from './src/core/utils/Logger';
@@ -139,6 +140,8 @@ const arkaplanMuhafiziBildirimleriniPlanla = async () => {
         latitude: konumState.koordinatlar.lat,
         longitude: konumState.koordinatlar.lng,
       });
+      // Widget verilerini güncelle (fire-and-forget, kritik değil)
+      WidgetServisi.getInstance().vakitleriyaz(konumState.koordinatlar).catch(() => {});
     }
 
     // 2. Servis ayarlarini ve bildirim iznini paralel yukle (birbirinden bagimsiz)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,5 +40,39 @@
         <data android:scheme="namazakisi"/>
       </intent-filter>
     </activity>
+
+    <!-- 1x1 Namaz Widget -->
+    <receiver
+        android:name=".widget.NamazWidget"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+          android:name="android.appwidget.provider"
+          android:resource="@xml/widget_namaz_bilgisi" />
+    </receiver>
+
+    <!-- 4x2 Geniş Namaz Widget -->
+    <receiver
+        android:name=".widget.NamazGenisBoyutWidget"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+      </intent-filter>
+      <meta-data
+          android:name="android.appwidget.provider"
+          android:resource="@xml/widget_namaz_genis_bilgisi" />
+    </receiver>
+
+    <!-- Widget dakikalık güncelleme + önyükleme alıcısı -->
+    <receiver
+        android:name=".widget.NamazWidgetAlarmAlici"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
+        <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+      </intent-filter>
+    </receiver>
   </application>
 </manifest>

--- a/android/app/src/main/java/com/furkanisikay/namazakisi/MainApplication.kt
+++ b/android/app/src/main/java/com/furkanisikay/namazakisi/MainApplication.kt
@@ -27,6 +27,7 @@ class MainApplication : Application(), ReactApplication {
               // Packages that cannot be autolinked yet can be added manually here, for example:
               // add(MyReactNativePackage())
               add(PlayStoreGuncellemePackage())
+              add(WidgetVeriPackage())
             }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"

--- a/android/app/src/main/java/com/furkanisikay/namazakisi/WidgetVeriModulu.kt
+++ b/android/app/src/main/java/com/furkanisikay/namazakisi/WidgetVeriModulu.kt
@@ -1,0 +1,70 @@
+package com.furkanisikay.namazakisi
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.furkanisikay.namazakisi.widget.NamazGenisBoyutWidget
+import com.furkanisikay.namazakisi.widget.NamazWidget
+
+/**
+ * Widget veri köprüsü — RN tarafından hesaplanan namaz vakitlerini
+ * SharedPreferences'a yazar ve tüm widget örneklerini güncellemeye zorlar.
+ */
+class WidgetVeriModulu(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    companion object {
+        private const val TAG = "WidgetVeriModulu"
+        const val MODULE_NAME = "WidgetVeri"
+        const val PREFS_NAME = "namazakisi_widget"
+        const val KEY_DATA = "widget_data"
+    }
+
+    override fun getName(): String = MODULE_NAME
+
+    /**
+     * Namaz vakitlerini (JSON string) SharedPreferences'a kaydeder
+     * ve mevcut tüm widget örneklerini (küçük + büyük) günceller.
+     */
+    @ReactMethod
+    fun vakitlerKaydet(dataJson: String) {
+        try {
+            val context = reactApplicationContext
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_DATA, dataJson)
+                .apply()
+
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+
+            // Küçük widget (1x1)
+            val kucukIds = appWidgetManager.getAppWidgetIds(
+                ComponentName(context, NamazWidget::class.java)
+            )
+            if (kucukIds.isNotEmpty()) {
+                context.sendBroadcast(Intent(context, NamazWidget::class.java).apply {
+                    action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                    putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, kucukIds)
+                })
+            }
+
+            // Büyük widget (4x2)
+            val buyukIds = appWidgetManager.getAppWidgetIds(
+                ComponentName(context, NamazGenisBoyutWidget::class.java)
+            )
+            if (buyukIds.isNotEmpty()) {
+                context.sendBroadcast(Intent(context, NamazGenisBoyutWidget::class.java).apply {
+                    action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                    putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, buyukIds)
+                })
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Vakit verisi kaydedilemedi veya widget güncellenemedi", e)
+        }
+    }
+}

--- a/android/app/src/main/java/com/furkanisikay/namazakisi/WidgetVeriPackage.kt
+++ b/android/app/src/main/java/com/furkanisikay/namazakisi/WidgetVeriPackage.kt
@@ -1,0 +1,16 @@
+package com.furkanisikay.namazakisi
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class WidgetVeriPackage : ReactPackage {
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext
+    ): List<NativeModule> = listOf(WidgetVeriModulu(reactContext))
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext
+    ): List<ViewManager<*, *>> = emptyList()
+}

--- a/android/app/src/main/java/com/furkanisikay/namazakisi/widget/NamazGenisBoyutWidget.kt
+++ b/android/app/src/main/java/com/furkanisikay/namazakisi/widget/NamazGenisBoyutWidget.kt
@@ -1,0 +1,234 @@
+package com.furkanisikay.namazakisi.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.graphics.Color
+import android.util.Log
+import android.widget.RemoteViews
+import com.furkanisikay.namazakisi.R
+import com.furkanisikay.namazakisi.WidgetVeriModulu
+import org.json.JSONObject
+import java.util.Calendar
+
+/**
+ * 4x2 Geniş Namaz Widget'ı.
+ *
+ * Sol bölüm: Bir sonraki namaz vaktine geri sayım (vakit adı + HH:MM).
+ * Sağ bölüm: Tüm günlük vakitler listesi; içinde bulunulan vakit vurgulanır.
+ *
+ * Güncelleme: NamazWidget ile aynı 1 dakikalık AlarmManager döngüsünü paylaşır.
+ */
+class NamazGenisBoyutWidget : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            try {
+                guncelleWidget(context, appWidgetManager, appWidgetId)
+            } catch (e: Throwable) {
+                Log.e(TAG, "Widget güncellenemedi: id=$appWidgetId", e)
+            }
+        }
+    }
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        // Küçük widget yoksa bile alarm döngüsünü başlat
+        NamazWidget.sonrakiGuncellemeIcinAlarmAyarla(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        // Alarmı yalnızca küçük widget da kaldırılmışsa iptal et
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val smallIds = appWidgetManager.getAppWidgetIds(
+            ComponentName(context, NamazWidget::class.java)
+        )
+        if (smallIds.isEmpty()) {
+            NamazWidget.alarmIptalEt(context)
+        }
+    }
+
+    companion object {
+
+        private const val TAG = "NamazGenisBoyutWidget"
+
+        private val VAKIT_GORUNTU = mapOf(
+            "sabah" to "İmsak",
+            "gunes" to "Güneş",
+            "ogle" to "Öğle",
+            "ikindi" to "İkindi",
+            "aksam" to "Akşam",
+            "yatsi" to "Yatsı"
+        )
+
+        private val VAKIT_DATIF = mapOf(
+            "sabah" to "Sabaha",
+            "gunes" to "Güneşe",
+            "ogle" to "Öğleye",
+            "ikindi" to "İkindiye",
+            "aksam" to "Akşama",
+            "yatsi" to "Yatsıya"
+        )
+
+        private val SIRA = listOf("sabah", "gunes", "ogle", "ikindi", "aksam", "yatsi")
+
+        private val ROW_IDS = mapOf(
+            "sabah" to R.id.row_sabah,
+            "gunes" to R.id.row_gunes,
+            "ogle" to R.id.row_ogle,
+            "ikindi" to R.id.row_ikindi,
+            "aksam" to R.id.row_aksam,
+            "yatsi" to R.id.row_yatsi
+        )
+
+        private val AD_IDS = mapOf(
+            "sabah" to R.id.txt_sabah_ad,
+            "gunes" to R.id.txt_gunes_ad,
+            "ogle" to R.id.txt_ogle_ad,
+            "ikindi" to R.id.txt_ikindi_ad,
+            "aksam" to R.id.txt_aksam_ad,
+            "yatsi" to R.id.txt_yatsi_ad
+        )
+
+        private val SAAT_IDS = mapOf(
+            "sabah" to R.id.txt_sabah_saat,
+            "gunes" to R.id.txt_gunes_saat,
+            "ogle" to R.id.txt_ogle_saat,
+            "ikindi" to R.id.txt_ikindi_saat,
+            "aksam" to R.id.txt_aksam_saat,
+            "yatsi" to R.id.txt_yatsi_saat
+        )
+
+        fun guncelleWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val views = RemoteViews(context.packageName, R.layout.widget_namaz_genis)
+
+            // Tıklamada uygulamayı aç
+            val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            if (launchIntent != null) {
+                val pendingIntent = PendingIntent.getActivity(
+                    context, 0, launchIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                views.setOnClickPendingIntent(R.id.widget_genis_container, pendingIntent)
+            }
+
+            geriSayimVeListeyiGuncelle(context, views)
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        private fun geriSayimVeListeyiGuncelle(context: Context, views: RemoteViews) {
+            try {
+                val prefs = context.getSharedPreferences(
+                    WidgetVeriModulu.PREFS_NAME, Context.MODE_PRIVATE
+                )
+                val dataJson = prefs.getString(WidgetVeriModulu.KEY_DATA, null)
+                if (dataJson == null) {
+                    views.setTextViewText(R.id.widget_genis_vakit_adi, "--")
+                    views.setTextViewText(R.id.widget_genis_kalan_sure, "--:--")
+                    return
+                }
+
+                val data = JSONObject(dataJson)
+                val vakitlerArray = data.getJSONArray("vakitler")
+                val now = System.currentTimeMillis()
+
+                // Bugünün takvim günü
+                val bugun = Calendar.getInstance()
+
+                // Bugüne ait vakitleri topla (aynı takvim günü)
+                val bugunVakitleri = mutableMapOf<String, Long>()
+                for (i in 0 until vakitlerArray.length()) {
+                    val v = vakitlerArray.getJSONObject(i)
+                    val vakit = v.getString("vakit")
+                    if (bugunVakitleri.containsKey(vakit)) continue
+                    val ms = v.getLong("ms")
+                    val cal = Calendar.getInstance().apply { timeInMillis = ms }
+                    if (cal.get(Calendar.YEAR) == bugun.get(Calendar.YEAR) &&
+                        cal.get(Calendar.DAY_OF_YEAR) == bugun.get(Calendar.DAY_OF_YEAR)
+                    ) {
+                        bugunVakitleri[vakit] = ms
+                    }
+                }
+
+                // Mevcut vakit (en son geçmiş olan) ve sonraki vakti bul
+                var mevcutVakit: String? = null
+                var sonrakiVakit: String? = null
+                var sonrakiMs = 0L
+
+                for (i in 0 until vakitlerArray.length()) {
+                    val v = vakitlerArray.getJSONObject(i)
+                    val ms = v.getLong("ms")
+                    if (ms > now) {
+                        sonrakiVakit = v.getString("vakit")
+                        sonrakiMs = ms
+                        break
+                    }
+                    mevcutVakit = v.getString("vakit")
+                }
+
+                // Geri sayım bölümünü güncelle
+                if (sonrakiVakit != null) {
+                    val dativ = VAKIT_DATIF[sonrakiVakit] ?: sonrakiVakit
+                    val kalanMs = sonrakiMs - now
+                    val saatler = (kalanMs / (1000L * 60 * 60)).toInt()
+                    val dakikalar = ((kalanMs % (1000L * 60 * 60)) / (1000L * 60)).toInt()
+                    views.setTextViewText(R.id.widget_genis_vakit_adi, dativ)
+                    views.setTextViewText(
+                        R.id.widget_genis_kalan_sure,
+                        "%02d:%02d".format(saatler, dakikalar)
+                    )
+                } else {
+                    views.setTextViewText(R.id.widget_genis_vakit_adi, "--")
+                    views.setTextViewText(R.id.widget_genis_kalan_sure, "--:--")
+                }
+
+                // Vakit listesi satırlarını güncelle
+                for (vakit in SIRA) {
+                    val rowId = ROW_IDS[vakit] ?: continue
+                    val adId = AD_IDS[vakit] ?: continue
+                    val saatId = SAAT_IDS[vakit] ?: continue
+
+                    val ms = bugunVakitleri[vakit]
+                    val saatStr = if (ms != null) msToSaat(ms) else "--:--"
+                    val goruntu = VAKIT_GORUNTU[vakit] ?: vakit
+
+                    views.setTextViewText(adId, goruntu)
+                    views.setTextViewText(saatId, saatStr)
+
+                    // Aktif vakti vurgula
+                    if (vakit == mevcutVakit) {
+                        views.setInt(rowId, "setBackgroundColor", Color.parseColor("#BB000000"))
+                        views.setTextColor(adId, Color.WHITE)
+                        views.setTextColor(saatId, Color.WHITE)
+                    } else {
+                        views.setInt(rowId, "setBackgroundColor", Color.TRANSPARENT)
+                        views.setTextColor(adId, Color.parseColor("#CCFFFFFF"))
+                        views.setTextColor(saatId, Color.parseColor("#CCFFFFFF"))
+                    }
+                }
+
+            } catch (e: Throwable) {
+                Log.e(TAG, "Vakit listesi güncellenemedi", e)
+            }
+        }
+
+        private fun msToSaat(ms: Long): String {
+            val cal = Calendar.getInstance().apply { timeInMillis = ms }
+            return "%02d:%02d".format(
+                cal.get(Calendar.HOUR_OF_DAY),
+                cal.get(Calendar.MINUTE)
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/furkanisikay/namazakisi/widget/NamazWidget.kt
+++ b/android/app/src/main/java/com/furkanisikay/namazakisi/widget/NamazWidget.kt
@@ -1,0 +1,176 @@
+package com.furkanisikay.namazakisi.widget
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import android.widget.RemoteViews
+import com.furkanisikay.namazakisi.R
+import com.furkanisikay.namazakisi.WidgetVeriModulu
+import org.json.JSONObject
+import java.util.Calendar
+
+/**
+ * 1x1 Namaz Widget'ı — bir sonraki namaz vaktine kalan süreyi gösterir.
+ *
+ * Veri akışı: RN (adhan.js) → WidgetVeriModulu → SharedPreferences → NamazWidget
+ * Güncelleme: 1 dakikada bir AlarmManager (NamazWidgetAlarmAlici üzerinden)
+ */
+class NamazWidget : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            guncelleWidget(context, appWidgetManager, appWidgetId)
+        }
+        sonrakiGuncellemeIcinAlarmAyarla(context)
+    }
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        sonrakiGuncellemeIcinAlarmAyarla(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        // Büyük widget da kaldırılmışsa alarmı iptal et
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val buyukIds = appWidgetManager.getAppWidgetIds(
+            ComponentName(context, NamazGenisBoyutWidget::class.java)
+        )
+        if (buyukIds.isEmpty()) {
+            alarmIptalEt(context)
+        }
+    }
+
+    companion object {
+
+        private const val TAG = "NamazWidget"
+
+        private val VAKIT_DATIFLERI = mapOf(
+            "sabah" to "sabaha",
+            "gunes" to "güneşe",
+            "ogle" to "öğleye",
+            "ikindi" to "ikindiye",
+            "aksam" to "akşama",
+            "yatsi" to "yatsıya"
+        )
+
+        fun guncelleWidget(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetId: Int
+        ) {
+            val views = RemoteViews(context.packageName, R.layout.widget_namaz)
+
+            // Tıklamada uygulamayı aç
+            val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            if (launchIntent != null) {
+                val pendingIntent = PendingIntent.getActivity(
+                    context, 0, launchIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                views.setOnClickPendingIntent(R.id.widget_container, pendingIntent)
+            }
+
+            val (vakitSatiri, sureSatiri) = sonrakiVaktiHesapla(context)
+            views.setTextViewText(R.id.widget_vakit_adi, vakitSatiri)
+            views.setTextViewText(R.id.widget_kalan_sure, sureSatiri)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        /**
+         * SharedPreferences'taki JSON verisinden bir sonraki namaz vaktini bulur
+         * ve (dativ, "HH:MM") ikilisi döner.
+         */
+        private fun sonrakiVaktiHesapla(context: Context): Pair<String, String> {
+            return try {
+                val prefs = context.getSharedPreferences(
+                    WidgetVeriModulu.PREFS_NAME,
+                    Context.MODE_PRIVATE
+                )
+                val dataJson = prefs.getString(WidgetVeriModulu.KEY_DATA, null)
+                    ?: return Pair("uygulama açın", "--:--")
+
+                val data = JSONObject(dataJson)
+                val vakitler = data.getJSONArray("vakitler")
+                val now = System.currentTimeMillis()
+
+                for (i in 0 until vakitler.length()) {
+                    val vakit = vakitler.getJSONObject(i)
+                    val ms = vakit.getLong("ms")
+                    if (ms > now) {
+                        val vakitKodu = vakit.getString("vakit")
+                        val dativ = VAKIT_DATIFLERI[vakitKodu] ?: vakitKodu
+                        val kalanMs = ms - now
+                        val saatler = (kalanMs / (1000L * 60 * 60)).toInt()
+                        val dakikalar = ((kalanMs % (1000L * 60 * 60)) / (1000L * 60)).toInt()
+                        return Pair("$dativ:", "%02d:%02d".format(saatler, dakikalar))
+                    }
+                }
+
+                Pair("--", "--:--")
+            } catch (e: Throwable) {
+                Log.e(TAG, "Vakit hesaplama hatası", e)
+                Pair("--", "--:--")
+            }
+        }
+
+        /**
+         * Bir sonraki tam dakika başına AlarmManager ayarlar.
+         * Alarm tetiklenince NamazWidgetAlarmAlici widget'ları günceller.
+         */
+        fun sonrakiGuncellemeIcinAlarmAyarla(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, NamazWidgetAlarmAlici::class.java)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context, 0, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            val cal = Calendar.getInstance().apply {
+                add(Calendar.MINUTE, 1)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+
+            try {
+                when {
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && alarmManager.canScheduleExactAlarms() ->
+                        alarmManager.setExactAndAllowWhileIdle(
+                            AlarmManager.RTC, cal.timeInMillis, pendingIntent
+                        )
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ->
+                        alarmManager.setExactAndAllowWhileIdle(
+                            AlarmManager.RTC, cal.timeInMillis, pendingIntent
+                        )
+                    else ->
+                        alarmManager.setExact(AlarmManager.RTC, cal.timeInMillis, pendingIntent)
+                }
+            } catch (e: SecurityException) {
+                // Exact alarm izni yoksa (Android 12+) yaklaşık zamanlama kullan
+                Log.w(TAG, "Exact alarm izni yok, yaklaşık zamanlama kullanılıyor", e)
+                alarmManager.set(AlarmManager.RTC, cal.timeInMillis, pendingIntent)
+            }
+        }
+
+        fun alarmIptalEt(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, NamazWidgetAlarmAlici::class.java)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context, 0, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            alarmManager.cancel(pendingIntent)
+        }
+    }
+}

--- a/android/app/src/main/java/com/furkanisikay/namazakisi/widget/NamazWidgetAlarmAlici.kt
+++ b/android/app/src/main/java/com/furkanisikay/namazakisi/widget/NamazWidgetAlarmAlici.kt
@@ -1,0 +1,53 @@
+package com.furkanisikay.namazakisi.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * AlarmManager ve önyükleme olaylarını dinler.
+ * Her dakika tetiklenerek tüm widget tiplerini günceller ve bir sonraki alarmı kurar.
+ * Cihaz yeniden başladığında (kilitli veya açık) alarmı yeniden başlatır.
+ */
+class NamazWidgetAlarmAlici : BroadcastReceiver() {
+
+    companion object {
+        private const val TAG = "NamazWidgetAlarmAlici"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+
+        // Sadece beklenen aksiyonları işle: önyükleme olayları veya (aksiyon olmayan) AlarmManager tetikleyicisi
+        val isBootAction = action == Intent.ACTION_BOOT_COMPLETED ||
+                action == "android.intent.action.LOCKED_BOOT_COMPLETED"
+        val isAlarmTick = action == null
+
+        if (!isBootAction && !isAlarmTick) return
+
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val kucukIds = appWidgetManager.getAppWidgetIds(ComponentName(context, NamazWidget::class.java))
+        val buyukIds = appWidgetManager.getAppWidgetIds(ComponentName(context, NamazGenisBoyutWidget::class.java))
+
+        // Hiç widget yoksa alarmı yeniden kurma
+        if (kucukIds.isEmpty() && buyukIds.isEmpty()) return
+
+        if (isBootAction) {
+            // Cihaz yeniden başladı, alarmı yeniden kur
+            NamazWidget.sonrakiGuncellemeIcinAlarmAyarla(context)
+            return
+        }
+
+        // Dakikalık alarm: her iki widget tipini de güncelle
+        try {
+            for (id in kucukIds) NamazWidget.guncelleWidget(context, appWidgetManager, id)
+            for (id in buyukIds) NamazGenisBoyutWidget.guncelleWidget(context, appWidgetManager, id)
+        } catch (e: Throwable) {
+            Log.e(TAG, "Widget güncellemesi sırasında hata oluştu", e)
+        }
+        NamazWidget.sonrakiGuncellemeIcinAlarmAyarla(context)
+    }
+}

--- a/android/app/src/main/res/drawable/widget_namaz_arkaplan.xml
+++ b/android/app/src/main/res/drawable/widget_namaz_arkaplan.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E0215732" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/layout/widget_namaz.xml
+++ b/android/app/src/main/res/layout/widget_namaz.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:background="@drawable/widget_namaz_arkaplan"
+    android:padding="4dp">
+
+    <TextView
+        android:id="@+id/widget_vakit_adi"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="öğleye:"
+        android:textColor="#FFFFFF"
+        android:textSize="10sp"
+        android:maxLines="1"
+        android:fontFamily="sans-serif" />
+
+    <TextView
+        android:id="@+id/widget_kalan_sure"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="02:45"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:maxLines="1"
+        android:fontFamily="sans-serif-medium" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/widget_namaz_genis.xml
+++ b/android/app/src/main/res/layout/widget_namaz_genis.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_genis_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:background="@drawable/widget_namaz_arkaplan"
+    android:baselineAligned="false"
+    android:padding="8dp">
+
+    <!-- Sol: geri sayım -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="2"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:baselineAligned="false">
+
+        <TextView
+            android:id="@+id/widget_genis_vakit_adi"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Akşama"
+            android:textColor="#FFFFFF"
+            android:textSize="17sp"
+            android:maxLines="1" />
+
+        <TextView
+            android:id="@+id/widget_genis_kalan_sure"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="02:33"
+            android:textColor="#FFD700"
+            android:textSize="32sp"
+            android:textStyle="bold"
+            android:maxLines="1" />
+
+    </LinearLayout>
+
+    <!-- Sağ: vakit listesi -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="3"
+        android:orientation="vertical"
+        android:paddingStart="8dp"
+        android:baselineAligned="false">
+
+        <LinearLayout
+            android:id="@+id/row_sabah"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+            <TextView
+                android:id="@+id/txt_sabah_ad"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical"
+                android:text="İmsak"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+            <TextView
+                android:id="@+id/txt_sabah_saat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="05:04"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/row_gunes"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+            <TextView
+                android:id="@+id/txt_gunes_ad"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical"
+                android:text="Güneş"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+            <TextView
+                android:id="@+id/txt_gunes_saat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="06:27"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/row_ogle"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+            <TextView
+                android:id="@+id/txt_ogle_ad"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical"
+                android:text="Öğle"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+            <TextView
+                android:id="@+id/txt_ogle_saat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="12:59"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/row_ikindi"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+            <TextView
+                android:id="@+id/txt_ikindi_ad"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical"
+                android:text="İkindi"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+            <TextView
+                android:id="@+id/txt_ikindi_saat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="16:32"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/row_aksam"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+            <TextView
+                android:id="@+id/txt_aksam_ad"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical"
+                android:text="Akşam"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+            <TextView
+                android:id="@+id/txt_aksam_saat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="19:21"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/row_yatsi"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:paddingStart="4dp"
+            android:paddingEnd="4dp">
+            <TextView
+                android:id="@+id/txt_yatsi_ad"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_gravity="center_vertical"
+                android:text="Yatsı"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+            <TextView
+                android:id="@+id/txt_yatsi_saat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="20:38"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp"
+                android:maxLines="1" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
   <string name="app_name">Namaz Akışı</string>
+  <string name="widget_aciklama">Sonraki namaz vaktine kalan süreyi gösterir</string>
+  <string name="widget_genis_aciklama">Tüm namaz vakitlerini ve geri sayımı gösterir</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/android/app/src/main/res/xml/widget_namaz_bilgisi.xml
+++ b/android/app/src/main/res/xml/widget_namaz_bilgisi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="72dp"
+    android:minHeight="72dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_namaz"
+    android:resizeMode="none"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_aciklama" />

--- a/android/app/src/main/res/xml/widget_namaz_genis_bilgisi.xml
+++ b/android/app/src/main/res/xml/widget_namaz_genis_bilgisi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_namaz_genis"
+    android:resizeMode="horizontal"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_genis_aciklama" />

--- a/src/domain/services/WidgetServisi.ts
+++ b/src/domain/services/WidgetServisi.ts
@@ -1,0 +1,78 @@
+/**
+ * Widget Servisi — Hesaplanan namaz vakitlerini Android home screen widget'ı için
+ * native SharedPreferences'a yazar.
+ *
+ * Veri akışı: adhan.js → WidgetServisi → WidgetVeriModulu.kt → SharedPreferences → NamazWidget.kt
+ */
+
+import { NativeModules, Platform } from 'react-native';
+import { Coordinates, CalculationMethod, PrayerTimes } from 'adhan';
+import { Logger } from '../../core/utils/Logger';
+
+interface WidgetVakitVeri {
+  vakit: 'sabah' | 'gunes' | 'ogle' | 'ikindi' | 'aksam' | 'yatsi';
+  ms: number;
+}
+
+interface WidgetVerisi {
+  tarih: string; // YYYY-MM-DD
+  vakitler: WidgetVakitVeri[]; // Kronolojik sırada, 3 günlük veri
+}
+
+const { WidgetVeri } = NativeModules;
+
+export class WidgetServisi {
+  private static instance: WidgetServisi;
+
+  public static getInstance(): WidgetServisi {
+    if (!WidgetServisi.instance) {
+      WidgetServisi.instance = new WidgetServisi();
+    }
+    return WidgetServisi.instance;
+  }
+
+  /**
+   * Verilen koordinatlar için bugün, yarın ve 2 gün sonrasının namaz vakitlerini
+   * hesaplayıp widget SharedPreferences'ına yazar.
+   *
+   * Android dışında no-op.
+   */
+  public async vakitleriyaz(koordinatlar: { lat: number; lng: number }): Promise<void> {
+    if (Platform.OS !== 'android' || !WidgetVeri) {
+      return;
+    }
+
+    try {
+      const coordinates = new Coordinates(koordinatlar.lat, koordinatlar.lng);
+      const params = CalculationMethod.Turkey();
+
+      const vakitler: WidgetVakitVeri[] = [];
+
+      for (let gunOffset = 0; gunOffset < 3; gunOffset++) {
+        const tarih = new Date();
+        tarih.setDate(tarih.getDate() + gunOffset);
+
+        const prayerTimes = new PrayerTimes(coordinates, tarih, params);
+
+        vakitler.push({ vakit: 'sabah', ms: prayerTimes.fajr.getTime() });
+        vakitler.push({ vakit: 'gunes', ms: prayerTimes.sunrise.getTime() });
+        vakitler.push({ vakit: 'ogle', ms: prayerTimes.dhuhr.getTime() });
+        vakitler.push({ vakit: 'ikindi', ms: prayerTimes.asr.getTime() });
+        vakitler.push({ vakit: 'aksam', ms: prayerTimes.maghrib.getTime() });
+        vakitler.push({ vakit: 'yatsi', ms: prayerTimes.isha.getTime() });
+      }
+
+      // Kronolojik sırala (adhan zaten sıralı üretir ama güvenlik için)
+      vakitler.sort((a, b) => a.ms - b.ms);
+
+      const bugun = new Date();
+      const tarihStr = `${bugun.getFullYear()}-${String(bugun.getMonth() + 1).padStart(2, '0')}-${String(bugun.getDate()).padStart(2, '0')}`;
+
+      const verisi: WidgetVerisi = { tarih: tarihStr, vakitler };
+
+      WidgetVeri.vakitlerKaydet(JSON.stringify(verisi));
+    } catch (e) {
+      Logger.error('WidgetServisi', 'Widget verisi kaydedilemedi', e);
+    }
+  }
+}


### PR DESCRIPTION
## Özet

- **1x1 NamazWidget:** Sonraki namaz vaktine kalan süreyi `akşama: 01:23` formatında gösterir. 1 dakikada bir AlarmManager ile güncellenir, uygulama kapalıyken de çalışır.
- **4x2 NamazGenisBoyutWidget:** Sol tarafta dativ isim + sarı geri sayım, sağ tarafta tüm 6 vakit listesi; aktif vakit koyu arka planla vurgulanır.
- **WidgetVeriModulu (Kotlin):** React Native → SharedPreferences köprüsü. RN hesapladığı 3 günlük vakitleri JSON olarak yazar, her iki widget'a broadcast gönderir.
- **WidgetServisi (TypeScript):** `adhan.js` + `CalculationMethod.Turkey()` ile 3 günlük vakitleri hesaplar, `NativeModules.WidgetVeri.vakitleriyaz()` üzerinden native tarafa aktarır.
- **NamazWidgetAlarmAlici:** Dakikalık alarm tick'i ve `BOOT_COMPLETED` / `LOCKED_BOOT_COMPLETED` olaylarını dinler.
- Tüm widget sınıflarında `android.util.Log` ile hata loglama (sessiz catch kaldırıldı).

## Test planı

- [ ] Widget menüsünde 1x1 "Namaz Widget" ve 4x2 "Geniş Namaz Widget" göründüğünü doğrula
- [ ] 1x1 widget'ta doğru vakit adı (dativ) ve HH:MM geri sayımın göründüğünü kontrol et
- [ ] 4x2 widget'ta tüm 6 vaktin listelendiğini ve aktif vaktin vurgulandığını kontrol et
- [ ] Uygulama tamamen kapatıldıktan sonra widget'ların 1 dakika içinde güncellendiğini doğrula
- [ ] Cihazı yeniden başlatıp widget'ların doğru verilerle yüklendiğini doğrula
- [ ] `adb logcat -s NamazGenisBoyutWidget NamazWidget NamazWidgetAlarmAlici WidgetVeriModulu` ile hata loglarını izle

🤖 Generated with [Claude Code](https://claude.com/claude-code)