### PR TITLE
feat: takvim entegrasyonu + yeni özellik duyuru sistemi + internal yayın (#75)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -488,10 +488,9 @@ jobs:
               workflow_id: 'expo-build.yml',
               ref: 'master',
               inputs: {
-                platform: 'android',
-                profile: 'production',
-                publish: 'true',
-                submit_profile: 'internal',
+                build_aab: 'true',
+                build_apk: 'false',
+                internal_a_gonder: 'true',
               },
             });
             console.log('✅ EAS Build kuyruğa alındı → internal track');

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -473,6 +473,29 @@ jobs:
           git push origin HEAD:${{ github.ref_name }}
           git push origin ${{ steps.version.outputs.version_tag }}
 
+      - name: 📦 EAS Build Tetikle — Internal Testing
+        if: inputs.build_type == 'release' && success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ steps.version.outputs.version }}';
+            const versionCode = require('./app.json').expo.android.versionCode;
+            console.log(`🚀 EAS Build tetikleniyor: v${version} (versionCode: ${versionCode})`);
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'expo-build.yml',
+              ref: 'master',
+              inputs: {
+                platform: 'android',
+                profile: 'production',
+                publish: 'true',
+                submit_profile: 'internal',
+              },
+            });
+            console.log('✅ EAS Build kuyruğa alındı → internal track');
+
       - name: 🚀 GitHub Release (Release)
         if: inputs.build_type == 'release' && success()
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -192,7 +192,6 @@ jobs:
             --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EXPO_GOOGLE_SERVICES_KEY: /tmp/google-service-account.json
 
       - name: ⚠️ Submit atlandı — Secret eksik
         if: |

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -1,79 +1,61 @@
 # ========================================================================
-# Expo Build Pipeline (PlayStore) — Namaz Akisi
+# EAS Build & Internal Testing — Namaz Akisi
 # ========================================================================
 #
 # Tetikleyiciler:
-#   - Manuel (workflow_dispatch): UI uzerinden herhangi bir profil ile
-#   - Otomatik (workflow_call): android-build.yml'in release adiminin
-#     ardından çağrılır — version bump commit'inden sonra tetiklenir,
-#     EAS o anki master'ı klonladığı için doğru versionCode'u alır.
+#   - Manuel (workflow_dispatch): Geliştirme sırasında test build almak için
+#   - Otomatik (workflow_call): android-build.yml'den master merge sonrası
 #
-# Otomatik akis:
-#   master push → CI gecer → android-build (versioning+APK+tag)
-#              → expo-build (production AAB → internal track)
-#              → Play Console internal testing → manuel promote → production
+# Varsayılan mod (manuel):
+#   AAB oluştur → internal track'e gönder (APK opsiyonel, GitHub Release yok)
 #
-# Gereksinimler:
-#   GitHub Secrets:
-#     EXPO_TOKEN               — Expo hesap tokeni
-#     GOOGLE_SERVICE_ACCOUNT   — Google Service Account JSON (tam icerik)
+# Master merge sonrası otomatik mod:
+#   android-build.yml APK + GitHub Release'i halleder
+#   Bu workflow sadece AAB → internal track yapar
+#
+# versionCode: EAS remote ile yönetilir (app.json'a dokunmaz)
+#   → Test buildleri git commit oluşturmaz
+#   → Her EAS build otomatik olarak bir sonraki versionCode'u alır
+#
+# Gereksinimler (GitHub Secrets):
+#   EXPO_TOKEN             — expo.dev hesap tokeni
+#   GOOGLE_SERVICE_ACCOUNT — Google Play service account JSON içeriği
 #
 # ========================================================================
 
-name: Expo Build (PlayStore)
+name: 📱 EAS Build & Internal Testing
 
 on:
   workflow_dispatch:
     inputs:
-      platform:
-        description: 'Platform'
-        required: true
-        default: 'android'
-        type: choice
-        options:
-          - android
-          - ios
-          - all
-      profile:
-        description: 'Build profili'
-        required: true
-        default: 'production'
-        type: choice
-        options:
-          - development
-          - preview
-          - production
-      publish:
-        description: "Yayinla (Play Store'a gonder)"
+      build_aab:
+        description: 'AAB oluştur — Play Store (production profili)'
         required: false
         default: true
         type: boolean
-      submit_profile:
-        description: 'Submit profili (publish=true ise gecerli; auto = build profiline gore secilir)'
+      build_apk:
+        description: 'APK oluştur — direkt indirme (preview profili)'
         required: false
-        default: 'auto'
-        type: choice
-        options:
-          - auto
-          - internal
-          - closed-testing
-          - production
+        default: false
+        type: boolean
+      internal_a_gonder:
+        description: "Internal track'e gönder (build_aab=true gerektirir)"
+        required: false
+        default: true
+        type: boolean
 
-  # android-build.yml tarafindan otomatik cagrilir (release sonrasi)
+  # android-build.yml tarafindan master merge sonrasi otomatik cagrilir
   workflow_call:
     inputs:
-      platform:
-        type: string
-        default: 'android'
-      profile:
-        type: string
-        default: 'production'
-      publish:
+      build_aab:
         type: boolean
         default: true
-      submit_profile:
-        type: string
-        default: 'internal'
+      build_apk:
+        type: boolean
+        default: false
+      internal_a_gonder:
+        type: boolean
+        default: true
     secrets:
       EXPO_TOKEN:
         required: true
@@ -81,7 +63,7 @@ on:
         required: false
 
 concurrency:
-  group: expo-build-${{ inputs.platform }}-${{ inputs.profile }}
+  group: eas-build-${{ github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -89,7 +71,7 @@ env:
 
 jobs:
   build:
-    name: 🚀 EAS Build (${{ inputs.platform }} / ${{ inputs.profile }})
+    name: 🚀 EAS Build (${{ inputs.build_aab && 'AAB' || '' }}${{ inputs.build_aab && inputs.build_apk && '+' || '' }}${{ inputs.build_apk && 'APK' || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -101,43 +83,12 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v4
 
-      # ==========================================
-      # Versiyon Dogrulama
-      # ==========================================
-      - name: 🔒 appVersionSource kontrolu
-        run: |
-          APP_VERSION_SOURCE=$(node -p "require('./eas.json').cli?.appVersionSource || 'not-set'")
-
-          if [ "$APP_VERSION_SOURCE" != "local" ]; then
-            echo "⚠️ appVersionSource '$APP_VERSION_SOURCE' → 'local' olarak duzeltiliyor..."
-            node -e "
-              const fs = require('fs');
-              const eas = JSON.parse(fs.readFileSync('./eas.json', 'utf8'));
-              if (!eas.cli) eas.cli = {};
-              eas.cli.appVersionSource = 'local';
-              fs.writeFileSync('./eas.json', JSON.stringify(eas, null, 2) + '\n');
-              console.log('✅ appVersionSource: local');
-            "
-          else
-            echo "✅ appVersionSource: local"
-          fi
-
       - name: 🔢 Versiyon bilgisi
         id: version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          APP_VERSION=$(node -p "require('./app.json').expo.version")
-          VERSION_CODE=$(node -p "require('./app.json').expo.android?.versionCode || 'yok'")
-
+          VERSION=$(node -p "require('./app.json').expo.version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT
-          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
-
-          echo "📦 package.json: $VERSION | app.json: $APP_VERSION | versionCode: $VERSION_CODE"
-
-          if [ "$VERSION" != "$APP_VERSION" ]; then
-            echo "⚠️ UYARI: package.json ($VERSION) ≠ app.json ($APP_VERSION)"
-          fi
+          echo "📦 v$VERSION | versionCode: EAS remote yönetiminde"
 
       # ==========================================
       # Ortam Hazırlığı
@@ -147,12 +98,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-
-      - name: 🚀 Setup Expo & EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 💾 Cache node_modules
         id: cache-modules
@@ -166,207 +111,134 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: npm ci
 
+      - name: 🚀 Setup Expo & EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
       - name: 🔍 EXPO_TOKEN kontrolu
         run: |
           if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "❌ EXPO_TOKEN bulunamadi!"
-            echo "💡 GitHub Secrets > EXPO_TOKEN ekleyin."
+            echo "❌ EXPO_TOKEN bulunamadı!"
             exit 1
           fi
           echo "✅ EXPO_TOKEN mevcut"
 
       # ==========================================
-      # EAS Build
+      # AAB Build (production — Play Store)
       # ==========================================
-      - name: 🤖 Android Build
-        if: inputs.platform == 'android' || inputs.platform == 'all'
-        id: android_build
+      - name: 🤖 AAB Build (production profili)
+        if: inputs.build_aab == true
+        id: aab_build
         run: |
-          # publish=true ise build bitene kadar beklemek zorundayiz
-          if [ "${{ inputs.publish }}" == "true" ]; then
-            echo "📦 Yayinlama aktif — build tamamlanana kadar bekleniyor..."
-            WAIT_FLAG=""
-          else
-            WAIT_FLAG="--no-wait"
-          fi
-
+          echo "📦 AAB build başlatılıyor (production)..."
+          echo "ℹ️  versionCode EAS tarafından otomatik artırılacak"
           eas build \
             --platform android \
-            --profile ${{ inputs.profile }} \
-            --non-interactive \
-            $WAIT_FLAG
+            --profile production \
+            --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
-      - name: 🍎 iOS Build
-        if: inputs.platform == 'ios' || inputs.platform == 'all'
-        id: ios_build
-        continue-on-error: true
+      # ==========================================
+      # APK Build (preview — direkt indirme)
+      # ==========================================
+      - name: 📱 APK Build (preview profili)
+        if: inputs.build_apk == true
+        id: apk_build
         run: |
+          echo "📦 APK build başlatılıyor (preview)..."
           eas build \
-            --platform ios \
-            --profile ${{ inputs.profile }} \
-            --non-interactive \
-            --no-wait
+            --platform android \
+            --profile preview \
+            --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
       # ==========================================
-      # Play Store Submit (publish=true ise)
+      # Play Store Internal Track Submit
       # ==========================================
-      - name: 📋 Release notes hazirla
-        if: |
-          inputs.publish == true &&
-          (inputs.platform == 'android' || inputs.platform == 'all') &&
-          steps.android_build.outcome == 'success'
-        id: release_notes
-        run: |
-          echo "Release notes CHANGELOG'dan cikartiliyor..."
-          NOTES=$(node scripts/extract-changelog.js)
-          echo "--- Release Notes ---"
-          echo "$NOTES"
-          echo "---------------------"
-
-          # EAS Submit, fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt dosyasini okur
-          VERSION_CODE=$(node -p "require('./app.json').expo.android.versionCode")
-          for LOCALE in "tr-TR" "en-US"; do
-            mkdir -p "fastlane/metadata/android/$LOCALE/changelogs"
-            echo "$NOTES" > "fastlane/metadata/android/$LOCALE/changelogs/${VERSION_CODE}.txt"
-          done
-
-          echo "✅ Release notes fastlane/metadata klasorune yazildi (versionCode: $VERSION_CODE)"
-
-      - name: 🎯 Submit profili belirle
-        if: |
-          inputs.publish == true &&
-          (inputs.platform == 'android' || inputs.platform == 'all') &&
-          steps.android_build.outcome == 'success'
-        id: resolve_submit
-        run: |
-          if [ "${{ inputs.submit_profile }}" == "auto" ]; then
-            case "${{ inputs.profile }}" in
-              preview)     PROFILE="internal" ;;
-              development) PROFILE="internal" ;;
-              production)  PROFILE="production" ;;
-              *)           PROFILE="internal" ;;
-            esac
-            echo "🎯 auto → $PROFILE (build profili: ${{ inputs.profile }})"
-          else
-            PROFILE="${{ inputs.submit_profile }}"
-            echo "🎯 Manuel profil: $PROFILE"
-          fi
-          echo "profile=$PROFILE" >> $GITHUB_OUTPUT
-
-      - name: 🔑 Google Service Account hazirla
-        if: |
-          inputs.publish == true &&
-          (inputs.platform == 'android' || inputs.platform == 'all') &&
-          steps.android_build.outcome == 'success'
+      - name: 🔑 Google Service Account hazırla
+        if: inputs.build_aab == true && inputs.internal_a_gonder == true && steps.aab_build.outcome == 'success'
         id: gsa
         run: |
           if [ -z "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}" ]; then
-            echo "⚠️ GOOGLE_SERVICE_ACCOUNT secret bulunamadi!"
+            echo "⚠️ GOOGLE_SERVICE_ACCOUNT secret bulunamadı!"
             echo "💡 GitHub Secrets > GOOGLE_SERVICE_ACCOUNT ekleyin."
-            echo "   (Google Play Console > API erişimi > Service account JSON içeriği)"
             echo "available=false" >> $GITHUB_OUTPUT
           else
-            # JSON iceriğini gecici dosyaya yaz
             echo '${{ secrets.GOOGLE_SERVICE_ACCOUNT }}' > /tmp/google-service-account.json
             echo "available=true" >> $GITHUB_OUTPUT
             echo "✅ Google Service Account mevcut"
           fi
 
-      - name: 🚀 Play Store Submit
+      - name: 🚀 Internal Track'e Gönder
         if: |
-          inputs.publish == true &&
-          (inputs.platform == 'android' || inputs.platform == 'all') &&
-          steps.android_build.outcome == 'success' &&
+          inputs.build_aab == true &&
+          inputs.internal_a_gonder == true &&
+          steps.aab_build.outcome == 'success' &&
           steps.gsa.outputs.available == 'true'
         run: |
-          SUBMIT_PROFILE="${{ steps.resolve_submit.outputs.profile }}"
-          echo "Play Store'a gonderiliyor (profil: $SUBMIT_PROFILE)..."
-
+          echo "📤 Play Store internal track'e gönderiliyor..."
           eas submit \
             --platform android \
-            --profile "$SUBMIT_PROFILE" \
+            --profile internal \
             --latest \
             --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EXPO_GOOGLE_SERVICES_KEY: /tmp/google-service-account.json
 
-      - name: ⚠️ Submit atland (Service Account yok)
+      - name: ⚠️ Submit atlandı — Secret eksik
         if: |
-          inputs.publish == true &&
-          (inputs.platform == 'android' || inputs.platform == 'all') &&
-          steps.android_build.outcome == 'success' &&
+          inputs.build_aab == true &&
+          inputs.internal_a_gonder == true &&
+          steps.aab_build.outcome == 'success' &&
           steps.gsa.outputs.available == 'false'
         run: |
-          echo "⚠️ Play Store submit atlandı — GOOGLE_SERVICE_ACCOUNT secret eksik."
-          echo ""
-          echo "Kurulum için:"
-          echo "1. Google Play Console > Kurulum > API erişimi"
-          echo "2. Bir Service Account oluştur veya bağla"
-          echo "3. JSON anahtarını indir"
-          echo "4. GitHub repo > Settings > Secrets > GOOGLE_SERVICE_ACCOUNT"
-          echo "   (JSON dosyasının tam içeriğini yapıştır)"
+          echo "⚠️ Internal submit atlandı — GOOGLE_SERVICE_ACCOUNT eksik"
+          echo "Build Expo dashboard'dan indirilebilir:"
+          echo "https://expo.dev/accounts/furkanisikay/projects/namazakisi/builds"
 
       # ==========================================
-      # Build Ozeti
+      # Build Özeti
       # ==========================================
-      - name: 📊 Build Ozeti
+      - name: 📊 Build Özeti
         if: always()
         run: |
           END_TIME=$(date +%s)
-          START_TIME="${{ steps.timer.outputs.start }}"
-          DURATION=$((END_TIME - START_TIME))
+          DURATION=$(( $(date +%s) - ${{ steps.timer.outputs.start }} ))
           MINUTES=$((DURATION / 60))
           SECONDS=$((DURATION % 60))
 
+          AAB_DURUM="${{ inputs.build_aab == true && (steps.aab_build.outcome == 'success' && '✅ Başarılı' || (steps.aab_build.outcome == 'skipped' && '⏭️ Atlandı' || '❌ Başarısız')) || '⏭️ Seçilmedi' }}"
+          APK_DURUM="${{ inputs.build_apk == true && (steps.apk_build.outcome == 'success' && '✅ Başarılı' || (steps.apk_build.outcome == 'skipped' && '⏭️ Atlandı' || '❌ Başarısız')) || '⏭️ Seçilmedi' }}"
+
+          if [ "${{ steps.gsa.outputs.available }}" == "true" ]; then
+            SUBMIT_DURUM="✅ Gönderildi"
+          elif [ "${{ inputs.internal_a_gonder }}" != "true" ]; then
+            SUBMIT_DURUM="⏭️ Seçilmedi"
+          else
+            SUBMIT_DURUM="⚠️ Secret eksik"
+          fi
+
           {
-            echo "## 🚀 EAS Build Sonucu"
+            echo "## 📱 EAS Build Sonucu"
             echo ""
             echo "| Detay | Bilgi |"
             echo "|-------|-------|"
             echo "| 📦 **Versiyon** | \`${{ steps.version.outputs.version }}\` |"
-            echo "| 🔢 **versionCode** | \`${{ steps.version.outputs.version_code }}\` |"
-            echo "| 🎯 **Platform** | \`${{ inputs.platform }}\` |"
-            echo "| 📋 **Profil** | \`${{ inputs.profile }}\` |"
-            echo "| 📤 **Yayinla** | \`${{ inputs.publish }}\` |"
-            echo "| 🏪 **Submit Profili** | \`${{ steps.resolve_submit.outputs.profile || inputs.submit_profile }}\` |"
-            echo "| ⏱️ **Sure** | ${MINUTES}dk ${SECONDS}sn |"
+            echo "| 🔢 **versionCode** | EAS remote (otomatik) |"
+            echo "| 🌿 **Branch** | \`${{ github.ref_name }}\` |"
+            echo "| ⏱️ **Süre** | ${MINUTES}dk ${SECONDS}sn |"
             echo ""
-
-            echo "### Platform Sonuclari"
-            echo ""
-            echo "| Platform | Build | Submit |"
-            echo "|----------|-------|--------|"
-
-            if [ "${{ inputs.platform }}" == "android" ] || [ "${{ inputs.platform }}" == "all" ]; then
-              BUILD_STATUS="${{ steps.android_build.outcome == 'success' && '✅ Basarili' || '❌ Basarisiz' }}"
-
-              if [ "${{ inputs.publish }}" == "true" ]; then
-                RESOLVED="${{ steps.resolve_submit.outputs.profile }}"
-                SUBMIT_STATUS="${{ steps.gsa.outputs.available == 'true' && '✅ Gonderildi' || '⚠️ Secret eksik' }} ($RESOLVED)"
-              else
-                SUBMIT_STATUS="⏭️ Atlandı"
-              fi
-
-              echo "| 🤖 Android | ${BUILD_STATUS} | ${SUBMIT_STATUS} |"
-            fi
-
-            if [ "${{ inputs.platform }}" == "ios" ] || [ "${{ inputs.platform }}" == "all" ]; then
-              echo "| 🍎 iOS | ${{ steps.ios_build.outcome == 'success' && '✅ Basarili' || (steps.ios_build.outcome == 'skipped' && '⏭️ Atlandi' || '❌ Basarisiz') }} | ⏭️ Desteklenmiyor |"
-            fi
-
+            echo "| Build | Durum |"
+            echo "|-------|-------|"
+            echo "| 🤖 AAB (Play Store) | ${AAB_DURUM} |"
+            echo "| 📱 APK (direkt) | ${APK_DURUM} |"
+            echo "| 🏪 Internal Submit | ${SUBMIT_DURUM} |"
             echo ""
             echo "---"
-            echo ""
-            echo "### 🔗 Baglantilar"
-            echo "- [📱 Expo Dashboard](https://expo.dev/accounts/${{ secrets.EXPO_ACCOUNT || 'furkanisikay' }}/projects/namazakisi/builds)"
-
-            if [ "${{ inputs.publish }}" != "true" ]; then
-              echo ""
-              echo "> ⚠️ Build arka planda devam ediyor (Yayinla kapaliydi). Expo Dashboard uzerinden takip edin."
-            fi
+            echo "[📱 Expo Dashboard — Builds](https://expo.dev/accounts/furkanisikay/projects/namazakisi/builds)"
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -142,19 +142,23 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
       # ==========================================
-      # APK Build (preview — direkt indirme)
+      # APK Build — Gradle (android-build.yml)
       # ==========================================
-      - name: 📱 APK Build (preview profili)
+      - name: 📱 APK Build Tetikle (Gradle)
         if: inputs.build_apk == true
         id: apk_build
-        run: |
-          echo "📦 APK build başlatılıyor (preview)..."
-          eas build \
-            --platform android \
-            --profile preview \
-            --non-interactive
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'android-build.yml',
+              ref: context.ref,
+              inputs: { build_type: 'debug' },
+            });
+            console.log('✅ Gradle debug APK build kuyruğa alındı');
 
       # ==========================================
       # Play Store Internal Track Submit
@@ -236,7 +240,7 @@ jobs:
             echo "| Build | Durum |"
             echo "|-------|-------|"
             echo "| 🤖 AAB (Play Store) | ${AAB_DURUM} |"
-            echo "| 📱 APK (direkt) | ${APK_DURUM} |"
+            echo "| 📱 APK (Gradle) | ${APK_DURUM} |"
             echo "| 🏪 Internal Submit | ${SUBMIT_DURUM} |"
             echo ""
             echo "---"

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -44,13 +44,15 @@ on:
         default: true
         type: boolean
       submit_profile:
-        description: 'Submit profili (publish=true ise gecerli)'
+        description: 'Submit profili (publish=true ise gecerli; auto = build profiline gore secilir)'
         required: false
-        default: 'production'
+        default: 'auto'
         type: choice
         options:
-          - production
+          - auto
+          - internal
           - closed-testing
+          - production
 
 concurrency:
   group: expo-build-${{ inputs.platform }}-${{ inputs.profile }}
@@ -208,6 +210,27 @@ jobs:
 
           echo "✅ Release notes fastlane/metadata klasorune yazildi (versionCode: $VERSION_CODE)"
 
+      - name: 🎯 Submit profili belirle
+        if: |
+          inputs.publish == true &&
+          (inputs.platform == 'android' || inputs.platform == 'all') &&
+          steps.android_build.outcome == 'success'
+        id: resolve_submit
+        run: |
+          if [ "${{ inputs.submit_profile }}" == "auto" ]; then
+            case "${{ inputs.profile }}" in
+              preview)     PROFILE="internal" ;;
+              development) PROFILE="internal" ;;
+              production)  PROFILE="production" ;;
+              *)           PROFILE="internal" ;;
+            esac
+            echo "🎯 auto → $PROFILE (build profili: ${{ inputs.profile }})"
+          else
+            PROFILE="${{ inputs.submit_profile }}"
+            echo "🎯 Manuel profil: $PROFILE"
+          fi
+          echo "profile=$PROFILE" >> $GITHUB_OUTPUT
+
       - name: 🔑 Google Service Account hazirla
         if: |
           inputs.publish == true &&
@@ -234,11 +257,12 @@ jobs:
           steps.android_build.outcome == 'success' &&
           steps.gsa.outputs.available == 'true'
         run: |
-          echo "Play Store'a gonderiliyor (profil: ${{ inputs.submit_profile }})..."
+          SUBMIT_PROFILE="${{ steps.resolve_submit.outputs.profile }}"
+          echo "Play Store'a gonderiliyor (profil: $SUBMIT_PROFILE)..."
 
           eas submit \
             --platform android \
-            --profile ${{ inputs.submit_profile }} \
+            --profile "$SUBMIT_PROFILE" \
             --latest \
             --non-interactive
         env:
@@ -283,6 +307,7 @@ jobs:
             echo "| 🎯 **Platform** | \`${{ inputs.platform }}\` |"
             echo "| 📋 **Profil** | \`${{ inputs.profile }}\` |"
             echo "| 📤 **Yayinla** | \`${{ inputs.publish }}\` |"
+            echo "| 🏪 **Submit Profili** | \`${{ steps.resolve_submit.outputs.profile || inputs.submit_profile }}\` |"
             echo "| ⏱️ **Sure** | ${MINUTES}dk ${SECONDS}sn |"
             echo ""
 
@@ -295,7 +320,8 @@ jobs:
               BUILD_STATUS="${{ steps.android_build.outcome == 'success' && '✅ Basarili' || '❌ Basarisiz' }}"
 
               if [ "${{ inputs.publish }}" == "true" ]; then
-                SUBMIT_STATUS="${{ steps.gsa.outputs.available == 'true' && '✅ Gonderildi' || '⚠️ Secret eksik' }}"
+                RESOLVED="${{ steps.resolve_submit.outputs.profile }}"
+                SUBMIT_STATUS="${{ steps.gsa.outputs.available == 'true' && '✅ Gonderildi' || '⚠️ Secret eksik' }} ($RESOLVED)"
               else
                 SUBMIT_STATUS="⏭️ Atlandı"
               fi

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -2,13 +2,18 @@
 # Expo Build Pipeline (PlayStore) — Namaz Akisi
 # ========================================================================
 #
-# EAS Build ile PlayStore icin uretim AAB olusturur.
-# Versiyon DEGISTIRMEZ — mevcut app.json versiyonunu kullanir.
+# Tetikleyiciler:
+#   - Manuel (workflow_dispatch): UI uzerinden herhangi bir profil ile
+#   - Otomatik (workflow_call): android-build.yml'in release adiminin
+#     ardından çağrılır — version bump commit'inden sonra tetiklenir,
+#     EAS o anki master'ı klonladığı için doğru versionCode'u alır.
 #
-# "Yayinla" secenegini isaretli birakinca build bittikten sonra
-# CHANGELOG'dan release notlari alinip Play Store'a otomatik gonderilir.
+# Otomatik akis:
+#   master push → CI gecer → android-build (versioning+APK+tag)
+#              → expo-build (production AAB → internal track)
+#              → Play Console internal testing → manuel promote → production
 #
-# Gereksinimler (Play Store submit icin):
+# Gereksinimler:
 #   GitHub Secrets:
 #     EXPO_TOKEN               — Expo hesap tokeni
 #     GOOGLE_SERVICE_ACCOUNT   — Google Service Account JSON (tam icerik)
@@ -53,6 +58,27 @@ on:
           - internal
           - closed-testing
           - production
+
+  # android-build.yml tarafindan otomatik cagrilir (release sonrasi)
+  workflow_call:
+    inputs:
+      platform:
+        type: string
+        default: 'android'
+      profile:
+        type: string
+        default: 'production'
+      publish:
+        type: boolean
+        default: true
+      submit_profile:
+        type: string
+        default: 'internal'
+    secrets:
+      EXPO_TOKEN:
+        required: true
+      GOOGLE_SERVICE_ACCOUNT:
+        required: false
 
 concurrency:
   group: expo-build-${{ inputs.platform }}-${{ inputs.profile }}

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -126,6 +126,30 @@ jobs:
           echo "✅ EXPO_TOKEN mevcut"
 
       # ==========================================
+      # versionCode Senkronizasyonu
+      # EAS remote sayacı local build.gradle'dan düşükse senkronize et
+      # ==========================================
+      - name: 🔢 versionCode senkronize et
+        if: inputs.build_aab == true
+        run: |
+          LOCAL_VC=$(grep -m1 'versionCode' android/app/build.gradle | tr -dc '0-9')
+          echo "📌 Local versionCode: $LOCAL_VC"
+
+          REMOTE_JSON=$(eas build:version:get -p android --json --non-interactive 2>/dev/null || echo '{}')
+          REMOTE_VC=$(echo "$REMOTE_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('buildNumber') or d.get('versionCode') or 0)" 2>/dev/null || echo 0)
+          echo "📡 EAS remote versionCode: $REMOTE_VC"
+
+          if [ "${REMOTE_VC:-0}" -lt "$LOCAL_VC" ]; then
+            echo "⚠️  Remote ($REMOTE_VC) < Local ($LOCAL_VC) — senkronize ediliyor..."
+            printf "%s\n" "$LOCAL_VC" | eas build:version:set -p android
+            echo "✅ EAS remote versionCode $LOCAL_VC'a set edildi"
+          else
+            echo "✅ EAS remote versionCode güncel ($REMOTE_VC >= $LOCAL_VC)"
+          fi
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      # ==========================================
       # AAB Build (production — Play Store)
       # ==========================================
       - name: 🤖 AAB Build (production profili)

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -141,7 +141,14 @@ jobs:
 
           if [ "${REMOTE_VC:-0}" -lt "$LOCAL_VC" ]; then
             echo "⚠️  Remote ($REMOTE_VC) < Local ($LOCAL_VC) — senkronize ediliyor..."
-            printf "%s\n" "$LOCAL_VC" | eas build:version:set -p android
+            # eas build:version:set TTY gerektirir, expect ile simüle ediyoruz
+            expect << EXPECT_SCRIPT
+              set timeout 30
+              spawn eas build:version:set -p android
+              expect -re {version}
+              send "$LOCAL_VC\r"
+              expect eof
+EXPECT_SCRIPT
             echo "✅ EAS remote versionCode $LOCAL_VC'a set edildi"
           else
             echo "✅ EAS remote versionCode güncel ($REMOTE_VC >= $LOCAL_VC)"

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -141,6 +141,7 @@ jobs:
 
           if [ "${REMOTE_VC:-0}" -lt "$LOCAL_VC" ]; then
             echo "⚠️  Remote ($REMOTE_VC) < Local ($LOCAL_VC) — senkronize ediliyor..."
+            sudo apt-get install -y expect -qq
             # eas build:version:set TTY gerektirir; expect -c ile inline simüle ediyoruz
             expect -c "
               set timeout 30

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -13,9 +13,12 @@
 #   android-build.yml APK + GitHub Release'i halleder
 #   Bu workflow sadece AAB → internal track yapar
 #
-# versionCode: EAS remote ile yönetilir (app.json'a dokunmaz)
-#   → Test buildleri git commit oluşturmaz
-#   → Her EAS build otomatik olarak bir sonraki versionCode'u alır
+# versionCode: Build aninda timestamp (date +%s) ile atanir
+#   → Hem test hem master buildleri ayni internal track'e gider,
+#     tek monoton dizi gerekir; timestamp her zaman artar.
+#   → Runner'da local commit edilir (push YOK) — git kirlenmez,
+#     EAS commit'li state'ten okur.
+#   → versionName (0.22.0) android-build.yml semantic versioning'inde kalir.
 #
 # Gereksinimler (GitHub Secrets):
 #   EXPO_TOKEN             — expo.dev hesap tokeni
@@ -88,7 +91,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./app.json').expo.version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "📦 v$VERSION | versionCode: EAS remote yönetiminde"
+          echo "📦 v$VERSION | versionCode: build aninda timestamp ile atanacak"
 
       # ==========================================
       # Ortam Hazırlığı
@@ -126,36 +129,38 @@ jobs:
           echo "✅ EXPO_TOKEN mevcut"
 
       # ==========================================
-      # versionCode Senkronizasyonu
-      # EAS remote sayacı local build.gradle'dan düşükse senkronize et
+      # versionCode = timestamp (build aninda, push YOK)
+      # EAS commit'li git state'ten okur; bu yuzden runner'da
+      # local commit ediyoruz (push etmiyoruz). Timestamp her
+      # zaman artar → Play Store monoton dizi sarti saglanir.
       # ==========================================
-      - name: 🔢 versionCode senkronize et
+      - name: 🔢 versionCode ata (timestamp)
         if: inputs.build_aab == true
+        id: vc
         run: |
-          LOCAL_VC=$(grep -m1 'versionCode' android/app/build.gradle | tr -dc '0-9')
-          echo "📌 Local versionCode: $LOCAL_VC"
+          VC=$(date +%s)
+          OLD_VC=$(grep -m1 'versionCode' android/app/build.gradle | tr -dc '0-9')
+          echo "📌 versionCode: $OLD_VC → $VC"
 
-          REMOTE_JSON=$(eas build:version:get -p android --json --non-interactive 2>/dev/null || echo '{}')
-          REMOTE_VC=$(echo "$REMOTE_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('buildNumber') or d.get('versionCode') or 0)" 2>/dev/null || echo 0)
-          echo "📡 EAS remote versionCode: $REMOTE_VC"
+          # Bare workflow: EAS native build.gradle'i okur.
+          # app.json'u da set ediyoruz — olasi prebuild senaryosuna karsi garanti.
+          sed -i "s/versionCode [0-9]*/versionCode $VC/" android/app/build.gradle
+          node -e "
+            const fs = require('fs');
+            const a = JSON.parse(fs.readFileSync('./app.json', 'utf8'));
+            a.expo.android = a.expo.android || {};
+            a.expo.android.versionCode = $VC;
+            fs.writeFileSync('./app.json', JSON.stringify(a, null, 2) + '\n');
+          "
 
-          if [ "${REMOTE_VC:-0}" -lt "$LOCAL_VC" ]; then
-            echo "⚠️  Remote ($REMOTE_VC) < Local ($LOCAL_VC) — senkronize ediliyor..."
-            sudo apt-get install -y expect -qq
-            # eas build:version:set TTY gerektirir; expect -c ile inline simüle ediyoruz
-            expect -c "
-              set timeout 30
-              spawn eas build:version:set -p android
-              expect -re {What version}
-              send \"${LOCAL_VC}\r\"
-              expect eof
-            "
-            echo "✅ EAS remote versionCode ${LOCAL_VC}'a set edildi"
-          else
-            echo "✅ EAS remote versionCode güncel ($REMOTE_VC >= $LOCAL_VC)"
-          fi
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          # EAS commit'li state okur → push'suz local commit yeterli
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add android/app/build.gradle app.json
+          git commit -m "ci: ephemeral versionCode $VC [skip ci]" --no-verify
+
+          echo "code=$VC" >> $GITHUB_OUTPUT
+          echo "✅ build.gradle versionCode $VC olarak ayarlandı (sadece bu build için)"
 
       # ==========================================
       # AAB Build (production — Play Store)
@@ -164,8 +169,7 @@ jobs:
         if: inputs.build_aab == true
         id: aab_build
         run: |
-          echo "📦 AAB build başlatılıyor (production)..."
-          echo "ℹ️  versionCode EAS tarafından otomatik artırılacak"
+          echo "📦 AAB build başlatılıyor (production, versionCode ${{ steps.vc.outputs.code }})..."
           eas build \
             --platform android \
             --profile production \
@@ -264,7 +268,7 @@ jobs:
             echo "| Detay | Bilgi |"
             echo "|-------|-------|"
             echo "| 📦 **Versiyon** | \`${{ steps.version.outputs.version }}\` |"
-            echo "| 🔢 **versionCode** | EAS remote (otomatik) |"
+            echo "| 🔢 **versionCode** | \`${{ steps.vc.outputs.code }}\` (timestamp) |"
             echo "| 🌿 **Branch** | \`${{ github.ref_name }}\` |"
             echo "| ⏱️ **Süre** | ${MINUTES}dk ${SECONDS}sn |"
             echo ""

--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -141,15 +141,15 @@ jobs:
 
           if [ "${REMOTE_VC:-0}" -lt "$LOCAL_VC" ]; then
             echo "⚠️  Remote ($REMOTE_VC) < Local ($LOCAL_VC) — senkronize ediliyor..."
-            # eas build:version:set TTY gerektirir, expect ile simüle ediyoruz
-            expect << EXPECT_SCRIPT
+            # eas build:version:set TTY gerektirir; expect -c ile inline simüle ediyoruz
+            expect -c "
               set timeout 30
               spawn eas build:version:set -p android
-              expect -re {version}
-              send "$LOCAL_VC\r"
+              expect -re {What version}
+              send \"${LOCAL_VC}\r\"
               expect eof
-EXPECT_SCRIPT
-            echo "✅ EAS remote versionCode $LOCAL_VC'a set edildi"
+            "
+            echo "✅ EAS remote versionCode ${LOCAL_VC}'a set edildi"
           else
             echo "✅ EAS remote versionCode güncel ($REMOTE_VC >= $LOCAL_VC)"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Bu dosyada projenin tüm önemli değişiklikleri belgelenmiştir.
 Format [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) standardına dayanmaktadır.
 [Semantik Sürümleme](https://semver.org/lang/tr/) kullanılmaktadır.
 
+## [0.21.0] - 2026-06-02
+
+### Eklendi
+- takvim entegrasyonu (#75)
+
+### Düzeltildi
+- review düzeltmeleri — orphan temizleme, sequential write, IANA timezone, izin UX
+
 ## [0.20.2] - 2026-04-19
 
 ### Düzeltildi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Bu dosyada projenin tüm önemli değişiklikleri belgelenmiştir.
 Format [Keep a Changelog](https://keepachangelog.com/tr/1.0.0/) standardına dayanmaktadır.
 [Semantik Sürümleme](https://semver.org/lang/tr/) kullanılmaktadır.
 
+## [0.22.0] - 2026-06-02
+
+### Eklendi
+- internal testers için otomatik submit desteği ekle
+- mevcut takvim etkinliklerini temizle butonu eklendi
+
+### Düzeltildi
+- takvim izin ve cleanup duzeltmeleri + testler
+
 ## [0.21.0] - 2026-06-02
 
 ### Eklendi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,14 @@
 > Proaktif İslami ibadet asistanı. React Native + Expo (bare workflow), `android/` native dizini git'te.
 > Bu dosya kısa ve yüksek-sinyal tutulmalıdır; uzun anlatım yerine kural ve reçete yazın.
 
+## ⚙️ Bu dosyayı güncel tut (Claude için talimat)
+Çalışırken öğrendiğin kalıcı bilgileri **proaktif olarak buraya ekle** — kullanıcının ayrıca istemesini bekleme. Şunları öğrendiğinde bu dosyayı güncelle (aynı commit içinde):
+- Tekrar düşmemen gereken bir tuzak/gotcha veya çözümü (örn. platform sınırı, çakışan desen).
+- Yeni bir reçete: "X eklemek için Y dosyasına şunu yap" (örn. yeni özellik duyurusu).
+- Yeni komut, konvansiyon, mimari kararı veya kullanıcının net tercihi (örn. dil/üslup kuralları).
+- Bir şeyin neden öyle yapıldığı (gelecekte yanlışlıkla geri almayasın).
+Kurallar: kısa ve eyleme dönük yaz; mevcut bölümlere ekle, yenisini ancak gerekiyorsa aç; sırrı/jeton/kişisel veri YAZMA; spekülasyon değil yalnızca doğrulanmış bilgi gir; dosyayı şişirme (eskiyen maddeyi güncelle/sil).
+
 ## Komutlar
 - Tip kontrolü: `npx tsc --noEmit`
 - Testler: `npx jest` (tek dosya: `npx jest <isimParçası>`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Namaz Akışı — Proje Rehberi (Claude için)
+
+> Proaktif İslami ibadet asistanı. React Native + Expo (bare workflow), `android/` native dizini git'te.
+> Bu dosya kısa ve yüksek-sinyal tutulmalıdır; uzun anlatım yerine kural ve reçete yazın.
+
+## Komutlar
+- Tip kontrolü: `npx tsc --noEmit`
+- Testler: `npx jest` (tek dosya: `npx jest <isimParçası>`)
+- Lint/test CI'da koşar (`.github/workflows`); push öncesi en az `tsc` + ilgili testleri çalıştır.
+
+## Mimari
+- Katmanlar: `src/domain` (servisler, iş kuralı), `src/presentation` (ekranlar, bileşenler, store, hooks), `src/core` (sabitler, tema, util, tipler).
+- State: Redux Toolkit slice'ları (`src/presentation/store`), kalıcılık AsyncStorage ile thunk içinde. Her slice `*Yukle` / `*Guncelle` deseni izler.
+- Navigasyon: `src/navigation/AppNavigator.tsx` — Tab + Stack. Ayar sayfaları `AyarlarStack` içinde.
+- Domain servisleri **store'a bağımlı olmamalı**; tipleri dosya-içi yerelleştirin (yapısal uyum yeter).
+
+## Dil ve İsimlendirme
+- Kod isimleri **Türkçe** (değişken/fonksiyon/dosya): `vakit`, `ayarlar`, `olustur`, `temizle`...
+- **Kullanıcıya gösterilen tüm metinler kibar "siz" dilinde** olmalı: "ekleyebilirsiniz", "kontrol edin", "vakitleriniz". Asla "sen/senin" kullanma.
+- Buton/CTA etiketleri de kibar: "Hemen kurun", "İnceleyin".
+
+## Kritik Desenler ve Tuzaklar (bu projede öğrenildi)
+- **New Architecture açık** (`app.json: newArchEnabled: true`). Bu yüzden RN core `<Modal>` `onRequestClose`'u Android donanım geri tuşunda **güvenilir çalışmaz**.
+  → Her modalda `useDonanimGeriTusu(gorunur, onKapat)` hook'unu kullan (`src/presentation/hooks/useDonanimGeriTusu.ts`). `onRequestClose`'u da bırak (zarar yok).
+- **Bottom-sheet deseni**: backdrop'u içeriği saran `TouchableWithoutFeedback` olarak DEĞİL, `StyleSheet.absoluteFill` ile **kardeş (sibling)** olarak koy. Aksi halde içteki FlatList/ScrollView scroll'u takılır.
+  → Örnek: `TakvimAyarlariSayfasi.tsx` (TemizleModali, VakitEditorModali).
+- **Sabit yükseklikli sheet**: `maxHeight` yerine `height` kullan; `flex:1` çocuklar (FlatList) ancak öyle düzgün çalışır.
+- Namaz vakti hesabı **gün bazında**: her gün için `new PrayerTimes(coordinates, tarih, params)` ayrı hesaplanır (`TakvimServisi.takvimOlaylariOlustur`).
+
+## Yeni Özellik Duyurusu (önemli reçete)
+Yeni bir özellik eklediğinde kullanıcıya duyurmak için **tek yer**: `src/core/constants/YeniOzellikler.ts`.
+- Diziye en üste bir `YeniOzellik` nesnesi ekle (id, surum, tarih, baslik, aciklama özeti, detayAciklama, detaylar[], opsiyonel hedefSayfa/ctaEtiketi/kartGoster).
+- Otomatik olarak: Ayarlar tab nokta rozeti + menü "Yeni" rozeti + (kartGoster ise) Ayarlar üstü tanıtım kartı + "Neler Yeni" sayfası beslenir. Ek kod gerekmez.
+- Durum: `ozelliklerSlice` (`gorulenIdler` rozetleri kaldırır, `kapatilanKartIdler` kartı gizler). Açılışta `ozellikleriYukle` (MainTabs'te) dispatch edilir.
+- Kopya kuralı: `baslik` dikkat çekici, `aciklama` özelliğin ~%70'ini tek bakışta anlatan özet, detaylar tıklayınca açılır. Hepsi kibar "siz" dili.
+
+## CI / Sürümleme
+- APK = **Gradle** (`android-build.yml`), EAS DEĞİL. AAB = EAS (`expo-build.yml`) → Play Store internal track'e otomatik submit.
+- `eas.json`: `appVersionSource: local`. CI'da AAB `versionCode` = build anında `date +%s` (timestamp); runner'da local commit edilir, push edilmez.
+- Geliştirme branch'i: `claude/feature-development-*`. Push sonrası PR aç (ready, draft değil).
+
+## Test Konvansiyonu
+- Slice testleri `src/presentation/store/__tests__`, servis testleri `src/domain/services/__tests__`.
+- Mock: `expo-calendar`, `adhan`, `@react-native-async-storage/async-storage`, `react-native` (`Platform`) jest.mock ile. Örnek: `TakvimServisi.test.ts`, `ozelliklerSlice.test.ts`.
+- Redux state donmuştur (Immer); testte diziyi `.sort()` etmeden önce `[...dizi]` ile kopyala.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,11 @@ Yeni bir özellik eklediğinde kullanıcıya duyurmak için **tek yer**: `src/co
 - Durum: `ozelliklerSlice` (`gorulenIdler` rozetleri kaldırır, `kapatilanKartIdler` kartı gizler). Açılışta `ozellikleriYukle` (MainTabs'te) dispatch edilir.
 - Kopya kuralı: `baslik` dikkat çekici, `aciklama` özelliğin ~%70'ini tek bakışta anlatan özet, detaylar tıklayınca açılır. Hepsi kibar "siz" dili.
 
+## Güncelleme Sistemi (gotcha'lar)
+- Provider mimarisi: Play Store'dan kurulduysa `PlayStoreGuncellemeKaynagi` (Play Core), aksi halde `GitHubGuncellemeKaynagi` aktif (`GuncellemeServisi`).
+- **Play Core API sürüm ADINI ve changelog'u VERMEZ**, sadece `availableVersionCode`. Bu yüzden Play Store güncelleme modalı sürüm adı/özellik gösteremez. Çözüm: modal temiz "Yeni sürüm" etiketi gösterir (`yeniVersiyonEtiketi`), yeni özellikler **güncelleme sonrası "Neler Yeni" sistemiyle** (`YeniOzellikler.ts`) duyurulur. Kullanıcıya asla "versionCode N" gösterme.
+- **Önbellek tuzağı**: Play Store sonucu versionCode tabanlı olduğundan `onbellekBayatMi()` ile bayatlığı tespit edilemez → güncelleme sonrası eski "güncelleme var" cache'i takılıp modalı tekrar gösteriyordu. Çözüm: Play Store aktifken `guncellemeKontrolEt` önbelleği ATLAR, her açılışta Play Core'u yeniden sorgular (lokal/ucuz); erteleme ("Sonra") yine de süresince banner'ı bastırır.
+
 ## CI / Sürümleme
 - APK = **Gradle** (`android-build.yml`), EAS DEĞİL. AAB = EAS (`expo-build.yml`) → Play Store internal track'e otomatik submit.
 - `eas.json`: `appVersionSource: local`. CI'da AAB `versionCode` = build anında `date +%s` (timestamp); runner'da local commit edilir, push edilmez.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.furkanisikay.namazakisi'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 45
-        versionName "0.20.2"
+        versionCode 46
+        versionName "0.21.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.furkanisikay.namazakisi'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 46
-        versionName "0.21.0"
+        versionCode 47
+        versionName "0.22.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.READ_CALENDAR"/>
+  <uses-permission android:name="android.permission.WRITE_CALENDAR"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/app.json
+++ b/app.json
@@ -67,7 +67,13 @@
         }
       ],
       "expo-task-manager",
-      "expo-background-fetch"
+      "expo-background-fetch",
+      [
+        "expo-calendar",
+        {
+          "calendarPermission": "Namaz vakitlerini takviminize eklemek için takvim iznine ihtiyaç var."
+        }
+      ]
     ],
     "owner": "furkanisikay",
     "extra": {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Namaz Akışı",
     "slug": "namazakisi",
-    "version": "0.20.2",
+    "version": "0.21.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -40,7 +40,7 @@
         "android.permission.MODIFY_AUDIO_SETTINGS",
         "android.permission.WAKE_LOCK"
       ],
-      "versionCode": 45
+      "versionCode": 46
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Namaz Akışı",
     "slug": "namazakisi",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -40,7 +40,7 @@
         "android.permission.MODIFY_AUDIO_SETTINGS",
         "android.permission.WAKE_LOCK"
       ],
-      "versionCode": 46
+      "versionCode": 47
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 12.0.0",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 12.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {

--- a/eas.json
+++ b/eas.json
@@ -39,7 +39,8 @@
     "internal": {
       "android": {
         "track": "internal",
-        "releaseStatus": "completed"
+        "releaseStatus": "completed",
+        "serviceAccountKeyPath": "/tmp/google-service-account.json"
       }
     }
   }

--- a/eas.json
+++ b/eas.json
@@ -35,6 +35,12 @@
         "track": "alpha",
         "releaseStatus": "completed"
       }
+    },
+    "internal": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "completed"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namazakisi",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "namazakisi",
-      "version": "0.20.2",
+      "version": "0.21.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "namazakisi",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "namazakisi",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "expo-audio": "~1.1.1",
         "expo-background-fetch": "~14.0.9",
         "expo-blur": "~15.0.8",
+        "expo-calendar": "~14.0.4",
         "expo-crypto": "~15.0.8",
         "expo-file-system": "~19.0.21",
         "expo-haptics": "~15.0.8",
@@ -128,7 +129,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -4809,7 +4809,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
       "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.14.0",
         "escape-string-regexp": "^4.0.0",
@@ -5219,7 +5218,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
       "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5230,7 +5228,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5314,7 +5311,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -5609,7 +5605,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6454,7 +6449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7086,7 +7080,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8131,7 +8124,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8596,7 +8588,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -8658,7 +8649,6 @@
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
       "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
         "expo-constants": "~18.0.12"
@@ -8704,6 +8694,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-calendar": {
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/expo-calendar/-/expo-calendar-14.0.6.tgz",
+      "integrity": "sha512-aOby7ueR8lB9sWTHXkECZiPDZNVRsGQYhJTe05puNZicMWCV4c53Z/LRiCTTq3LBXV4zpBOB5rXiCyA1f082yA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
@@ -8745,7 +8745,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -10972,7 +10971,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -15339,7 +15337,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -15760,7 +15757,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15780,7 +15776,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -15811,7 +15806,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -16172,7 +16166,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -16201,7 +16194,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -16212,7 +16204,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -16288,7 +16279,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
       "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -16303,7 +16293,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -16406,7 +16395,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -16430,7 +16418,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16441,7 +16428,6 @@
       "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-is": "^19.1.0",
         "scheduler": "^0.26.0"
@@ -16504,8 +16490,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -17786,7 +17771,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
       "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -18050,7 +18034,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18353,7 +18336,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19120,7 +19102,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namazakisi",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "description": "Free & Open Source Prayer App (Sadaqah Jariyah)",
   "license": "GPL-3.0",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "expo-audio": "~1.1.1",
     "expo-background-fetch": "~14.0.9",
     "expo-blur": "~15.0.8",
+    "expo-calendar": "~14.0.4",
     "expo-crypto": "~15.0.8",
     "expo-file-system": "~19.0.21",
     "expo-haptics": "~15.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namazakisi",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Free & Open Source Prayer App (Sadaqah Jariyah)",
   "license": "GPL-3.0",
   "main": "index.ts",

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -161,6 +161,8 @@ export const DEPOLAMA_ANAHTARLARI = {
   ILK_KURULUM_TAMAMLANDI: '@namaz_akisi/ilk_kurulum_tamamlandi',
   // Takvim entegrasyonu
   TAKVIM_AYARLARI: '@namaz_akisi/takvim_ayarlari',
+  // Yeni özellik duyuruları (görülen/kapatılan)
+  GORULEN_OZELLIKLER: '@namaz_akisi/gorulen_ozellikler',
 } as const;
 
 // Tarih formatlari

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -37,7 +37,7 @@ export const NAMAZ_ISIMLERI = [
 // Uygulama meta verileri
 export const UYGULAMA = {
   ADI: 'Namaz Akışı',
-  VERSIYON: '0.21.0',
+  VERSIYON: '0.22.0',
   ACIKLAMA: 'Günlük namaz takip uygulaması',
   GITHUB_REPO: 'furkanisikay/namazakisi',
 } as const;

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -37,7 +37,7 @@ export const NAMAZ_ISIMLERI = [
 // Uygulama meta verileri
 export const UYGULAMA = {
   ADI: 'Namaz Akışı',
-  VERSIYON: '0.20.2',
+  VERSIYON: '0.21.0',
   ACIKLAMA: 'Günlük namaz takip uygulaması',
   GITHUB_REPO: 'furkanisikay/namazakisi',
 } as const;

--- a/src/core/constants/UygulamaSabitleri.ts
+++ b/src/core/constants/UygulamaSabitleri.ts
@@ -159,6 +159,8 @@ export const DEPOLAMA_ANAHTARLARI = {
   KAZA_TEMPO_GECMIS: '@namaz_akisi/kaza_tempo_gecmis',
   // Kurulum sihirbazi
   ILK_KURULUM_TAMAMLANDI: '@namaz_akisi/ilk_kurulum_tamamlandi',
+  // Takvim entegrasyonu
+  TAKVIM_AYARLARI: '@namaz_akisi/takvim_ayarlari',
 } as const;
 
 // Tarih formatlari

--- a/src/core/constants/YeniOzellikler.ts
+++ b/src/core/constants/YeniOzellikler.ts
@@ -1,0 +1,79 @@
+/**
+ * Yeni Özellik Kataloğu
+ *
+ * Uygulamaya eklenen yeni özelliklerin tek kaynağı. Rozet, "Neler Yeni" kartı
+ * ve "Neler Yeni" sayfası bu listeden beslenir.
+ *
+ * Yeni bir özellik duyurmak için: diziye en üste bir nesne ekle. Tüm yüzeyler
+ * (rozet + kart + sayfa) otomatik güncellenir; ek kod gerekmez.
+ *
+ * KOPYA YAZIM KURALLARI (önemli):
+ *   - Her zaman kibar "siz" dili kullanın ("ekleyebilirsiniz", "görürsünüz").
+ *   - `baslik` dikkat çekici ve net olsun.
+ *   - `aciklama` tek bakışta özelliğin ~%70'ini anlatan özet olsun (kapalı görünüm).
+ *   - `detayAciklama` + `detaylar` ile tıklayınca açılan detayda tam resmi verin.
+ */
+
+export interface YeniOzellik {
+    /** Benzersiz kimlik (kalıcı; değiştirme) */
+    id: string;
+    /** Hangi sürümde eklendi (örn. '0.22.0') */
+    surum: string;
+    /** Tanıtım tarihi — 'YYYY-MM-DD' (Neler Yeni sıralaması için) */
+    tarih: string;
+    /** Dikkat çekici başlık */
+    baslik: string;
+    /** Tek bakışta özelliği anlatan özet (kapalı görünümde gösterilir) */
+    aciklama: string;
+    /** Açılınca gösterilen detaylı paragraf */
+    detayAciklama?: string;
+    /** FontAwesome5 ikon adı */
+    ikon: string;
+    /** Ayarlar yığınındaki hedef sayfa (CTA + menü rozeti eşlemesi) */
+    hedefSayfa?: string;
+    /** CTA buton etiketi (örn. 'Hemen kurun') */
+    ctaEtiketi?: string;
+    /** Ayarlar üstünde kapatılabilir tanıtım kartı gösterilsin mi */
+    kartGoster?: boolean;
+    /** Açılınca gösterilen madde madde detaylar */
+    detaylar?: string[];
+}
+
+export const YENI_OZELLIKLER: YeniOzellik[] = [
+    {
+        id: 'takvim-entegrasyonu',
+        surum: '0.22.0',
+        tarih: '2026-06-05',
+        baslik: 'Namaz Vakitleri Artık Takviminizde',
+        aciklama:
+            'Seçtiğiniz namaz vakitlerini telefonunuzun takvimine otomatik etkinlik olarak ekleyebilirsiniz. Böylece günlük planınızı vakitlere göre rahatça yaparsınız.',
+        detayAciklama:
+            'Her vakit için etkinliğin ne zaman başlayacağını ve kaç dakika süreceğini ayrı ayrı belirleyebilirsiniz. Etkinlikler, eklediğiniz her gün için o günün gerçek namaz vakitlerine göre hesaplanır.',
+        ikon: 'calendar-alt',
+        hedefSayfa: 'TakvimAyarlari',
+        ctaEtiketi: 'Hemen kurun',
+        kartGoster: true,
+        detaylar: [
+            'Her vakit için süreyi ve başlangıcı (vakitte / çıkmadan önce / sonra) ayrı ayarlayın',
+            'Dilediğiniz kadar gün ileriye, o günün gerçek vakitleriyle etkinlik oluşturun',
+            'Takvim, tarih aralığı ve vakit seçerek istediğiniz etkinlikleri kolayca temizleyin',
+        ],
+    },
+    {
+        id: 'ana-ekran-widgetlari',
+        surum: '0.21.0',
+        tarih: '2026-05-20',
+        baslik: 'Ana Ekran Widget’ları',
+        aciklama:
+            'Namaz vakitlerini telefonunuzun ana ekranına ekleyebilir, uygulamayı açmadan bir sonraki vakti ve kalan süreyi görebilirsiniz.',
+        detayAciklama:
+            'İki farklı boyutta widget sunuyoruz: kompakt ve geniş. Widget’lar gün içinde otomatik güncellenir; ana ekranınızdan ayrılmadan vaktinde haberdar olursunuz. Eklemek için ana ekranınıza uzun basın, “Widget’lar” bölümünden Namaz Akışı’nı seçin.',
+        ikon: 'th-large',
+        kartGoster: false,
+        detaylar: [
+            'Kompakt ve geniş olmak üzere iki boyut',
+            'Bir sonraki vakit ve kalan süre tek bakışta',
+            'Gün içinde otomatik güncellenir',
+        ],
+    },
+];

--- a/src/domain/services/GuncellemeServisi.ts
+++ b/src/domain/services/GuncellemeServisi.ts
@@ -30,8 +30,14 @@ import { PlayStoreGuncellemeKaynagi } from './PlayStoreGuncellemeKaynagi';
  * Guncelleme bilgisi
  */
 export interface GuncellemeBilgisi {
-  /** Yeni versiyon numarasi */
+  /** Yeni versiyon numarasi (mantik/erteleme icin; Play Store'da versionCode) */
   yeniVersiyon: string;
+  /**
+   * Kullaniciya gosterilecek temiz surum etiketi (opsiyonel).
+   * Play Store gibi semantik surum adi alinamayan kaynaklarda "Yeni sürüm" gibi
+   * bir metin tutulur; UI bunu varsa `v{yeniVersiyon}` yerine gosterir.
+   */
+  yeniVersiyonEtiketi?: string;
   /** Mevcut versiyon numarasi */
   mevcutVersiyon: string;
   /** Degisiklik notlari */
@@ -364,7 +370,16 @@ export class GuncellemeServisi {
       // Onbellegi yukle
       await this.onbellegiYukle();
 
-      if (!zorla) {
+      // Play Store provider'i Play Core'un YEREL ve GUNCEL durumunu kullanir.
+      // Onbellek "bayat" tespiti yapilamadigindan (versionCode semantik degil,
+      // guncelleme sonrasi tespit edilemiyor) eski "guncelleme var" sonucu takilip
+      // kalabiliyordu. Cozum: Play Store aktifken onbellek kisa devresini ATLA ve
+      // her zaman taze sorgula. GitHub icin ag maliyetli oldugundan onbellek korunur.
+      const playStoreAktif = this.kaynaklar.some(
+        (k) => k.tip === 'playstore' && k.destekleniyor()
+      );
+
+      if (!playStoreAktif && !zorla) {
         // Erteleme kontrolu: erteleme sureci devam ediyorsa VE cache bayat degilse
         if (this.ertelemeSurecindeMi() && !this.onbellekBayatMi()) {
           return this.onbellek?.sonSonuc || { guncellemeMevcut: false, bilgi: null };
@@ -376,22 +391,36 @@ export class GuncellemeServisi {
         }
       }
 
-      // Ag baglantisi kontrolu (NetInfo ile hizli ve guvenilir)
-      const agDurumu = await NetInfo.fetch();
-      if (!agDurumu.isConnected) {
-        Logger.info('GuncellemeServisi', 'Cevrimdisi - kontrol atlaniyor');
-        // Bayat cache varsa guncelleme yok olarak dondur
-        if (this.onbellekBayatMi()) {
-          return { guncellemeMevcut: false, bilgi: null };
+      // Ag baglantisi kontrolu yalnizca GitHub icin (Play Core kendi baglantisini yonetir)
+      if (!playStoreAktif) {
+        const agDurumu = await NetInfo.fetch();
+        if (!agDurumu.isConnected) {
+          Logger.info('GuncellemeServisi', 'Cevrimdisi - kontrol atlaniyor');
+          // Bayat cache varsa guncelleme yok olarak dondur
+          if (this.onbellekBayatMi()) {
+            return { guncellemeMevcut: false, bilgi: null };
+          }
+          return this.onbellek?.sonSonuc || { guncellemeMevcut: false, bilgi: null };
         }
-        return this.onbellek?.sonSonuc || { guncellemeMevcut: false, bilgi: null };
       }
 
       // Desteklenen kaynaklardan kontrol et
       const sonuc = await this.kaynaklardanKontrolEt();
 
-      // Onbellege kaydet
+      // Gercek durumu onbellege kaydet
       await this.onbellegeKaydet(sonuc);
+
+      // Play Store: kullanici bu surumu "Sonra" dediyse ve erteleme suresi dolmadiysa
+      // banner'i bastir (gercek durum cache'e yazildi; manuel/zorla kontrol gosterir)
+      if (
+        playStoreAktif &&
+        !zorla &&
+        sonuc.guncellemeMevcut &&
+        this.ertelemeSurecindeMi() &&
+        this.onbellek?.ertelenenVersiyon === sonuc.bilgi?.yeniVersiyon
+      ) {
+        return { guncellemeMevcut: false, bilgi: null };
+      }
 
       return sonuc;
     } catch (hata) {

--- a/src/domain/services/NamazVaktiHesaplayiciServisi.ts
+++ b/src/domain/services/NamazVaktiHesaplayiciServisi.ts
@@ -99,6 +99,29 @@ export class NamazVaktiHesaplayiciServisi {
         return false;
     }
 
+    public getGunlukVakitler(tarih: Date): {
+        imsak: Date;
+        gunes: Date;
+        ogle: Date;
+        ikindi: Date;
+        aksam: Date;
+        yatsi: Date;
+    } | null {
+        if (!this.config) return null;
+        const { latitude, longitude } = this.config;
+        const coordinates = new Coordinates(latitude, longitude);
+        const params = CalculationMethod.Turkey();
+        const pt = new PrayerTimes(coordinates, tarih, params);
+        return {
+            imsak:  pt.fajr,
+            gunes:  pt.sunrise,
+            ogle:   pt.dhuhr,
+            ikindi: pt.asr,
+            aksam:  pt.maghrib,
+            yatsi:  pt.isha,
+        };
+    }
+
     public getSuankiVakitBilgisi(): VakitBilgisi | null {
         if (!this.config) {
             Logger.warn('NamazVaktiHesaplayiciServisi', 'NamazVaktiHesaplayici yapılandırılmadı!');

--- a/src/domain/services/PlayStoreGuncellemeKaynagi.ts
+++ b/src/domain/services/PlayStoreGuncellemeKaynagi.ts
@@ -39,11 +39,14 @@ export class PlayStoreGuncellemeKaynagi implements GuncellemeKaynagi {
       return {
         guncellemeMevcut: true,
         bilgi: {
-          // Play Store versiyonları için versionCode kullanılır;
-          // mevcut versionName'i gösteriyoruz, yeni için "Play Store" notu
+          // Play Core sürüm ADINI ve changelog'u vermez; yalnızca versionCode verir.
+          // versionCode'u erteleme/karşılaştırma MANTIĞI için saklarız ama kullanıcıya
+          // göstermeyiz — UI temiz "Yeni sürüm" etiketini gösterir. Özelliklerin
+          // tanıtımı güncelleme sonrası "Neler Yeni" sistemiyle yapılır.
           yeniVersiyon: durum.availableVersionCode
-            ? `versionCode ${durum.availableVersionCode}`
-            : 'Yeni sürüm',
+            ? String(durum.availableVersionCode)
+            : 'playstore',
+          yeniVersiyonEtiketi: 'Yeni sürüm',
           mevcutVersiyon: UYGULAMA.VERSIYON,
           degisiklikNotlari: '',
           // Sembolik URL — GuncellemeBildirimi'nde kaynak 'playstore' olunca

--- a/src/domain/services/TakvimServisi.ts
+++ b/src/domain/services/TakvimServisi.ts
@@ -1,0 +1,187 @@
+/**
+ * Takvim Entegrasyonu Servisi
+ * Namaz vakitleri icin cihaz takvim etkinlikleri olusturma
+ */
+
+import * as Calendar from 'expo-calendar';
+import { Platform } from 'react-native';
+import { Coordinates, CalculationMethod, PrayerTimes } from 'adhan';
+import { Logger } from '../../core/utils/Logger';
+import type { TakvimAyarlari, TakvimVakitAdi } from '../../presentation/store/takvimSlice';
+
+const OLUSTURULDU_NOTU = 'Namaz Akışı tarafından oluşturuldu';
+
+const VAKIT_ISIMLERI: Record<TakvimVakitAdi, string> = {
+    imsak:  'Sabah',
+    ogle:   'Öğle',
+    ikindi: 'İkindi',
+    aksam:  'Akşam',
+    yatsi:  'Yatsı',
+};
+
+export class TakvimServisi {
+    private static instance: TakvimServisi;
+
+    private constructor() {}
+
+    public static getInstance(): TakvimServisi {
+        if (!TakvimServisi.instance) {
+            TakvimServisi.instance = new TakvimServisi();
+        }
+        return TakvimServisi.instance;
+    }
+
+    public async izinIste(): Promise<boolean> {
+        try {
+            const { status } = await Calendar.requestCalendarPermissionsAsync();
+            return status === 'granted';
+        } catch (hata) {
+            Logger.error('TakvimServisi', 'Takvim izni istenemedi', hata);
+            return false;
+        }
+    }
+
+    public async cihazTakvimleriniGetir(): Promise<Array<{ id: string; title: string; color: string }>> {
+        try {
+            const izin = await this.izinIste();
+            if (!izin) return [];
+
+            const takvimler = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
+            return takvimler
+                .filter(t => t.allowsModifications)
+                .map(t => ({
+                    id: t.id,
+                    title: t.title,
+                    color: t.color || '#007AFF',
+                }));
+        } catch (hata) {
+            Logger.error('TakvimServisi', 'Takvimler getirilemedi', hata);
+            return [];
+        }
+    }
+
+    public async eskiOlaylariTemizle(takvimId: string, gunSayisi: number): Promise<void> {
+        try {
+            const bugun = new Date();
+            bugun.setHours(0, 0, 0, 0);
+            const bitis = new Date(bugun);
+            bitis.setDate(bitis.getDate() + gunSayisi + 1);
+
+            const etkinlikler = await Calendar.getEventsAsync([takvimId], bugun, bitis);
+            const silinecekler = etkinlikler.filter(e => e.notes?.includes(OLUSTURULDU_NOTU));
+
+            await Promise.all(
+                silinecekler.map(e => Calendar.deleteEventAsync(e.id).catch(() => {}))
+            );
+        } catch (hata) {
+            Logger.error('TakvimServisi', 'Eski olaylar temizlenemedi', hata);
+        }
+    }
+
+    private hesaplaBaslangic(
+        girisSaati: Date,
+        cikisSaati: Date,
+        baslangicTipi: TakvimAyarlari['vakitAyarlari'][TakvimVakitAdi]['baslangicTipi'],
+        dakika: number
+    ): Date {
+        const ms = dakika * 60 * 1000;
+        switch (baslangicTipi) {
+            case 'vakit_girisi':
+                return new Date(girisSaati);
+            case 'vakit_sonrasi':
+                return new Date(girisSaati.getTime() + ms);
+            case 'vakit_oncesi':
+                return new Date(cikisSaati.getTime() - ms);
+        }
+    }
+
+    public async takvimOlaylariOlustur(
+        ayarlar: TakvimAyarlari,
+        koordinatlar: { lat: number; lng: number }
+    ): Promise<number> {
+        const izin = await this.izinIste();
+        if (!izin) {
+            throw new Error('Takvim izni reddedildi');
+        }
+
+        if (!ayarlar.takvimId) {
+            throw new Error('Takvim seçilmedi');
+        }
+
+        await this.eskiOlaylariTemizle(ayarlar.takvimId, ayarlar.kaciGunIlerisi);
+
+        const coordinates = new Coordinates(koordinatlar.lat, koordinatlar.lng);
+        const params = CalculationMethod.Turkey();
+        let toplamOlusturulan = 0;
+
+        const gunIslemleri: Array<Promise<number>> = [];
+
+        for (let g = 0; g < ayarlar.kaciGunIlerisi; g++) {
+            const tarih = new Date();
+            tarih.setDate(tarih.getDate() + g);
+            tarih.setHours(0, 0, 0, 0);
+
+            gunIslemleri.push(
+                (async () => {
+                    let gunSayisi = 0;
+                    const pt = new PrayerTimes(coordinates, tarih, params);
+
+                    const yarinTarih = new Date(tarih);
+                    yarinTarih.setDate(yarinTarih.getDate() + 1);
+                    const ptYarin = new PrayerTimes(coordinates, yarinTarih, params);
+
+                    const girisSaatleri: Record<TakvimVakitAdi, Date> = {
+                        imsak:  pt.fajr,
+                        ogle:   pt.dhuhr,
+                        ikindi: pt.asr,
+                        aksam:  pt.maghrib,
+                        yatsi:  pt.isha,
+                    };
+
+                    const cikisSaatleri: Record<TakvimVakitAdi, Date> = {
+                        imsak:  pt.sunrise,
+                        ogle:   pt.asr,
+                        ikindi: pt.maghrib,
+                        aksam:  pt.isha,
+                        yatsi:  ptYarin.fajr,
+                    };
+
+                    const vakitSiralari: TakvimVakitAdi[] = ['imsak', 'ogle', 'ikindi', 'aksam', 'yatsi'];
+
+                    for (const vakit of vakitSiralari) {
+                        const vakitAyari = ayarlar.vakitAyarlari[vakit];
+                        if (!vakitAyari.aktif) continue;
+
+                        const startDate = this.hesaplaBaslangic(
+                            girisSaatleri[vakit],
+                            cikisSaatleri[vakit],
+                            vakitAyari.baslangicTipi,
+                            vakitAyari.dakika
+                        );
+                        const endDate = new Date(startDate.getTime() + vakitAyari.sureDakika * 60 * 1000);
+
+                        try {
+                            await Calendar.createEventAsync(ayarlar.takvimId!, {
+                                title: `${VAKIT_ISIMLERI[vakit]} Namazı`,
+                                startDate,
+                                endDate,
+                                notes: OLUSTURULDU_NOTU,
+                                timeZone: Platform.OS === 'android' ? 'local' : undefined,
+                            });
+                            gunSayisi++;
+                        } catch (hata) {
+                            Logger.error('TakvimServisi', `${vakit} etkinliği oluşturulamadı`, hata);
+                        }
+                    }
+                    return gunSayisi;
+                })()
+            );
+        }
+
+        const sonuclar = await Promise.all(gunIslemleri);
+        toplamOlusturulan = sonuclar.reduce((a, b) => a + b, 0);
+
+        Logger.info('TakvimServisi', `${toplamOlusturulan} takvim etkinliği oluşturuldu`);
+        return toplamOlusturulan;
+    }
+}

--- a/src/domain/services/TakvimServisi.ts
+++ b/src/domain/services/TakvimServisi.ts
@@ -114,6 +114,51 @@ export class TakvimServisi {
         }
     }
 
+    public async etkinlikleriGetir(
+        takvimIds: string[],
+        baslangicTarih: Date,
+        bitisTarih: Date,
+        vakitBasliklari?: string[]
+    ): Promise<Array<{ id: string; title: string; startDate: Date; takvimId: string }>> {
+        const izin = await this.izinIste();
+        if (!izin) return [];
+
+        const sonuclar: Array<{ id: string; title: string; startDate: Date; takvimId: string }> = [];
+
+        for (const takvimId of takvimIds) {
+            try {
+                const etkinlikler = await Calendar.getEventsAsync([takvimId], baslangicTarih, bitisTarih);
+                for (const e of etkinlikler) {
+                    if (!e.notes?.includes(OLUSTURULDU_NOTU)) continue;
+                    if (vakitBasliklari && vakitBasliklari.length > 0 && !vakitBasliklari.includes(e.title)) continue;
+                    sonuclar.push({
+                        id: e.id,
+                        title: e.title,
+                        startDate: new Date(e.startDate as string),
+                        takvimId,
+                    });
+                }
+            } catch (hata) {
+                Logger.error('TakvimServisi', `Takvim ${takvimId} sorgulanamadı`, hata);
+            }
+        }
+
+        return sonuclar.sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
+    }
+
+    public async etkinlikleriSil(eventIds: string[]): Promise<number> {
+        let silinen = 0;
+        for (const id of eventIds) {
+            try {
+                await Calendar.deleteEventAsync(id);
+                silinen++;
+            } catch (hata) {
+                Logger.error('TakvimServisi', `Etkinlik ${id} silinemedi`, hata);
+            }
+        }
+        return silinen;
+    }
+
     public async takvimOlaylariOlustur(
         ayarlar: TakvimAyarlari,
         koordinatlar: { lat: number; lng: number }

--- a/src/domain/services/TakvimServisi.ts
+++ b/src/domain/services/TakvimServisi.ts
@@ -7,7 +7,23 @@ import * as Calendar from 'expo-calendar';
 import { Platform } from 'react-native';
 import { Coordinates, CalculationMethod, PrayerTimes } from 'adhan';
 import { Logger } from '../../core/utils/Logger';
-import type { TakvimAyarlari, TakvimVakitAdi } from '../../presentation/store/takvimSlice';
+
+// Domain-local tipler — presentation/store'a bağımlılık olmadan yapısal uyum sağlar
+type TakvimVakitAdi = 'imsak' | 'ogle' | 'ikindi' | 'aksam' | 'yatsi';
+type BaslangicTipi = 'vakit_oncesi' | 'vakit_girisi' | 'vakit_sonrasi';
+
+interface VakitTakvimAyari {
+    aktif: boolean;
+    sureDakika: number;
+    baslangicTipi: BaslangicTipi;
+    dakika: number;
+}
+
+interface TakvimAyarlari {
+    takvimId: string | null;
+    kaciGunIlerisi: number;
+    vakitAyarlari: Record<TakvimVakitAdi, VakitTakvimAyari>;
+}
 
 const OLUSTURULDU_NOTU = 'Namaz Akışı tarafından oluşturuldu';
 
@@ -65,7 +81,10 @@ export class TakvimServisi {
             const bugun = new Date();
             bugun.setHours(0, 0, 0, 0);
             const bitis = new Date(bugun);
-            bitis.setDate(bitis.getDate() + gunSayisi + 1);
+            // Kullanici gun sayisini dusurse (ornegin 30->7) eski etkinliklerin yetim kalmamasi icin
+            // her zaman en az 31 gunluk (maksimum sinir) bir araligi temizle
+            const temizlemeGunSayisi = Math.max(gunSayisi, 31);
+            bitis.setDate(bitis.getDate() + temizlemeGunSayisi);
 
             const etkinlikler = await Calendar.getEventsAsync([takvimId], bugun, bitis);
             const silinecekler = etkinlikler.filter(e => e.notes?.includes(OLUSTURULDU_NOTU));
@@ -114,72 +133,67 @@ export class TakvimServisi {
         const params = CalculationMethod.Turkey();
         let toplamOlusturulan = 0;
 
-        const gunIslemleri: Array<Promise<number>> = [];
+        // IANA timezone: 'local' gecersiz, cihazin gercek timezone'unu al
+        const deviceTimeZone = Platform.OS === 'android'
+            ? Intl.DateTimeFormat().resolvedOptions().timeZone
+            : undefined;
 
+        // Sequential loop: 150 eşzamanlı IPC yerine sırayla yazarak takvim DB'yi aşırı yüklemiyoruz
         for (let g = 0; g < ayarlar.kaciGunIlerisi; g++) {
             const tarih = new Date();
             tarih.setDate(tarih.getDate() + g);
             tarih.setHours(0, 0, 0, 0);
 
-            gunIslemleri.push(
-                (async () => {
-                    let gunSayisi = 0;
-                    const pt = new PrayerTimes(coordinates, tarih, params);
+            const pt = new PrayerTimes(coordinates, tarih, params);
 
-                    const yarinTarih = new Date(tarih);
-                    yarinTarih.setDate(yarinTarih.getDate() + 1);
-                    const ptYarin = new PrayerTimes(coordinates, yarinTarih, params);
+            const yarinTarih = new Date(tarih);
+            yarinTarih.setDate(yarinTarih.getDate() + 1);
+            const ptYarin = new PrayerTimes(coordinates, yarinTarih, params);
 
-                    const girisSaatleri: Record<TakvimVakitAdi, Date> = {
-                        imsak:  pt.fajr,
-                        ogle:   pt.dhuhr,
-                        ikindi: pt.asr,
-                        aksam:  pt.maghrib,
-                        yatsi:  pt.isha,
-                    };
+            const girisSaatleri: Record<TakvimVakitAdi, Date> = {
+                imsak:  pt.fajr,
+                ogle:   pt.dhuhr,
+                ikindi: pt.asr,
+                aksam:  pt.maghrib,
+                yatsi:  pt.isha,
+            };
 
-                    const cikisSaatleri: Record<TakvimVakitAdi, Date> = {
-                        imsak:  pt.sunrise,
-                        ogle:   pt.asr,
-                        ikindi: pt.maghrib,
-                        aksam:  pt.isha,
-                        yatsi:  ptYarin.fajr,
-                    };
+            const cikisSaatleri: Record<TakvimVakitAdi, Date> = {
+                imsak:  pt.sunrise,
+                ogle:   pt.asr,
+                ikindi: pt.maghrib,
+                aksam:  pt.isha,
+                yatsi:  ptYarin.fajr,
+            };
 
-                    const vakitSiralari: TakvimVakitAdi[] = ['imsak', 'ogle', 'ikindi', 'aksam', 'yatsi'];
+            const vakitSiralari: TakvimVakitAdi[] = ['imsak', 'ogle', 'ikindi', 'aksam', 'yatsi'];
 
-                    for (const vakit of vakitSiralari) {
-                        const vakitAyari = ayarlar.vakitAyarlari[vakit];
-                        if (!vakitAyari.aktif) continue;
+            for (const vakit of vakitSiralari) {
+                const vakitAyari = ayarlar.vakitAyarlari[vakit];
+                if (!vakitAyari.aktif) continue;
 
-                        const startDate = this.hesaplaBaslangic(
-                            girisSaatleri[vakit],
-                            cikisSaatleri[vakit],
-                            vakitAyari.baslangicTipi,
-                            vakitAyari.dakika
-                        );
-                        const endDate = new Date(startDate.getTime() + vakitAyari.sureDakika * 60 * 1000);
+                const startDate = this.hesaplaBaslangic(
+                    girisSaatleri[vakit],
+                    cikisSaatleri[vakit],
+                    vakitAyari.baslangicTipi,
+                    vakitAyari.dakika
+                );
+                const endDate = new Date(startDate.getTime() + vakitAyari.sureDakika * 60 * 1000);
 
-                        try {
-                            await Calendar.createEventAsync(ayarlar.takvimId!, {
-                                title: `${VAKIT_ISIMLERI[vakit]} Namazı`,
-                                startDate,
-                                endDate,
-                                notes: OLUSTURULDU_NOTU,
-                                timeZone: Platform.OS === 'android' ? 'local' : undefined,
-                            });
-                            gunSayisi++;
-                        } catch (hata) {
-                            Logger.error('TakvimServisi', `${vakit} etkinliği oluşturulamadı`, hata);
-                        }
-                    }
-                    return gunSayisi;
-                })()
-            );
+                try {
+                    await Calendar.createEventAsync(ayarlar.takvimId!, {
+                        title: `${VAKIT_ISIMLERI[vakit]} Namazı`,
+                        startDate,
+                        endDate,
+                        notes: OLUSTURULDU_NOTU,
+                        timeZone: deviceTimeZone,
+                    });
+                    toplamOlusturulan++;
+                } catch (hata) {
+                    Logger.error('TakvimServisi', `${vakit} etkinliği oluşturulamadı`, hata);
+                }
+            }
         }
-
-        const sonuclar = await Promise.all(gunIslemleri);
-        toplamOlusturulan = sonuclar.reduce((a, b) => a + b, 0);
 
         Logger.info('TakvimServisi', `${toplamOlusturulan} takvim etkinliği oluşturuldu`);
         return toplamOlusturulan;

--- a/src/domain/services/__tests__/GuncellemeServisi.test.ts
+++ b/src/domain/services/__tests__/GuncellemeServisi.test.ts
@@ -804,6 +804,84 @@ describe('GuncellemeServisi — onbellekBayatMi Play Store guard', () => {
   });
 });
 
+describe('GuncellemeServisi — Play Store her açılışta taze sorgular (cache takılmaz)', () => {
+  const playStoreAvailable = (yeniVersiyon = '46') => ({
+    guncellemeMevcut: true,
+    bilgi: {
+      yeniVersiyon,
+      yeniVersiyonEtiketi: 'Yeni sürüm',
+      mevcutVersiyon: UYGULAMA.VERSIYON,
+      degisiklikNotlari: '',
+      indirmeBaglantisi: 'playstore://update',
+      yayinTarihi: '',
+      kaynak: 'playstore' as const,
+      zorunluMu: false,
+    },
+  });
+
+  beforeEach(() => {
+    Object.keys(asyncStorageMock).forEach(k => delete asyncStorageMock[k]);
+    GuncellemeServisi.resetInstance();
+    mockNetInfoFetch.mockResolvedValue({ isConnected: true });
+    mockKurulumKaynagiGetir.mockReset().mockResolvedValue('play_store');
+    mockPlayStoreKontrolEt.mockReset();
+    mockFetch.mockReset();
+  });
+
+  it('geçerli cache olsa bile Play Core yeniden sorgulanır', async () => {
+    // Geçerli (taze) playstore cache
+    asyncStorageMock[GUNCELLEME_SABITLERI.DEPOLAMA_ANAHTARI] = JSON.stringify({
+      sonKontrolZamani: Date.now(),
+      sonSonuc: playStoreAvailable('46'),
+      ertelenenVersiyon: null,
+      ertelemeZamani: null,
+    });
+    mockPlayStoreKontrolEt.mockResolvedValue(playStoreAvailable('46'));
+
+    const servis = GuncellemeServisi.getInstance();
+    const sonuc = await servis.guncellemeKontrolEt(false);
+
+    // Cache'e takılmadan Play Core sorgulanmış olmalı
+    expect(mockPlayStoreKontrolEt).toHaveBeenCalled();
+    expect(sonuc.guncellemeMevcut).toBe(true);
+  });
+
+  it('güncelleme sonrası Play Core "yok" derse, eski cache olsa bile modal çıkmaz', async () => {
+    // Eski cache hâlâ "güncelleme var" diyor (kullanıcı güncellemeden önceki durum)
+    asyncStorageMock[GUNCELLEME_SABITLERI.DEPOLAMA_ANAHTARI] = JSON.stringify({
+      sonKontrolZamani: Date.now(),
+      sonSonuc: playStoreAvailable('46'),
+      ertelenenVersiyon: null,
+      ertelemeZamani: null,
+    });
+    // Play Core artık güncelleme yok diyor (kullanıcı güncelledi)
+    mockPlayStoreKontrolEt.mockResolvedValue({ guncellemeMevcut: false, bilgi: null });
+
+    const servis = GuncellemeServisi.getInstance();
+    const sonuc = await servis.guncellemeKontrolEt(false);
+
+    expect(mockPlayStoreKontrolEt).toHaveBeenCalled();
+    expect(sonuc.guncellemeMevcut).toBe(false);
+  });
+
+  it('kullanıcı "Sonra" dediyse erteleme süresince banner bastırılır, zorla kontrol gösterir', async () => {
+    mockPlayStoreKontrolEt.mockResolvedValue(playStoreAvailable('46'));
+
+    const servis = GuncellemeServisi.getInstance();
+    // İlk kontrol + ertele
+    await servis.guncellemeKontrolEt(false);
+    await servis.guncellemeErtele('46');
+
+    // Erteleme aktif → banner bastırılır
+    const ertelenmis = await servis.guncellemeKontrolEt(false);
+    expect(ertelenmis.guncellemeMevcut).toBe(false);
+
+    // Zorla (manuel) kontrol → gerçek durum gösterilir
+    const zorlanmis = await servis.guncellemeKontrolEt(true);
+    expect(zorlanmis.guncellemeMevcut).toBe(true);
+  });
+});
+
 describe('guvenilirBaglantiMi', () => {
   it('github.com HTTPS baglantisini kabul eder', () => {
     expect(guvenilirBaglantiMi('https://github.com/furkanisikay/namazakisi/releases')).toBe(true);

--- a/src/domain/services/__tests__/PlayStoreGuncellemeKaynagi.test.ts
+++ b/src/domain/services/__tests__/PlayStoreGuncellemeKaynagi.test.ts
@@ -67,6 +67,20 @@ describe('PlayStoreGuncellemeKaynagi', () => {
       expect(sonuc.bilgi!.zorunluMu).toBe(false);
     });
 
+    it('kullanıcıya çirkin "versionCode" göstermez; temiz etiket kullanır', async () => {
+      mockKontrolEt.mockResolvedValue({
+        guncellemeMevcut: true,
+        availableVersionCode: 46,
+      });
+
+      const sonuc = await kaynak.enSonSurumuKontrolEt();
+
+      // versionCode mantık için saklanır ama gösterim etiketi temiz olmalı
+      expect(sonuc.bilgi!.yeniVersiyon).toBe('46');
+      expect(sonuc.bilgi!.yeniVersiyonEtiketi).toBe('Yeni sürüm');
+      expect(sonuc.bilgi!.yeniVersiyon).not.toContain('versionCode');
+    });
+
     it('güncelleme yokken { guncellemeMevcut: false } döner', async () => {
       mockKontrolEt.mockResolvedValue({
         guncellemeMevcut: false,

--- a/src/domain/services/__tests__/TakvimServisi.test.ts
+++ b/src/domain/services/__tests__/TakvimServisi.test.ts
@@ -1,0 +1,273 @@
+/**
+ * TakvimServisi Testleri
+ * expo-calendar + adhan mock'lariyla takvim etkinligi olusturma/temizleme akislari
+ */
+
+import * as Calendar from 'expo-calendar';
+import { TakvimServisi } from '../TakvimServisi';
+
+// ─── Mock'lar ──────────────────────────────────────────────────────────────────
+
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+
+jest.mock('../../../core/utils/Logger', () => ({
+    Logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('expo-calendar', () => ({
+    EntityTypes: { EVENT: 'event' },
+    requestCalendarPermissionsAsync: jest.fn(),
+    getCalendarsAsync: jest.fn(),
+    getEventsAsync: jest.fn(),
+    createEventAsync: jest.fn(),
+    deleteEventAsync: jest.fn(),
+}));
+
+// adhan: her gun icin deterministik vakitler dondur (gercek hesap yapmaya gerek yok)
+jest.mock('adhan', () => ({
+    Coordinates: jest.fn().mockImplementation((lat: number, lng: number) => ({ lat, lng })),
+    CalculationMethod: { Turkey: jest.fn(() => ({})) },
+    PrayerTimes: jest.fn().mockImplementation((_coords: any, date: Date) => {
+        const g = (saat: number, dakika = 0) =>
+            new Date(date.getFullYear(), date.getMonth(), date.getDate(), saat, dakika);
+        return {
+            fajr:     g(5, 0),
+            sunrise:  g(6, 30),
+            dhuhr:    g(13, 0),
+            asr:      g(16, 0),
+            maghrib:  g(19, 0),
+            isha:     g(20, 30),
+        };
+    }),
+}));
+
+const mockCalendar = Calendar as jest.Mocked<typeof Calendar>;
+
+const OLUSTURULDU_NOTU = 'Namaz Akışı tarafından oluşturuldu';
+
+// ─── Yardimcilar ────────────────────────────────────────────────────────────────
+
+type VakitAyari = { aktif: boolean; sureDakika: number; baslangicTipi: string; dakika: number };
+
+function vakit(aktif: boolean, ekstra: Partial<VakitAyari> = {}): VakitAyari {
+    return { aktif, sureDakika: 15, baslangicTipi: 'vakit_girisi', dakika: 5, ...ekstra };
+}
+
+function ayarlarOlustur(overrides: any = {}) {
+    return {
+        takvimId: 'cal-1',
+        kaciGunIlerisi: 2,
+        vakitAyarlari: {
+            imsak:  vakit(true),
+            ogle:   vakit(false),
+            ikindi: vakit(false),
+            aksam:  vakit(false),
+            yatsi:  vakit(true),
+        },
+        ...overrides,
+    };
+}
+
+const KOORDINAT = { lat: 41.0, lng: 29.0 };
+
+describe('TakvimServisi', () => {
+    const servis = TakvimServisi.getInstance();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Varsayilan: izin verildi, temizlenecek eski etkinlik yok
+        (mockCalendar.requestCalendarPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+        (mockCalendar.getEventsAsync as jest.Mock).mockResolvedValue([]);
+        (mockCalendar.createEventAsync as jest.Mock).mockResolvedValue('evt-id');
+        (mockCalendar.deleteEventAsync as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    // ─── izin / on kosullar ──────────────────────────────────────────────────
+
+    describe('takvimOlaylariOlustur — ön koşullar', () => {
+        it('izin reddedilirse hata fırlatır ve etkinlik oluşturmaz', async () => {
+            (mockCalendar.requestCalendarPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+
+            await expect(
+                servis.takvimOlaylariOlustur(ayarlarOlustur() as any, KOORDINAT)
+            ).rejects.toThrow('Takvim izni reddedildi');
+
+            expect(mockCalendar.createEventAsync).not.toHaveBeenCalled();
+        });
+
+        it('takvim seçilmemişse hata fırlatır', async () => {
+            await expect(
+                servis.takvimOlaylariOlustur(ayarlarOlustur({ takvimId: null }) as any, KOORDINAT)
+            ).rejects.toThrow('Takvim seçilmedi');
+
+            expect(mockCalendar.createEventAsync).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─── aktif vakit filtreleme ──────────────────────────────────────────────
+
+    describe('takvimOlaylariOlustur — etkinlik oluşturma', () => {
+        it('yalnızca aktif vakitler için, gün × aktif vakit sayısı kadar etkinlik oluşturur', async () => {
+            // 2 aktif vakit (imsak, yatsi) × 2 gün = 4 etkinlik
+            const sayi = await servis.takvimOlaylariOlustur(ayarlarOlustur() as any, KOORDINAT);
+
+            expect(sayi).toBe(4);
+            expect(mockCalendar.createEventAsync).toHaveBeenCalledTimes(4);
+        });
+
+        it('hiç aktif vakit yoksa 0 döner ve etkinlik oluşturmaz', async () => {
+            const ayarlar = ayarlarOlustur({
+                vakitAyarlari: {
+                    imsak: vakit(false), ogle: vakit(false), ikindi: vakit(false),
+                    aksam: vakit(false), yatsi: vakit(false),
+                },
+            });
+
+            const sayi = await servis.takvimOlaylariOlustur(ayarlar as any, KOORDINAT);
+
+            expect(sayi).toBe(0);
+            expect(mockCalendar.createEventAsync).not.toHaveBeenCalled();
+        });
+
+        it('oluşturulan etkinlik doğru başlık, takvim ve "oluşturuldu" notunu içerir', async () => {
+            const ayarlar = ayarlarOlustur({
+                kaciGunIlerisi: 1,
+                vakitAyarlari: {
+                    imsak: vakit(true), ogle: vakit(false), ikindi: vakit(false),
+                    aksam: vakit(false), yatsi: vakit(false),
+                },
+            });
+
+            await servis.takvimOlaylariOlustur(ayarlar as any, KOORDINAT);
+
+            expect(mockCalendar.createEventAsync).toHaveBeenCalledTimes(1);
+            const [takvimId, detay] = (mockCalendar.createEventAsync as jest.Mock).mock.calls[0];
+            expect(takvimId).toBe('cal-1');
+            expect(detay.title).toBe('Sabah Namazı');
+            expect(detay.notes).toBe(OLUSTURULDU_NOTU);
+            expect(detay.startDate).toBeInstanceOf(Date);
+            expect(detay.endDate).toBeInstanceOf(Date);
+            // vakit_girisi: imsak girisi 05:00, sure 15 dk → bitis 05:15
+            expect(detay.startDate.getHours()).toBe(5);
+            expect(detay.startDate.getMinutes()).toBe(0);
+            expect(detay.endDate.getMinutes()).toBe(15);
+        });
+
+        it('bir etkinlik oluşturulamasa bile diğerleri oluşturulur ve sayım doğru kalır', async () => {
+            (mockCalendar.createEventAsync as jest.Mock)
+                .mockRejectedValueOnce(new Error('takvim hatası')) // ilk çağrı patlar
+                .mockResolvedValue('evt-id');
+
+            const sayi = await servis.takvimOlaylariOlustur(ayarlarOlustur() as any, KOORDINAT);
+
+            // 4 deneme, 1 başarısız → 3 başarılı
+            expect(mockCalendar.createEventAsync).toHaveBeenCalledTimes(4);
+            expect(sayi).toBe(3);
+        });
+    });
+
+    // ─── hesaplaBaslangic (private) ──────────────────────────────────────────
+
+    describe('hesaplaBaslangic — başlangıç tipi mantığı', () => {
+        const giris = new Date(2026, 5, 5, 13, 0); // 13:00
+        const cikis = new Date(2026, 5, 5, 16, 0); // 16:00
+
+        it('vakit_girisi: tam vakit girişinde başlar', () => {
+            const sonuc = (servis as any).hesaplaBaslangic(giris, cikis, 'vakit_girisi', 10);
+            expect(sonuc.getHours()).toBe(13);
+            expect(sonuc.getMinutes()).toBe(0);
+        });
+
+        it('vakit_sonrasi: giriş + dakika kadar sonra başlar', () => {
+            const sonuc = (servis as any).hesaplaBaslangic(giris, cikis, 'vakit_sonrasi', 10);
+            expect(sonuc.getHours()).toBe(13);
+            expect(sonuc.getMinutes()).toBe(10);
+        });
+
+        it('vakit_oncesi: çıkış - dakika kadar önce başlar', () => {
+            const sonuc = (servis as any).hesaplaBaslangic(giris, cikis, 'vakit_oncesi', 10);
+            expect(sonuc.getHours()).toBe(15);
+            expect(sonuc.getMinutes()).toBe(50);
+        });
+    });
+
+    // ─── eskiOlaylariTemizle ──────────────────────────────────────────────────
+
+    describe('eskiOlaylariTemizle', () => {
+        it('yalnızca "oluşturuldu" notu taşıyan etkinlikleri siler', async () => {
+            (mockCalendar.getEventsAsync as jest.Mock).mockResolvedValue([
+                { id: 'a', notes: OLUSTURULDU_NOTU },
+                { id: 'b', notes: 'kullanıcının kendi etkinliği' },
+                { id: 'c', notes: undefined },
+                { id: 'd', notes: `${OLUSTURULDU_NOTU} (Öğle)` },
+            ]);
+
+            await servis.eskiOlaylariTemizle('cal-1', 7);
+
+            expect(mockCalendar.deleteEventAsync).toHaveBeenCalledTimes(2);
+            expect(mockCalendar.deleteEventAsync).toHaveBeenCalledWith('a');
+            expect(mockCalendar.deleteEventAsync).toHaveBeenCalledWith('d');
+            expect(mockCalendar.deleteEventAsync).not.toHaveBeenCalledWith('b');
+        });
+
+        it('gün sayısı düşük olsa bile en az 31 günlük aralığı tarar (orphan önleme)', async () => {
+            await servis.eskiOlaylariTemizle('cal-1', 7);
+
+            const [, baslangic, bitis] = (mockCalendar.getEventsAsync as jest.Mock).mock.calls[0];
+            const gunFarki = Math.round((bitis.getTime() - baslangic.getTime()) / (24 * 60 * 60 * 1000));
+            expect(gunFarki).toBeGreaterThanOrEqual(31);
+        });
+
+        it('gün sayısı 31’den büyükse o değeri kullanır', async () => {
+            await servis.eskiOlaylariTemizle('cal-1', 60);
+
+            const [, baslangic, bitis] = (mockCalendar.getEventsAsync as jest.Mock).mock.calls[0];
+            const gunFarki = Math.round((bitis.getTime() - baslangic.getTime()) / (24 * 60 * 60 * 1000));
+            expect(gunFarki).toBe(60);
+        });
+    });
+
+    // ─── cihazTakvimleriniGetir ──────────────────────────────────────────────
+
+    describe('cihazTakvimleriniGetir', () => {
+        it('yalnızca düzenlenebilir takvimleri döndürür', async () => {
+            (mockCalendar.getCalendarsAsync as jest.Mock).mockResolvedValue([
+                { id: '1', title: 'Kişisel', color: '#FF0000', allowsModifications: true },
+                { id: '2', title: 'Tatiller', color: '#00FF00', allowsModifications: false },
+                { id: '3', title: 'İş', color: '', allowsModifications: true },
+            ]);
+
+            const sonuc = await servis.cihazTakvimleriniGetir();
+
+            expect(sonuc).toHaveLength(2);
+            expect(sonuc.map(t => t.id)).toEqual(['1', '3']);
+            // renk boşsa varsayılan atanır
+            expect(sonuc[1].color).toBe('#007AFF');
+        });
+
+        it('izin yoksa boş dizi döner', async () => {
+            (mockCalendar.requestCalendarPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+
+            const sonuc = await servis.cihazTakvimleriniGetir();
+
+            expect(sonuc).toEqual([]);
+            expect(mockCalendar.getCalendarsAsync).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─── etkinlikleriSil ──────────────────────────────────────────────────────
+
+    describe('etkinlikleriSil', () => {
+        it('başarıyla silinen etkinlik sayısını döndürür', async () => {
+            (mockCalendar.deleteEventAsync as jest.Mock)
+                .mockResolvedValueOnce(undefined)
+                .mockRejectedValueOnce(new Error('silinemedi'))
+                .mockResolvedValueOnce(undefined);
+
+            const silinen = await servis.etkinlikleriSil(['a', 'b', 'c']);
+
+            expect(silinen).toBe(2);
+            expect(mockCalendar.deleteEventAsync).toHaveBeenCalledTimes(3);
+        });
+    });
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -31,9 +31,13 @@ import {
   KazaDefteriSayfasi,
   KurulumSihirbaziSayfasi,
   TakvimAyarlariSayfasi,
+  NelerYeniSayfasi,
 } from '../presentation/screens';
 import { DEPOLAMA_ANAHTARLARI } from '../core/constants/UygulamaSabitleri';
 import { useRenkler } from '../core/theme';
+import { useAppDispatch } from '../presentation/store/hooks';
+import { ozellikleriYukle } from '../presentation/store/ozelliklerSlice';
+import { useYeniOzellikler } from '../presentation/hooks/useYeniOzellikler';
 import { GuncellemeBildirimi } from '../presentation/components/guncelleme/GuncellemeBildirimi';
 import ErrorBoundary from '../presentation/components/common/ErrorBoundary';
 
@@ -124,6 +128,11 @@ const AyarlarStack: React.FC = () => {
         component={TakvimAyarlariSayfasi}
         options={{ title: 'Takvim Entegrasyonu' }}
       />
+      <Stack.Screen
+        name="NelerYeni"
+        component={NelerYeniSayfasi}
+        options={{ title: 'Neler Yeni' }}
+      />
     </Stack.Navigator>
   );
 };
@@ -134,6 +143,13 @@ const AyarlarStack: React.FC = () => {
 const MainTabs: React.FC = () => {
   const renkler = useRenkler();
   const insets = useSafeAreaInsets();
+  const dispatch = useAppDispatch();
+  const { okunmamisVarMi } = useYeniOzellikler();
+
+  // Yeni özellik duyuru durumunu uygulama açılışında yükle (tab rozeti için)
+  useEffect(() => {
+    dispatch(ozellikleriYukle());
+  }, [dispatch]);
 
   return (
     <Tab.Navigator
@@ -228,6 +244,18 @@ const MainTabs: React.FC = () => {
         options={{
           headerShown: false,
           tabBarLabel: 'Ayarlar',
+          // Okunmamış yeni özellik varsa küçük nokta rozeti (anasayfa akışını bozmaz)
+          tabBarBadge: okunmamisVarMi ? '' : undefined,
+          tabBarBadgeStyle: {
+            backgroundColor: renkler.birincil,
+            minWidth: 10,
+            maxHeight: 10,
+            borderRadius: 5,
+            fontSize: 1,
+            lineHeight: 10,
+            alignSelf: 'center',
+            marginTop: 4,
+          },
           tabBarIcon: ({ focused, color, size }) => (
             <FontAwesome5 name="cog" size={20} color={focused ? renkler.birincil : renkler.metinIkincil} />
           ),

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -30,6 +30,7 @@ import {
   DebugLogsSayfasi,
   KazaDefteriSayfasi,
   KurulumSihirbaziSayfasi,
+  TakvimAyarlariSayfasi,
 } from '../presentation/screens';
 import { DEPOLAMA_ANAHTARLARI } from '../core/constants/UygulamaSabitleri';
 import { useRenkler } from '../core/theme';
@@ -117,6 +118,11 @@ const AyarlarStack: React.FC = () => {
         name="DebugLogs"
         component={DebugLogsSayfasi}
         options={{ title: 'Debug Logları' }}
+      />
+      <Stack.Screen
+        name="TakvimAyarlari"
+        component={TakvimAyarlariSayfasi}
+        options={{ title: 'Takvim Entegrasyonu' }}
       />
     </Stack.Navigator>
   );

--- a/src/presentation/components/KonumIzniDisclosureModali.tsx
+++ b/src/presentation/components/KonumIzniDisclosureModali.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react-native';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 import { useRenkler } from '../../core/theme';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 export type IzinTipi = 'onPlan' | 'arkaPlan';
 
@@ -180,6 +181,9 @@ export const KonumIzniDisclosureModali: React.FC<Props> = ({
 
   const handleKabul = () => kapatAnimasyonu(onKabul);
   const handleReddet = () => kapatAnimasyonu(onReddet);
+
+  // Geri tuşu = reddet (animasyonlu kapanış)
+  useDonanimGeriTusu(gorunur, handleReddet);
 
   const translateY = animDeger.interpolate({
     inputRange: [0, 1],

--- a/src/presentation/components/KutlamaModal.tsx
+++ b/src/presentation/components/KutlamaModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -24,6 +24,7 @@ import { KutlamaBilgisi, KutlamaTipi } from '../../core/types/SeriTipleri';
 import { LottieAnimasyon } from './LottieAnimasyon';
 import { PaylasimModal } from './Sharing/PaylasimModal';
 import { PaylasilabilirKutlama } from './Sharing/PaylasilabilirKutlama';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 const { width: EKRAN_GENISLIGI } = Dimensions.get('window');
 
@@ -84,6 +85,20 @@ export const KutlamaModal: React.FC<KutlamaModalProps> = ({
   const rotateAnim = useRef(new Animated.Value(0)).current;
   const konfettiAnim = useRef(new Animated.Value(0)).current;
 
+  const handleKapat = useCallback(() => {
+    // Cikis animasyonu
+    Animated.timing(scaleAnim, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => {
+      onKapat();
+    });
+  }, [scaleAnim, onKapat]);
+
+  // Paylaşım açıkken geri tuşu önce onu kapatsın; değilse kutlamayı kapat
+  useDonanimGeriTusu(gorunur && !!kutlama && !paylasimGorunur, handleKapat);
+
   useEffect(() => {
     if (gorunur) {
       // Giris animasyonu
@@ -124,17 +139,6 @@ export const KutlamaModal: React.FC<KutlamaModalProps> = ({
   // TypeScript tip guvenceligi icin explicit cast
   const kutlamaBilgisi = kutlama as any;
   const vurguRengi = kutlamaVurguRengiAl(kutlamaBilgisi.tip, renkler);
-
-  const handleKapat = () => {
-    // Cikis animasyonu
-    Animated.timing(scaleAnim, {
-      toValue: 0,
-      duration: 200,
-      useNativeDriver: true,
-    }).start(() => {
-      onKapat();
-    });
-  };
 
   const handlePaylasimAc = () => {
     setPaylasimGorunur(true);

--- a/src/presentation/components/OzelGunTakvimi.tsx
+++ b/src/presentation/components/OzelGunTakvimi.tsx
@@ -15,6 +15,7 @@ import {
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useRenkler } from '../../core/theme';
 import { BOYUTLAR } from '../../core/constants/UygulamaSabitleri';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 interface OzelGunTakvimiProps {
     gorunur: boolean;
@@ -33,6 +34,7 @@ export const OzelGunTakvimi: React.FC<OzelGunTakvimiProps> = ({
         new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // Varsayilan 7 gun
     );
     const [seciciModu, setSeciciModu] = useState<'baslangic' | 'bitis' | null>(null);
+    useDonanimGeriTusu(gorunur, onKapat);
 
     const handleTarihDegisimi = (_event: any, selectedDate?: Date) => {
         if (Platform.OS === 'android') {

--- a/src/presentation/components/Sharing/PaylasimModal.tsx
+++ b/src/presentation/components/Sharing/PaylasimModal.tsx
@@ -6,6 +6,7 @@ import { FontAwesome5 } from '@expo/vector-icons';
 import { useRenkler } from '../../../core/theme';
 import { BlurView } from 'expo-blur';
 import { Logger } from '../../../core/utils/Logger';
+import { useDonanimGeriTusu } from '../../hooks/useDonanimGeriTusu';
 
 interface PaylasimModalProps {
   gorunur: boolean;
@@ -22,6 +23,7 @@ export const PaylasimModal: React.FC<PaylasimModalProps> = ({
   const viewRef = useRef<View | null>(null);
   const [paylasiliyor, setPaylasiliyor] = useState(false);
   const [captureLayout, setCaptureLayout] = useState({ width: 0, height: 0 });
+  useDonanimGeriTusu(gorunur, onKapat);
 
   const paylas = async () => {
     try {

--- a/src/presentation/components/ToparlanmaModal.tsx
+++ b/src/presentation/components/ToparlanmaModal.tsx
@@ -7,6 +7,7 @@ import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { ToparlanmaKarti } from './ToparlanmaKarti';
 import type { ToparlanmaDurumu } from '../../core/types/SeriTipleri';
 import { useRenkler } from '../../core/theme';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 interface ToparlanmaModalProps {
   gorunur: boolean;
@@ -22,6 +23,7 @@ export const ToparlanmaModal: React.FC<ToparlanmaModalProps> = ({
   oncekiSeri,
 }) => {
   const renkler = useRenkler();
+  useDonanimGeriTusu(gorunur, onKapat);
 
   return (
     <Modal

--- a/src/presentation/components/YeniOzellikKarti.tsx
+++ b/src/presentation/components/YeniOzellikKarti.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, TouchableOpacity, Animated, Easing } from 'react-native';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import { useRenkler } from '../../core/theme';
+import type { YeniOzellik } from '../../core/constants/YeniOzellikler';
+
+interface YeniOzellikKartiProps {
+    ozellik: YeniOzellik;
+    /** CTA / karta dokunma → özelliği aç (görüldü işaretlenir) */
+    onAc: () => void;
+    /** X → kartı kapat (rozet kalır) */
+    onKapat: () => void;
+}
+
+/**
+ * Ayarlar ekranının üstünde görünen, kapatılabilir tanıtım kartı.
+ * Çekirdek akışa (anasayfa/vakit) dokunmaz; yalnızca Ayarlar'a girince görünür.
+ */
+export const YeniOzellikKarti: React.FC<YeniOzellikKartiProps> = ({ ozellik, onAc, onKapat }) => {
+    const renkler = useRenkler();
+    const opacity = useRef(new Animated.Value(0)).current;
+    const translateY = useRef(new Animated.Value(-12)).current;
+
+    useEffect(() => {
+        Animated.parallel([
+            Animated.timing(opacity, { toValue: 1, duration: 320, useNativeDriver: true }),
+            Animated.timing(translateY, {
+                toValue: 0, duration: 320, easing: Easing.out(Easing.cubic), useNativeDriver: true,
+            }),
+        ]).start();
+    }, [opacity, translateY]);
+
+    return (
+        <Animated.View
+            style={{
+                opacity,
+                transform: [{ translateY }],
+                marginHorizontal: 16,
+                marginBottom: 16,
+                borderRadius: 16,
+                overflow: 'hidden',
+                borderWidth: 1,
+                borderColor: `${renkler.birincil}40`,
+                backgroundColor: `${renkler.birincil}10`,
+            }}
+        >
+            <View className="p-4">
+                <View className="flex-row items-center mb-2">
+                    <View
+                        className="px-2 py-0.5 rounded-full mr-2"
+                        style={{ backgroundColor: renkler.birincil }}
+                    >
+                        <Text style={{ color: '#FFF', fontSize: 10, fontWeight: '700', letterSpacing: 0.3 }}>
+                            YENİ
+                        </Text>
+                    </View>
+                    <Text className="text-xs font-semibold" style={{ color: renkler.birincil }}>
+                        Uygulamaya eklendi
+                    </Text>
+                    <TouchableOpacity
+                        onPress={onKapat}
+                        hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
+                        style={{ marginLeft: 'auto' }}
+                    >
+                        <FontAwesome5 name="times" size={14} color={renkler.metinIkincil} />
+                    </TouchableOpacity>
+                </View>
+
+                <View className="flex-row items-start">
+                    <View
+                        className="w-11 h-11 rounded-2xl items-center justify-center mr-3"
+                        style={{ backgroundColor: `${renkler.birincil}20` }}
+                    >
+                        <FontAwesome5 name={ozellik.ikon} size={18} color={renkler.birincil} solid />
+                    </View>
+                    <View className="flex-1">
+                        <Text className="text-base font-bold" style={{ color: renkler.metin }}>
+                            {ozellik.baslik}
+                        </Text>
+                        <Text className="text-xs mt-1 leading-5" style={{ color: renkler.metinIkincil }}>
+                            {ozellik.aciklama}
+                        </Text>
+                    </View>
+                </View>
+
+                <TouchableOpacity
+                    className="flex-row items-center justify-center mt-3 py-3 rounded-xl"
+                    style={{ backgroundColor: renkler.birincil }}
+                    onPress={onAc}
+                    activeOpacity={0.85}
+                >
+                    <FontAwesome5 name="arrow-right" size={13} color="#FFF" style={{ marginRight: 8 }} />
+                    <Text className="text-sm font-semibold" style={{ color: '#FFF' }}>
+                        {ozellik.ctaEtiketi ?? 'İncele'}
+                    </Text>
+                </TouchableOpacity>
+            </View>
+        </Animated.View>
+    );
+};

--- a/src/presentation/components/YeniRozet.tsx
+++ b/src/presentation/components/YeniRozet.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Text } from 'react-native';
+import { useRenkler } from '../../core/theme';
+
+interface YeniRozetProps {
+    /** Metin (varsayılan: "Yeni") */
+    etiket?: string;
+}
+
+/**
+ * Küçük "Yeni" rozeti — menü öğeleri ve başlıkların yanında kullanılır.
+ * Hafif bir nabız animasyonuyla dikkat çeker ama rahatsız etmez.
+ */
+export const YeniRozet: React.FC<YeniRozetProps> = ({ etiket = 'Yeni' }) => {
+    const renkler = useRenkler();
+    const nabiz = useRef(new Animated.Value(1)).current;
+
+    useEffect(() => {
+        const animasyon = Animated.loop(
+            Animated.sequence([
+                Animated.timing(nabiz, { toValue: 1.12, duration: 850, useNativeDriver: true }),
+                Animated.timing(nabiz, { toValue: 1, duration: 850, useNativeDriver: true }),
+            ])
+        );
+        animasyon.start();
+        return () => animasyon.stop();
+    }, [nabiz]);
+
+    return (
+        <Animated.View
+            style={{
+                backgroundColor: renkler.birincil,
+                borderRadius: 999,
+                paddingHorizontal: 8,
+                paddingVertical: 2,
+                transform: [{ scale: nabiz }],
+            }}
+        >
+            <Text style={{ color: '#FFF', fontSize: 10, fontWeight: '700', letterSpacing: 0.3 }}>
+                {etiket}
+            </Text>
+        </Animated.View>
+    );
+};

--- a/src/presentation/components/guncelleme/GuncellemeBildirimi.tsx
+++ b/src/presentation/components/guncelleme/GuncellemeBildirimi.tsx
@@ -247,7 +247,7 @@ export const GuncellemeBildirimi: React.FC = () => {
                   color: renkler.bilgi,
                 }}
               >
-                v{bilgi.yeniVersiyon}
+                {bilgi.yeniVersiyonEtiketi ?? `v${bilgi.yeniVersiyon}`}
               </Text>
               {formatlananTarih ? (
                 <Text

--- a/src/presentation/components/home/SeriKartiModal.tsx
+++ b/src/presentation/components/home/SeriKartiModal.tsx
@@ -6,6 +6,7 @@ import { BlurView } from 'expo-blur';
 import { useTema } from '../../../core/theme';
 import { PaylasimModal } from '../Sharing/PaylasimModal';
 import { PaylasilabilirSeri } from '../Sharing/PaylasilabilirSeri';
+import { useDonanimGeriTusu } from '../../hooks/useDonanimGeriTusu';
 
 interface SeriKartiModalProps {
     gorunur: boolean;
@@ -22,6 +23,8 @@ export const SeriKartiModal: React.FC<SeriKartiModalProps> = ({
 }) => {
     const { koyuMu } = useTema();
     const [paylasimModalGorunur, setPaylasimModalGorunur] = useState(false);
+    // Paylaşım modalı açıkken geri tuşu önce onu kapatsın, değilse ana modalı
+    useDonanimGeriTusu(gorunur && !paylasimModalGorunur, onKapat);
 
     // Hedef hesaplama (basit mantık: sonraki eşiği bul)
     const hedefler = [7, 21, 60];

--- a/src/presentation/hooks/useDonanimGeriTusu.ts
+++ b/src/presentation/hooks/useDonanimGeriTusu.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { BackHandler } from 'react-native';
+
+/**
+ * Android donanim geri tusunu guvenilir sekilde yakalar.
+ *
+ * Neden gerekli: New Architecture (Fabric) altinda RN <Modal> bileseninin
+ * `onRequestClose` callback'i Android donanim geri tusunda guvenilir
+ * tetiklenmiyor. Acik modal/overlay'lerde geri tusuyla kapatma davranisini
+ * garanti altina almak icin BackHandler dinleyicisi kullaniyoruz.
+ *
+ * @param aktif   Dinleyici aktif mi (ornegin modal gorunur oldugunda true).
+ * @param handler Geri tusuna basildiginda calisir. `false` donerse olay
+ *                tuketilmez ve normal davranis (navigasyon/cikis) devam eder;
+ *                aksi halde (true/undefined) olay tuketilir.
+ */
+export function useDonanimGeriTusu(
+    aktif: boolean,
+    handler: () => boolean | void
+): void {
+    useEffect(() => {
+        if (!aktif) return;
+
+        const abone = BackHandler.addEventListener('hardwareBackPress', () => {
+            const sonuc = handler();
+            // undefined veya true => olayi tuket (modal kapanir, ekran degismez)
+            return sonuc !== false;
+        });
+
+        return () => abone.remove();
+    }, [aktif, handler]);
+}

--- a/src/presentation/hooks/useYeniOzellikler.ts
+++ b/src/presentation/hooks/useYeniOzellikler.ts
@@ -1,0 +1,60 @@
+import { useMemo, useCallback } from 'react';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+    ozellikGorulduIsaretle,
+    ozellikKartiKapat,
+} from '../store/ozelliklerSlice';
+import { YENI_OZELLIKLER, type YeniOzellik } from '../../core/constants/YeniOzellikler';
+
+/**
+ * Yeni özellik duyurularının ortak erişim noktası.
+ * Rozet, tanıtım kartı ve "Neler Yeni" sayfası bu hook'tan beslenir.
+ */
+export function useYeniOzellikler() {
+    const dispatch = useAppDispatch();
+    const { gorulenIdler, kapatilanKartIdler } = useAppSelector(s => s.ozellikler);
+
+    const okunmamis = useMemo(
+        () => YENI_OZELLIKLER.filter(o => !gorulenIdler.includes(o.id)),
+        [gorulenIdler]
+    );
+
+    // Ayarlar üstünde gösterilecek tek tanıtım kartı (en güncel, kapatılmamış)
+    const kart = useMemo<YeniOzellik | null>(
+        () => okunmamis.find(o => o.kartGoster && !kapatilanKartIdler.includes(o.id)) ?? null,
+        [okunmamis, kapatilanKartIdler]
+    );
+
+    const sayfaOkunmamisMi = useCallback(
+        (sayfa: string) => okunmamis.some(o => o.hedefSayfa === sayfa),
+        [okunmamis]
+    );
+
+    const isaretle = useCallback(
+        (id: string | string[]) => { dispatch(ozellikGorulduIsaretle(id)); },
+        [dispatch]
+    );
+
+    const sayfayiGorulduIsaretle = useCallback(
+        (sayfa: string) => {
+            const idler = okunmamis.filter(o => o.hedefSayfa === sayfa).map(o => o.id);
+            if (idler.length > 0) dispatch(ozellikGorulduIsaretle(idler));
+        },
+        [dispatch, okunmamis]
+    );
+
+    const kartiKapat = useCallback(
+        (id: string) => { dispatch(ozellikKartiKapat(id)); },
+        [dispatch]
+    );
+
+    return {
+        okunmamis,
+        okunmamisVarMi: okunmamis.length > 0,
+        kart,
+        sayfaOkunmamisMi,
+        isaretle,
+        sayfayiGorulduIsaretle,
+        kartiKapat,
+    };
+}

--- a/src/presentation/screens/AyarlarSayfasi.tsx
+++ b/src/presentation/screens/AyarlarSayfasi.tsx
@@ -22,6 +22,9 @@ import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useRenkler } from '../../core/theme';
 import { useFeedback } from '../../core/feedback';
+import { useYeniOzellikler } from '../hooks/useYeniOzellikler';
+import { YeniRozet } from '../components/YeniRozet';
+import { YeniOzellikKarti } from '../components/YeniOzellikKarti';
 
 // Ikon tipleri
 type IkonTipi = {
@@ -40,6 +43,7 @@ const MENU_IKONLARI: Record<string, IkonTipi> = {
   ramazan: { name: 'moon', family: 'fa5', solid: true },
   hakkinda: { name: 'info-circle', family: 'fa5', solid: true },
   takvim: { name: 'calendar-alt', family: 'fa5', solid: true },
+  nelerYeni: { name: 'gift', family: 'fa5', solid: true },
   titresim: { name: 'vibration', family: 'material' },
   ses: { name: 'volume-up', family: 'fa5', solid: true },
 };
@@ -52,6 +56,7 @@ interface AyarMenuSatiriProps {
   aciklama: string;
   ikonAdi: string;
   onPress: () => void;
+  yeni?: boolean;
 }
 
 /**
@@ -62,6 +67,7 @@ const AyarMenuSatiri: React.FC<AyarMenuSatiriProps> = ({
   aciklama,
   ikonAdi,
   onPress,
+  yeni,
 }) => {
   const renkler = useRenkler();
   const { butonTiklandiFeedback } = useFeedback();
@@ -99,12 +105,19 @@ const AyarMenuSatiri: React.FC<AyarMenuSatiriProps> = ({
         )}
       </View>
       <View className="flex-1">
-        <Text
-          className="text-base font-semibold"
-          style={{ color: renkler.metin }}
-        >
-          {baslik}
-        </Text>
+        <View className="flex-row items-center">
+          <Text
+            className="text-base font-semibold"
+            style={{ color: renkler.metin }}
+          >
+            {baslik}
+          </Text>
+          {yeni && (
+            <View className="ml-2">
+              <YeniRozet />
+            </View>
+          )}
+        </View>
         <Text
           className="text-xs mt-0.5"
           style={{ color: renkler.metinIkincil }}
@@ -205,6 +218,7 @@ const ToggleAyarSatiri: React.FC<ToggleAyarSatiriProps> = ({
 export const AyarlarSayfasi: React.FC<any> = ({ navigation }) => {
   const renkler = useRenkler();
   const { ayarlar, titresimDurumunuDegistir, sesDurumunuDegistir } = useFeedback();
+  const { kart, okunmamisVarMi, sayfaOkunmamisMi, sayfayiGorulduIsaretle, kartiKapat } = useYeniOzellikler();
 
   // Giris animasyonu
   const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -271,12 +285,24 @@ export const AyarlarSayfasi: React.FC<any> = ({ navigation }) => {
       sayfa: 'TakvimAyarlari',
     },
     {
+      baslik: 'Neler Yeni',
+      aciklama: 'Uygulamaya eklenen yeni özellikler',
+      ikonAdi: 'nelerYeni',
+      sayfa: 'NelerYeni',
+    },
+    {
       baslik: 'Hakkında',
       aciklama: 'Uygulama bilgileri ve versiyon',
       ikonAdi: 'hakkinda',
       sayfa: 'Hakkinda',
     },
   ];
+
+  // Bir menü öğesi açılınca ilgili özelliği (varsa) görüldü işaretle, sonra geç
+  const menuyeGit = (sayfa: string) => {
+    if (sayfa !== 'NelerYeni') sayfayiGorulduIsaretle(sayfa);
+    navigation.navigate(sayfa);
+  };
 
   return (
     <SafeAreaView className="flex-1" style={{ backgroundColor: renkler.arkaplan }} edges={['top', 'left', 'right']}>
@@ -291,6 +317,17 @@ export const AyarlarSayfasi: React.FC<any> = ({ navigation }) => {
           transform: [{ translateY: slideAnim }],
         }}
       >
+        {/* Yeni Özellik Tanıtım Kartı (yalnızca Ayarlar'da; anasayfaya dokunmaz) */}
+        {kart && (
+          <YeniOzellikKarti
+            ozellik={kart}
+            onAc={() => {
+              if (kart.hedefSayfa) menuyeGit(kart.hedefSayfa);
+            }}
+            onKapat={() => kartiKapat(kart.id)}
+          />
+        )}
+
         {/* Ana Menu Bolumu */}
         <View className="mb-6">
           {menuOgeleri.map((oge) => (
@@ -299,7 +336,8 @@ export const AyarlarSayfasi: React.FC<any> = ({ navigation }) => {
               baslik={oge.baslik}
               aciklama={oge.aciklama}
               ikonAdi={oge.ikonAdi}
-              onPress={() => navigation.navigate(oge.sayfa)}
+              yeni={oge.sayfa === 'NelerYeni' ? okunmamisVarMi : sayfaOkunmamisMi(oge.sayfa)}
+              onPress={() => menuyeGit(oge.sayfa)}
             />
           ))}
         </View>

--- a/src/presentation/screens/AyarlarSayfasi.tsx
+++ b/src/presentation/screens/AyarlarSayfasi.tsx
@@ -39,6 +39,7 @@ const MENU_IKONLARI: Record<string, IkonTipi> = {
   hedef: { name: 'bullseye', family: 'fa5', solid: true },
   ramazan: { name: 'moon', family: 'fa5', solid: true },
   hakkinda: { name: 'info-circle', family: 'fa5', solid: true },
+  takvim: { name: 'calendar-alt', family: 'fa5', solid: true },
   titresim: { name: 'vibration', family: 'material' },
   ses: { name: 'volume-up', family: 'fa5', solid: true },
 };
@@ -262,6 +263,12 @@ export const AyarlarSayfasi: React.FC<any> = ({ navigation }) => {
       aciklama: 'İftar sayacı ve Ramazan ayarları',
       ikonAdi: 'ramazan',
       sayfa: 'RamazanAyarlari',
+    },
+    {
+      baslik: 'Takvim Entegrasyonu',
+      aciklama: 'Namaz vakitlerini cihaz takviminize ekle',
+      ikonAdi: 'takvim',
+      sayfa: 'TakvimAyarlari',
     },
     {
       baslik: 'Hakkında',

--- a/src/presentation/screens/HakkindaSayfasi.tsx
+++ b/src/presentation/screens/HakkindaSayfasi.tsx
@@ -137,7 +137,7 @@ export const HakkindaSayfasi: React.FC = () => {
   const guncellemeDurumMetni = kontrolEdiliyor
     ? 'Kontrol ediliyor...'
     : guncellemeMevcut && bilgi
-      ? `v${bilgi.yeniVersiyon} mevcut`
+      ? `${bilgi.yeniVersiyonEtiketi ?? `v${bilgi.yeniVersiyon}`} mevcut`
       : 'Güncel';
 
   const guncellemeDurumRengi = guncellemeMevcut && bilgi

--- a/src/presentation/screens/KazaDefteriSayfasi.tsx
+++ b/src/presentation/screens/KazaDefteriSayfasi.tsx
@@ -35,6 +35,7 @@ import {
   tahminiTarihiFormatla,
   motivasyonOnerileriHesapla,
 } from '../../domain/services/KazaHesaplayiciServisi';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 // ==================== TİPLER ====================
 
@@ -84,6 +85,16 @@ export const KazaDefteriSayfasi: React.FC = () => {
 
   // Animasyon: tamamlama flash
   const flashAnim = useRef(new Animated.Value(1)).current;
+
+  // Donanım geri tuşu: sihirbazda önceki adıma dön, değilse aktif modalı kapat
+  const handleModalGeri = useCallback(() => {
+    if (aktifModal?.tip === 'sihirbaz' && aktifModal.adim > 1) {
+      setAktifModal({ tip: 'sihirbaz', adim: (aktifModal.adim - 1) as 1 | 2 | 3 });
+    } else {
+      setAktifModal(null);
+    }
+  }, [aktifModal]);
+  useDonanimGeriTusu(aktifModal !== null, handleModalGeri);
 
   // ==================== YÜKLEME ====================
 

--- a/src/presentation/screens/KonumAyarlariSayfasi.tsx
+++ b/src/presentation/screens/KonumAyarlariSayfasi.tsx
@@ -36,6 +36,7 @@ import { KonumTakipServisi } from '../../domain/services/KonumTakipServisi';
 import { useFeedback } from '../../core/feedback';
 import { Logger } from '../../core/utils/Logger';
 import { KonumIzniDisclosureModali, IzinTipi } from '../components/KonumIzniDisclosureModali';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 const { height: EKRAN_YUKSEKLIGI } = Dimensions.get('window');
 
@@ -157,6 +158,13 @@ const IlIlceSecici: React.FC<IlIlceSeciciProps> = ({
         setSecilenIl(null);
         setAramaMetni('');
     }, []);
+
+    // Geri tuşu: ilçe adımındaysa il adımına dön, değilse modalı kapat
+    const handleModalGeri = useCallback(() => {
+        if (adim === 'ilce') geriHandler();
+        else modalKapat();
+    }, [adim, geriHandler, modalKapat]);
+    useDonanimGeriTusu(modalGorunum, handleModalGeri);
 
     const ilOgesiRender = useCallback(({ item }: { item: Il }) => {
         const seciliMi = item.id === seciliIlId;

--- a/src/presentation/screens/NelerYeniSayfasi.tsx
+++ b/src/presentation/screens/NelerYeniSayfasi.tsx
@@ -1,0 +1,215 @@
+/**
+ * Neler Yeni Sayfası
+ * Uygulamaya eklenen yeni özelliklerin kronolojik, açılır-kapanır listesi.
+ * Kapalı görünüm özelliğin ~%70'ini anlatır; dokununca detay açılır.
+ * Sayfaya girince tüm özellikler "görüldü" işaretlenir (rozetler kalkar).
+ */
+
+import * as React from 'react';
+import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
+import {
+    View, Text, ScrollView, TouchableOpacity, Animated, Easing,
+    LayoutAnimation, Platform, UIManager,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import { useRenkler } from '../../core/theme';
+import { useAppDispatch } from '../store/hooks';
+import { ozellikGorulduIsaretle } from '../store/ozelliklerSlice';
+import { YENI_OZELLIKLER, type YeniOzellik } from '../../core/constants/YeniOzellikler';
+import { useFeedback } from '../../core/feedback';
+
+// Android'de LayoutAnimation'ı etkinleştir (eski mimari güvencesi)
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+function tarihFormatla(iso: string): string {
+    const [yil, ay, gun] = iso.split('-');
+    const aylar = ['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık'];
+    const ayIdx = parseInt(ay, 10) - 1;
+    return `${parseInt(gun, 10)} ${aylar[ayIdx] ?? ''} ${yil}`;
+}
+
+interface OzellikKartiProps {
+    ozellik: YeniOzellik;
+    acik: boolean;
+    onTogglePress: () => void;
+    onAc?: () => void;
+}
+
+const OzellikKarti: React.FC<OzellikKartiProps> = ({ ozellik, acik, onTogglePress, onAc }) => {
+    const renkler = useRenkler();
+    const okAnim = useRef(new Animated.Value(acik ? 1 : 0)).current;
+
+    useEffect(() => {
+        Animated.timing(okAnim, {
+            toValue: acik ? 1 : 0,
+            duration: 220,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+        }).start();
+    }, [acik, okAnim]);
+
+    const okDonus = okAnim.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '90deg'] });
+
+    return (
+        <View
+            className="rounded-2xl mb-3 mx-4 overflow-hidden"
+            style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+        >
+            {/* Başlık satırı — her zaman görünür */}
+            <TouchableOpacity
+                className="flex-row items-center p-4"
+                onPress={onTogglePress}
+                activeOpacity={0.7}
+            >
+                <View
+                    className="w-11 h-11 rounded-2xl items-center justify-center mr-3"
+                    style={{ backgroundColor: `${renkler.birincil}15` }}
+                >
+                    <FontAwesome5 name={ozellik.ikon} size={18} color={renkler.birincil} solid />
+                </View>
+                <View className="flex-1 pr-2">
+                    <Text className="text-base font-bold" style={{ color: renkler.metin }}>
+                        {ozellik.baslik}
+                    </Text>
+                    <Text className="text-[11px] mt-0.5" style={{ color: renkler.metinIkincil }}>
+                        {tarihFormatla(ozellik.tarih)}  ·  v{ozellik.surum}
+                    </Text>
+                </View>
+                <Animated.View style={{ transform: [{ rotate: okDonus }] }}>
+                    <FontAwesome5 name="chevron-right" size={14} color={renkler.metinIkincil} />
+                </Animated.View>
+            </TouchableOpacity>
+
+            {/* Özet — kapalıyken de görünür (%70 anlaşılırlık) */}
+            <View className="px-4 pb-4 -mt-1">
+                <Text className="text-sm leading-5" style={{ color: renkler.metinIkincil }}>
+                    {ozellik.aciklama}
+                </Text>
+            </View>
+
+            {/* Detay — açılınca görünür */}
+            {acik && (
+                <View className="px-4 pb-4">
+                    <View style={{ height: 1, backgroundColor: renkler.sinir, marginBottom: 12 }} />
+
+                    {ozellik.detayAciklama && (
+                        <Text className="text-sm leading-6 mb-3" style={{ color: renkler.metin }}>
+                            {ozellik.detayAciklama}
+                        </Text>
+                    )}
+
+                    {ozellik.detaylar && ozellik.detaylar.length > 0 && (
+                        <View className="gap-2">
+                            {ozellik.detaylar.map((d, i) => (
+                                <View key={i} className="flex-row items-start">
+                                    <FontAwesome5
+                                        name="check-circle"
+                                        size={13}
+                                        color={renkler.birincil}
+                                        style={{ marginTop: 2, marginRight: 8 }}
+                                    />
+                                    <Text className="flex-1 text-sm leading-5" style={{ color: renkler.metin }}>
+                                        {d}
+                                    </Text>
+                                </View>
+                            ))}
+                        </View>
+                    )}
+
+                    {ozellik.hedefSayfa && onAc && (
+                        <TouchableOpacity
+                            className="flex-row items-center justify-center mt-4 py-3 rounded-xl"
+                            style={{ backgroundColor: renkler.birincil }}
+                            onPress={onAc}
+                            activeOpacity={0.85}
+                        >
+                            <FontAwesome5 name="arrow-right" size={13} color="#FFF" style={{ marginRight: 8 }} />
+                            <Text className="text-sm font-semibold" style={{ color: '#FFF' }}>
+                                {ozellik.ctaEtiketi ?? 'İnceleyin'}
+                            </Text>
+                        </TouchableOpacity>
+                    )}
+                </View>
+            )}
+        </View>
+    );
+};
+
+export const NelerYeniSayfasi: React.FC<any> = ({ navigation }) => {
+    const renkler = useRenkler();
+    const dispatch = useAppDispatch();
+    const { butonTiklandiFeedback } = useFeedback();
+
+    const fadeAnim = useRef(new Animated.Value(0)).current;
+    const slideAnim = useRef(new Animated.Value(20)).current;
+
+    // Kronolojik (en yeni üstte)
+    const siraliOzellikler = useMemo(
+        () => [...YENI_OZELLIKLER].sort((a, b) => b.tarih.localeCompare(a.tarih)),
+        []
+    );
+
+    // En güncel özellik başta açık gelsin
+    const [acikIdler, setAcikIdler] = useState<Set<string>>(
+        () => new Set(siraliOzellikler.length > 0 ? [siraliOzellikler[0].id] : [])
+    );
+
+    const toggle = useCallback(async (id: string) => {
+        await butonTiklandiFeedback();
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setAcikIdler(prev => {
+            const yeni = new Set(prev);
+            if (yeni.has(id)) yeni.delete(id); else yeni.add(id);
+            return yeni;
+        });
+    }, [butonTiklandiFeedback]);
+
+    useEffect(() => {
+        // Sayfayı görünce tüm özellikler okundu sayılır → rozetler kalkar
+        dispatch(ozellikGorulduIsaretle(YENI_OZELLIKLER.map(o => o.id)));
+
+        Animated.parallel([
+            Animated.timing(fadeAnim, { toValue: 1, duration: 350, useNativeDriver: true }),
+            Animated.timing(slideAnim, { toValue: 0, duration: 350, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+        ]).start();
+    }, []);
+
+    const handleAc = async (sayfa: string) => {
+        await butonTiklandiFeedback();
+        navigation.navigate(sayfa);
+    };
+
+    return (
+        <SafeAreaView className="flex-1" style={{ backgroundColor: renkler.arkaplan }} edges={['bottom', 'left', 'right']}>
+            <ScrollView
+                className="flex-1"
+                contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+                showsVerticalScrollIndicator={false}
+            >
+                <Animated.View style={{ opacity: fadeAnim, transform: [{ translateY: slideAnim }] }}>
+                    <View className="px-4 mb-4">
+                        <Text className="text-2xl font-bold" style={{ color: renkler.metin }}>
+                            Neler Yeni
+                        </Text>
+                        <Text className="text-sm mt-1 leading-5" style={{ color: renkler.metinIkincil }}>
+                            Namaz Akışı'na eklenen yeni özellikleri burada bulabilirsiniz. Detay için bir başlığa dokunun.
+                        </Text>
+                    </View>
+
+                    {siraliOzellikler.map(ozellik => (
+                        <OzellikKarti
+                            key={ozellik.id}
+                            ozellik={ozellik}
+                            acik={acikIdler.has(ozellik.id)}
+                            onTogglePress={() => toggle(ozellik.id)}
+                            onAc={ozellik.hedefSayfa ? () => handleAc(ozellik.hedefSayfa!) : undefined}
+                        />
+                    ))}
+                </Animated.View>
+            </ScrollView>
+        </SafeAreaView>
+    );
+};

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -1279,8 +1279,8 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
                                         tip="temizleme"
                                         baslik="Etkinlikler Temizlendi"
                                         altBaslik={silinenSayi > 0
-                                            ? 'Seçtiğin etkinlikler takvimden başarıyla silindi.'
-                                            : 'Belirtilen kriterlerde silinecek etkinlik kalmadı.'}
+                                            ? 'Seçtiğiniz etkinlikler takviminizden başarıyla silindi.'
+                                            : 'Belirttiğiniz kriterlerde silinecek etkinlik kalmadı.'}
                                         satirlar={temizlemeOzetSatirlari}
                                         onTakvimiAc={handleTakvimiAc}
                                         onKapat={onKapat}
@@ -1760,8 +1760,8 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 tip="olusturma"
                                 baslik="Etkinlikler Oluşturuldu"
                                 altBaslik={olusturmaSonucu.sayi > 0
-                                    ? 'Namaz vakitlerin takvimine başarıyla eklendi.'
-                                    : 'Eklenecek aktif vakit bulunamadı. Vakit ayarlarını kontrol et.'}
+                                    ? 'Namaz vakitleriniz takviminize başarıyla eklendi.'
+                                    : 'Eklenecek aktif vakit bulunamadı. Lütfen vakit ayarlarınızı kontrol edin.'}
                                 satirlar={[
                                     { ikon: 'calendar-check', etiket: 'Oluşturulan', deger: `${olusturmaSonucu.sayi} etkinlik` },
                                     { ikon: 'bookmark', etiket: 'Takvim', deger: ayarlar.takvimAdi ?? '—' },

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -9,12 +9,15 @@ import {
     View,
     Text,
     ScrollView,
+    FlatList,
     TouchableOpacity,
+    TouchableWithoutFeedback,
     Switch,
     ActivityIndicator,
-    Alert,
+    Modal,
     Animated,
     Easing,
+    Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
@@ -32,6 +35,7 @@ import { TakvimServisi } from '../../domain/services/TakvimServisi';
 import { NamazVaktiHesaplayiciServisi } from '../../domain/services/NamazVaktiHesaplayiciServisi';
 import { useFeedback } from '../../core/feedback';
 
+const { height: EKRAN_YUKSEKLIGI } = Dimensions.get('window');
 const THROTTLE_SURESI = 100;
 
 const VAKIT_GORUNTU_ADLARI: Record<TakvimVakitAdi, string> = {
@@ -43,6 +47,15 @@ const VAKIT_GORUNTU_ADLARI: Record<TakvimVakitAdi, string> = {
 };
 
 const VAKIT_SIRASI: TakvimVakitAdi[] = ['imsak', 'ogle', 'ikindi', 'aksam', 'yatsi'];
+
+// Event title → temizle filtresi için
+const VAKIT_TEMIZLE_BASLIK: Record<TakvimVakitAdi, string> = {
+    imsak:  'Sabah Namazı',
+    ogle:   'Öğle Namazı',
+    ikindi: 'İkindi Namazı',
+    aksam:  'Akşam Namazı',
+    yatsi:  'Yatsı Namazı',
+};
 
 // ─── SayisalSecici ────────────────────────────────────────────────────────────
 
@@ -120,10 +133,10 @@ interface VakitAyarSatiriProps {
     sonMu: boolean;
 }
 
-const BASLANGIC_TIPLERI: { tip: BaslangicTipi; etiket: string }[] = [
-    { tip: 'vakit_oncesi',  etiket: 'Çıkmadan Önce' },
-    { tip: 'vakit_girisi',  etiket: 'Vakitte' },
-    { tip: 'vakit_sonrasi', etiket: 'Vakitten Sonra' },
+const BASLANGIC_TIPLERI: { tip: BaslangicTipi; etiket: string; aciklama: string }[] = [
+    { tip: 'vakit_oncesi',  etiket: 'Çıkmadan Önce', aciklama: 'Vakit bitmeden X dk önce' },
+    { tip: 'vakit_girisi',  etiket: 'Vakitte',        aciklama: 'Tam vakit girince başlar' },
+    { tip: 'vakit_sonrasi', etiket: 'Vakitten Sonra', aciklama: 'Vakit girdikten X dk sonra' },
 ];
 
 const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
@@ -136,7 +149,6 @@ const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
             className="py-3"
             style={!sonMu ? { borderBottomWidth: 1, borderBottomColor: renkler.sinir } : undefined}
         >
-            {/* Vakit başlığı + toggle */}
             <View className="flex-row justify-between items-center">
                 <Text className="text-sm font-semibold" style={{ color: renkler.metin }}>
                     {gorununumAdi} Vakti
@@ -149,10 +161,8 @@ const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
                 />
             </View>
 
-            {/* Aktifse detay ayarlar */}
             {ayar.aktif && (
                 <View className="mt-3 gap-3">
-                    {/* Başlangıç tipi seçici */}
                     <View>
                         <Text className="text-xs mb-2" style={{ color: renkler.metinIkincil }}>
                             Etkinlik Ne Zaman Başlasın
@@ -185,7 +195,6 @@ const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
                         </View>
                     </View>
 
-                    {/* Dakika seçici — sadece önce/sonra durumunda */}
                     {ayar.baslangicTipi !== 'vakit_girisi' && (
                         <View className="flex-row justify-between items-center">
                             <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
@@ -203,7 +212,6 @@ const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
                         </View>
                     )}
 
-                    {/* Süre seçici */}
                     <View className="flex-row justify-between items-center">
                         <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
                             Etkinlik Süresi
@@ -235,9 +243,13 @@ interface OnizlemeSatiriProps {
 }
 
 function saatFormatla(tarih: Date): string {
-    const s = tarih.getHours().toString().padStart(2, '0');
-    const d = tarih.getMinutes().toString().padStart(2, '0');
-    return `${s}:${d}`;
+    return `${tarih.getHours().toString().padStart(2, '0')}:${tarih.getMinutes().toString().padStart(2, '0')}`;
+}
+
+function tarihSaatFormatla(tarih: Date): string {
+    const gun = tarih.getDate().toString().padStart(2, '0');
+    const ay = (tarih.getMonth() + 1).toString().padStart(2, '0');
+    return `${gun}.${ay}  ${saatFormatla(tarih)}`;
 }
 
 const OnizlemeSatiri: React.FC<OnizlemeSatiriProps> = ({
@@ -253,15 +265,9 @@ const OnizlemeSatiri: React.FC<OnizlemeSatiriProps> = ({
     let startDate: Date;
     const ms = (ayar.dakika || 0) * 60 * 1000;
     switch (ayar.baslangicTipi) {
-        case 'vakit_girisi':
-            startDate = new Date(girisSaati);
-            break;
-        case 'vakit_sonrasi':
-            startDate = new Date(girisSaati.getTime() + ms);
-            break;
-        case 'vakit_oncesi':
-            startDate = new Date(cikisSaati.getTime() - ms);
-            break;
+        case 'vakit_girisi':  startDate = new Date(girisSaati); break;
+        case 'vakit_sonrasi': startDate = new Date(girisSaati.getTime() + ms); break;
+        case 'vakit_oncesi':  startDate = new Date(cikisSaati.getTime() - ms); break;
     }
     const endDate = new Date(startDate.getTime() + ayar.sureDakika * 60 * 1000);
 
@@ -289,8 +295,7 @@ const OnizlemeSatiri: React.FC<OnizlemeSatiriProps> = ({
                     {gorununumAdi} Namazı
                 </Text>
                 <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
-                    {saatFormatla(startDate)} – {saatFormatla(endDate)}
-                    {'  '}({ayar.sureDakika} dk)
+                    {saatFormatla(startDate)} – {saatFormatla(endDate)}{'  '}({ayar.sureDakika} dk)
                 </Text>
                 <Text className="text-xs mt-0.5" style={{ color: renkler.metinIkincil }}>
                     {baslangicAciklamasi}
@@ -300,7 +305,578 @@ const OnizlemeSatiri: React.FC<OnizlemeSatiriProps> = ({
     );
 };
 
+// ─── BildirimBanneri ──────────────────────────────────────────────────────────
+
+interface BildirimBanneriProps {
+    mesaj: string;
+    tip: 'basari' | 'hata' | 'bilgi';
+    onKapat: () => void;
+}
+
+const BildirimBanneri: React.FC<BildirimBanneriProps> = ({ mesaj, tip, onKapat }) => {
+    const renkler = useRenkler();
+    const renk = tip === 'basari' ? '#22C55E' : tip === 'hata' ? '#EF4444' : renkler.birincil;
+    const ikon = tip === 'basari' ? 'check-circle' : tip === 'hata' ? 'exclamation-circle' : 'info-circle';
+
+    return (
+        <View
+            className="flex-row items-center p-3.5 rounded-xl mb-3"
+            style={{ backgroundColor: `${renk}15`, borderWidth: 1, borderColor: `${renk}40` }}
+        >
+            <FontAwesome5 name={ikon} size={16} color={renk} style={{ marginRight: 10 }} />
+            <Text className="flex-1 text-sm leading-5" style={{ color: renkler.metin }}>{mesaj}</Text>
+            <TouchableOpacity
+                onPress={onKapat}
+                hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+            >
+                <FontAwesome5 name="times" size={13} color={renkler.metinIkincil} />
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+// ─── OzellikBilgi (inactive state) ────────────────────────────────────────────
+
+const OzellikBilgi: React.FC = () => {
+    const renkler = useRenkler();
+
+    const ozellikler = [
+        {
+            ikon: 'sliders-h',
+            baslik: 'Vakit Başına Özelleştirme',
+            aciklama: 'Her namaz için etkinlik süresi, başlangıç ve ofset ayrı ayrı ayarlanır.',
+        },
+        {
+            ikon: 'calendar-check',
+            baslik: 'Anlık Önizleme',
+            aciklama: 'Bugün için hesaplanan saatleri kaydetmeden önce ekranda görebilirsin.',
+        },
+        {
+            ikon: 'trash-alt',
+            baslik: 'Seçici Temizleme',
+            aciklama: 'Takvim, zaman aralığı ve vakit seçerek etkinlikleri istediğin gibi silebilirsin.',
+        },
+    ];
+
+    return (
+        <View
+            className="rounded-2xl p-5 mb-4"
+            style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+        >
+            <View className="items-center mb-5">
+                <View
+                    className="w-20 h-20 rounded-2xl items-center justify-center mb-3"
+                    style={{ backgroundColor: `${renkler.birincil}12` }}
+                >
+                    <FontAwesome5 name="calendar-alt" size={36} color={renkler.birincil} solid />
+                </View>
+                <Text className="text-base font-bold text-center" style={{ color: renkler.metin }}>
+                    Namaz Vakitlerini Takvimine Ekle
+                </Text>
+                <Text className="text-xs text-center mt-2 leading-5" style={{ color: renkler.metinIkincil }}>
+                    Seçtiğin vakitler için cihaz takvimine ileriye dönük etkinlikler otomatik oluşturulur.
+                </Text>
+            </View>
+
+            {ozellikler.map((o, i) => (
+                <View key={i} className={`flex-row items-start ${i < ozellikler.length - 1 ? 'mb-4' : ''}`}>
+                    <View
+                        className="w-9 h-9 rounded-xl items-center justify-center mr-3"
+                        style={{ backgroundColor: `${renkler.birincil}15` }}
+                    >
+                        <FontAwesome5 name={o.ikon} size={15} color={renkler.birincil} />
+                    </View>
+                    <View className="flex-1 justify-center">
+                        <Text className="text-sm font-semibold mb-0.5" style={{ color: renkler.metin }}>
+                            {o.baslik}
+                        </Text>
+                        <Text className="text-xs leading-4" style={{ color: renkler.metinIkincil }}>
+                            {o.aciklama}
+                        </Text>
+                    </View>
+                </View>
+            ))}
+
+            <View
+                className="mt-5 flex-row items-center justify-center p-3 rounded-xl gap-2"
+                style={{ backgroundColor: `${renkler.birincil}10` }}
+            >
+                <FontAwesome5 name="arrow-up" size={11} color={renkler.birincil} />
+                <Text className="text-xs font-medium" style={{ color: renkler.birincil }}>
+                    Başlamak için yukarıdaki düğmeyi aktif edin
+                </Text>
+            </View>
+        </View>
+    );
+};
+
+// ─── TemizleModali ────────────────────────────────────────────────────────────
+
+type TemizleAdim = 'kriter' | 'taraniyor' | 'onay';
+type TakvimModTipi = 'secili' | 'tumu';
+
+interface BulunanEtkinlik {
+    id: string;
+    title: string;
+    startDate: Date;
+    takvimId: string;
+}
+
+interface TemizleModaliProps {
+    gorunur: boolean;
+    onKapat: () => void;
+    onTemizlendi: (silinen: number, ozet: string) => void;
+    secilenTakvimId: string | null;
+    secilenTakvimAdi: string | null;
+    cihazTakvimleri: Array<{ id: string; title: string; color: string }>;
+}
+
+const ARALIK_PRESETLER: { gun: 7 | 30 | 90; etiket: string; aciklama: string }[] = [
+    { gun: 7,  etiket: '7 Gün',  aciklama: 'Bu hafta' },
+    { gun: 30, etiket: '30 Gün', aciklama: 'Bu ay' },
+    { gun: 90, etiket: '90 Gün', aciklama: '3 ay' },
+];
+
+const TemizleModali: React.FC<TemizleModaliProps> = ({
+    gorunur, onKapat, onTemizlendi,
+    secilenTakvimId, secilenTakvimAdi, cihazTakvimleri,
+}) => {
+    const renkler = useRenkler();
+
+    const [adim, setAdim] = useState<TemizleAdim>('kriter');
+    const [takvimMod, setTakvimMod] = useState<TakvimModTipi>('secili');
+    const [aralikGun, setAralikGun] = useState<7 | 30 | 90>(30);
+    const [secilenVakitler, setSecilenVakitler] = useState<Set<TakvimVakitAdi>>(
+        new Set<TakvimVakitAdi>(VAKIT_SIRASI)
+    );
+    const [bulunanEtkinlikler, setBulunanEtkinlikler] = useState<BulunanEtkinlik[]>([]);
+    const [siliniyor, setSiliniyor] = useState(false);
+
+    useEffect(() => {
+        if (!gorunur) {
+            setAdim('kriter');
+            setTakvimMod('secili');
+            setAralikGun(30);
+            setSecilenVakitler(new Set<TakvimVakitAdi>(VAKIT_SIRASI));
+            setBulunanEtkinlikler([]);
+            setSiliniyor(false);
+        }
+    }, [gorunur]);
+
+    const toggleVakit = (vakit: TakvimVakitAdi) => {
+        setSecilenVakitler(prev => {
+            const yeni = new Set(prev);
+            if (yeni.has(vakit)) {
+                if (yeni.size > 1) yeni.delete(vakit);
+            } else {
+                yeni.add(vakit);
+            }
+            return yeni;
+        });
+    };
+
+    const tumunuSec = () => {
+        if (secilenVakitler.size === VAKIT_SIRASI.length) {
+            setSecilenVakitler(new Set([VAKIT_SIRASI[0]]));
+        } else {
+            setSecilenVakitler(new Set<TakvimVakitAdi>(VAKIT_SIRASI));
+        }
+    };
+
+    const handleTara = async () => {
+        const takvimIds = takvimMod === 'secili'
+            ? (secilenTakvimId ? [secilenTakvimId] : [])
+            : cihazTakvimleri.map(t => t.id);
+
+        if (takvimIds.length === 0) return;
+
+        setAdim('taraniyor');
+
+        try {
+            const baslangic = new Date();
+            baslangic.setHours(0, 0, 0, 0);
+            const bitis = new Date(baslangic);
+            bitis.setDate(bitis.getDate() + aralikGun);
+
+            const tumVakitlerSecili = secilenVakitler.size === VAKIT_SIRASI.length;
+            const vakitBasliklari = tumVakitlerSecili
+                ? undefined
+                : Array.from(secilenVakitler).map(v => VAKIT_TEMIZLE_BASLIK[v]);
+
+            const etkinlikler = await TakvimServisi.getInstance().etkinlikleriGetir(
+                takvimIds, baslangic, bitis, vakitBasliklari
+            );
+
+            setBulunanEtkinlikler(etkinlikler);
+            setAdim('onay');
+        } catch {
+            setAdim('kriter');
+        }
+    };
+
+    const handleSil = async () => {
+        setSiliniyor(true);
+        try {
+            const ids = bulunanEtkinlikler.map(e => e.id);
+            const silinen = await TakvimServisi.getInstance().etkinlikleriSil(ids);
+
+            const takvimOzeti = takvimMod === 'tumu' ? 'Tüm takvimler' : (secilenTakvimAdi ?? 'Seçili takvim');
+            const vakitOzeti = secilenVakitler.size === VAKIT_SIRASI.length
+                ? 'tüm vakitler'
+                : Array.from(secilenVakitler).map(v => VAKIT_GORUNTU_ADLARI[v]).join(', ');
+            onTemizlendi(silinen, `${takvimOzeti} · ${aralikGun} gün · ${vakitOzeti}`);
+            onKapat();
+        } catch {
+            setSiliniyor(false);
+        }
+    };
+
+    const takvimRengi = (tid: string) =>
+        cihazTakvimleri.find(t => t.id === tid)?.color ?? '#007AFF';
+
+    const renderEtkinlik = ({ item }: { item: BulunanEtkinlik }) => (
+        <View className="flex-row items-center py-2.5 px-1" style={{ borderBottomWidth: 1, borderBottomColor: renkler.sinir }}>
+            <View
+                className="w-2.5 h-2.5 rounded-full mr-3"
+                style={{ backgroundColor: takvimRengi(item.takvimId) }}
+            />
+            <Text className="text-sm mr-2 font-medium tabular-nums" style={{ color: renkler.metinIkincil, minWidth: 44 }}>
+                {`${item.startDate.getDate().toString().padStart(2,'0')}.${(item.startDate.getMonth()+1).toString().padStart(2,'0')}`}
+            </Text>
+            <Text className="flex-1 text-sm" style={{ color: renkler.metin }}>
+                {item.title}
+            </Text>
+            <Text className="text-xs tabular-nums" style={{ color: renkler.metinIkincil }}>
+                {saatFormatla(item.startDate)}
+            </Text>
+        </View>
+    );
+
+    const taraButonuAktif = takvimMod === 'secili' ? !!secilenTakvimId : cihazTakvimleri.length > 0;
+
+    return (
+        <Modal visible={gorunur} animationType="slide" transparent statusBarTranslucent>
+            <TouchableWithoutFeedback onPress={adim === 'kriter' ? onKapat : undefined}>
+                <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' }}>
+                    <TouchableWithoutFeedback>
+                        <View
+                            style={{
+                                backgroundColor: renkler.kartArkaplan,
+                                borderTopLeftRadius: 24,
+                                borderTopRightRadius: 24,
+                                maxHeight: EKRAN_YUKSEKLIGI * 0.87,
+                                paddingBottom: 32,
+                            }}
+                        >
+                            {/* Handle */}
+                            <View className="items-center pt-3 pb-2">
+                                <View
+                                    style={{ width: 40, height: 4, borderRadius: 2, backgroundColor: renkler.sinir }}
+                                />
+                            </View>
+
+                            {/* ── Aşama 1: Kriter Seçimi ── */}
+                            {adim === 'kriter' && (
+                                <ScrollView
+                                    showsVerticalScrollIndicator={false}
+                                    contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 8 }}
+                                >
+                                    {/* Başlık */}
+                                    <View className="flex-row items-center mb-4">
+                                        <View
+                                            className="w-10 h-10 rounded-xl items-center justify-center mr-3"
+                                            style={{ backgroundColor: '#EF444415' }}
+                                        >
+                                            <FontAwesome5 name="broom" size={16} color="#EF4444" />
+                                        </View>
+                                        <View className="flex-1">
+                                            <Text className="text-base font-bold" style={{ color: renkler.metin }}>
+                                                Etkinlikleri Temizle
+                                            </Text>
+                                            <Text className="text-xs mt-0.5" style={{ color: renkler.metinIkincil }}>
+                                                Hangi etkinliklerin silineceğini seç
+                                            </Text>
+                                        </View>
+                                    </View>
+
+                                    {/* Takvim Seçimi */}
+                                    <Text className="text-xs font-bold tracking-wider mb-2" style={{ color: renkler.metinIkincil }}>
+                                        HANGİ TAKVİM
+                                    </Text>
+                                    <View
+                                        className="rounded-2xl overflow-hidden mb-4"
+                                        style={{ borderWidth: 1, borderColor: renkler.sinir }}
+                                    >
+                                        {[
+                                            {
+                                                mod: 'secili' as TakvimModTipi,
+                                                baslik: secilenTakvimAdi ?? 'Seçili Takvim',
+                                                aciklama: secilenTakvimAdi ? 'Sadece bu takvimde ara' : 'Önce bir takvim seçin',
+                                                ikon: 'bookmark',
+                                                disabled: !secilenTakvimId,
+                                            },
+                                            {
+                                                mod: 'tumu' as TakvimModTipi,
+                                                baslik: 'Tüm Takvimler',
+                                                aciklama: `${cihazTakvimleri.length} takvimde ara`,
+                                                ikon: 'layer-group',
+                                                disabled: false,
+                                            },
+                                        ].map(({ mod, baslik, aciklama, ikon, disabled }) => {
+                                            const secili = takvimMod === mod;
+                                            return (
+                                                <TouchableOpacity
+                                                    key={mod}
+                                                    className="flex-row items-center p-3.5"
+                                                    style={{
+                                                        backgroundColor: secili ? `${renkler.birincil}10` : 'transparent',
+                                                        opacity: disabled ? 0.4 : 1,
+                                                        borderBottomWidth: mod === 'secili' ? 1 : 0,
+                                                        borderBottomColor: renkler.sinir,
+                                                    }}
+                                                    onPress={() => !disabled && setTakvimMod(mod)}
+                                                    disabled={disabled}
+                                                    activeOpacity={0.7}
+                                                >
+                                                    <View
+                                                        className="w-8 h-8 rounded-lg items-center justify-center mr-3"
+                                                        style={{ backgroundColor: secili ? `${renkler.birincil}20` : renkler.arkaplan }}
+                                                    >
+                                                        <FontAwesome5 name={ikon} size={14} color={secili ? renkler.birincil : renkler.metinIkincil} />
+                                                    </View>
+                                                    <View className="flex-1">
+                                                        <Text className="text-sm font-semibold" style={{ color: secili ? renkler.birincil : renkler.metin }}>
+                                                            {baslik}
+                                                        </Text>
+                                                        <Text className="text-xs mt-0.5" style={{ color: renkler.metinIkincil }}>
+                                                            {aciklama}
+                                                        </Text>
+                                                    </View>
+                                                    <View
+                                                        className="w-5 h-5 rounded-full items-center justify-center"
+                                                        style={{ borderWidth: 2, borderColor: secili ? renkler.birincil : renkler.sinir, backgroundColor: secili ? renkler.birincil : 'transparent' }}
+                                                    >
+                                                        {secili && <FontAwesome5 name="check" size={9} color="#FFF" />}
+                                                    </View>
+                                                </TouchableOpacity>
+                                            );
+                                        })}
+                                    </View>
+
+                                    {/* Zaman Aralığı */}
+                                    <Text className="text-xs font-bold tracking-wider mb-2" style={{ color: renkler.metinIkincil }}>
+                                        ZAMAN ARALIĞI (BUGÜNDEN İTİBAREN)
+                                    </Text>
+                                    <View className="flex-row gap-2 mb-4">
+                                        {ARALIK_PRESETLER.map(({ gun, etiket, aciklama }) => {
+                                            const secili = aralikGun === gun;
+                                            return (
+                                                <TouchableOpacity
+                                                    key={gun}
+                                                    className="flex-1 py-3 rounded-2xl items-center"
+                                                    style={{
+                                                        backgroundColor: secili ? renkler.birincil : renkler.arkaplan,
+                                                        borderWidth: 1,
+                                                        borderColor: secili ? renkler.birincil : renkler.sinir,
+                                                    }}
+                                                    onPress={() => setAralikGun(gun)}
+                                                    activeOpacity={0.7}
+                                                >
+                                                    <Text className="text-sm font-bold" style={{ color: secili ? '#FFF' : renkler.metin }}>
+                                                        {etiket}
+                                                    </Text>
+                                                    <Text className="text-xs mt-0.5" style={{ color: secili ? 'rgba(255,255,255,0.75)' : renkler.metinIkincil }}>
+                                                        {aciklama}
+                                                    </Text>
+                                                </TouchableOpacity>
+                                            );
+                                        })}
+                                    </View>
+
+                                    {/* Vakitler */}
+                                    <View className="flex-row items-center justify-between mb-2">
+                                        <Text className="text-xs font-bold tracking-wider" style={{ color: renkler.metinIkincil }}>
+                                            VAKİTLER
+                                        </Text>
+                                        <TouchableOpacity onPress={tumunuSec}>
+                                            <Text className="text-xs font-semibold" style={{ color: renkler.birincil }}>
+                                                {secilenVakitler.size === VAKIT_SIRASI.length ? 'Seçimi Kaldır' : 'Tümünü Seç'}
+                                            </Text>
+                                        </TouchableOpacity>
+                                    </View>
+                                    <View
+                                        className="rounded-2xl overflow-hidden mb-5"
+                                        style={{ borderWidth: 1, borderColor: renkler.sinir }}
+                                    >
+                                        {VAKIT_SIRASI.map((vakit, idx) => {
+                                            const secili = secilenVakitler.has(vakit);
+                                            return (
+                                                <TouchableOpacity
+                                                    key={vakit}
+                                                    className="flex-row items-center px-4 py-3"
+                                                    style={{
+                                                        backgroundColor: secili ? `${renkler.birincil}08` : 'transparent',
+                                                        borderBottomWidth: idx < VAKIT_SIRASI.length - 1 ? 1 : 0,
+                                                        borderBottomColor: renkler.sinir,
+                                                    }}
+                                                    onPress={() => toggleVakit(vakit)}
+                                                    activeOpacity={0.7}
+                                                >
+                                                    <View
+                                                        className="w-5 h-5 rounded items-center justify-center mr-3"
+                                                        style={{
+                                                            backgroundColor: secili ? renkler.birincil : 'transparent',
+                                                            borderWidth: 2,
+                                                            borderColor: secili ? renkler.birincil : renkler.sinir,
+                                                        }}
+                                                    >
+                                                        {secili && <FontAwesome5 name="check" size={10} color="#FFF" />}
+                                                    </View>
+                                                    <Text className="text-sm" style={{ color: renkler.metin, fontWeight: secili ? '600' : '400' }}>
+                                                        {VAKIT_GORUNTU_ADLARI[vakit]} Namazı
+                                                    </Text>
+                                                    <Text className="ml-auto text-xs" style={{ color: renkler.metinIkincil }}>
+                                                        {VAKIT_TEMIZLE_BASLIK[vakit]}
+                                                    </Text>
+                                                </TouchableOpacity>
+                                            );
+                                        })}
+                                    </View>
+
+                                    {/* Tara Butonu */}
+                                    <TouchableOpacity
+                                        className="flex-row items-center justify-center p-4 rounded-2xl"
+                                        style={{
+                                            backgroundColor: taraButonuAktif ? '#EF4444' : renkler.sinir,
+                                        }}
+                                        onPress={handleTara}
+                                        disabled={!taraButonuAktif}
+                                        activeOpacity={0.8}
+                                    >
+                                        <FontAwesome5 name="search" size={14} color="#FFF" style={{ marginRight: 8 }} />
+                                        <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                            Etkinlikleri Tara
+                                        </Text>
+                                    </TouchableOpacity>
+
+                                    {!taraButonuAktif && (
+                                        <Text className="text-xs text-center mt-2" style={{ color: renkler.metinIkincil }}>
+                                            Önce takvim ayarlarından bir takvim seçin
+                                        </Text>
+                                    )}
+                                </ScrollView>
+                            )}
+
+                            {/* ── Aşama: Taranıyor ── */}
+                            {adim === 'taraniyor' && (
+                                <View className="items-center justify-center py-16">
+                                    <ActivityIndicator size="large" color="#EF4444" />
+                                    <Text className="text-sm mt-4" style={{ color: renkler.metinIkincil }}>
+                                        Etkinlikler taranıyor…
+                                    </Text>
+                                </View>
+                            )}
+
+                            {/* ── Aşama 2: Onay ── */}
+                            {adim === 'onay' && (
+                                <View style={{ flex: 1, minHeight: 0 }}>
+                                    {/* Özet */}
+                                    <View className="px-5 pb-3">
+                                        <View className="flex-row items-center mb-1">
+                                            <Text className="text-base font-bold" style={{ color: renkler.metin }}>
+                                                Silinecek Etkinlikler
+                                            </Text>
+                                            <View
+                                                className="ml-2 px-2 py-0.5 rounded-full"
+                                                style={{ backgroundColor: bulunanEtkinlikler.length > 0 ? '#EF444420' : `${renkler.birincil}20` }}
+                                            >
+                                                <Text className="text-xs font-bold" style={{ color: bulunanEtkinlikler.length > 0 ? '#EF4444' : renkler.birincil }}>
+                                                    {bulunanEtkinlikler.length}
+                                                </Text>
+                                            </View>
+                                        </View>
+                                        <Text className="text-xs leading-4" style={{ color: renkler.metinIkincil }}>
+                                            {takvimMod === 'tumu' ? 'Tüm takvimler' : (secilenTakvimAdi ?? 'Seçili takvim')}
+                                            {'  ·  '}{aralikGun} gün
+                                            {'  ·  '}{secilenVakitler.size === VAKIT_SIRASI.length ? 'Tüm vakitler' : Array.from(secilenVakitler).map(v => VAKIT_GORUNTU_ADLARI[v]).join(', ')}
+                                        </Text>
+                                    </View>
+
+                                    {bulunanEtkinlikler.length === 0 ? (
+                                        <View className="flex-1 items-center justify-center py-10 px-5">
+                                            <FontAwesome5 name="calendar-check" size={40} color={renkler.metinIkincil} />
+                                            <Text className="text-sm font-semibold mt-3 text-center" style={{ color: renkler.metin }}>
+                                                Etkinlik Bulunamadı
+                                            </Text>
+                                            <Text className="text-xs text-center mt-1.5 leading-5" style={{ color: renkler.metinIkincil }}>
+                                                Belirtilen kriterlerde silinecek etkinlik bulunamadı.
+                                            </Text>
+                                        </View>
+                                    ) : (
+                                        <FlatList
+                                            data={bulunanEtkinlikler}
+                                            keyExtractor={item => item.id}
+                                            renderItem={renderEtkinlik}
+                                            style={{ flex: 1 }}
+                                            contentContainerStyle={{ paddingHorizontal: 20 }}
+                                            showsVerticalScrollIndicator={false}
+                                        />
+                                    )}
+
+                                    {/* Alt Butonlar */}
+                                    <View className="flex-row gap-3 px-5 pt-3" style={{ borderTopWidth: 1, borderTopColor: renkler.sinir }}>
+                                        <TouchableOpacity
+                                            className="flex-1 flex-row items-center justify-center py-3.5 rounded-2xl"
+                                            style={{ backgroundColor: renkler.arkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                                            onPress={() => setAdim('kriter')}
+                                            disabled={siliniyor}
+                                            activeOpacity={0.7}
+                                        >
+                                            <FontAwesome5 name="arrow-left" size={13} color={renkler.metinIkincil} style={{ marginRight: 6 }} />
+                                            <Text className="text-sm font-semibold" style={{ color: renkler.metinIkincil }}>
+                                                Geri
+                                            </Text>
+                                        </TouchableOpacity>
+
+                                        <TouchableOpacity
+                                            className="flex-[2] flex-row items-center justify-center py-3.5 rounded-2xl"
+                                            style={{
+                                                backgroundColor: bulunanEtkinlikler.length > 0 ? '#EF4444' : renkler.sinir,
+                                            }}
+                                            onPress={handleSil}
+                                            disabled={siliniyor || bulunanEtkinlikler.length === 0}
+                                            activeOpacity={0.8}
+                                        >
+                                            {siliniyor ? (
+                                                <ActivityIndicator size="small" color="#FFF" />
+                                            ) : (
+                                                <>
+                                                    <FontAwesome5 name="trash-alt" size={14} color="#FFF" style={{ marginRight: 8 }} />
+                                                    <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                                        {bulunanEtkinlikler.length > 0
+                                                            ? `${bulunanEtkinlikler.length} Etkinliği Sil`
+                                                            : 'Silinecek Etkinlik Yok'}
+                                                    </Text>
+                                                </>
+                                            )}
+                                        </TouchableOpacity>
+                                    </View>
+                                </View>
+                            )}
+                        </View>
+                    </TouchableWithoutFeedback>
+                </View>
+            </TouchableWithoutFeedback>
+        </Modal>
+    );
+};
+
 // ─── Ana Ekran ────────────────────────────────────────────────────────────────
+
+interface Bildirim {
+    mesaj: string;
+    tip: 'basari' | 'hata' | 'bilgi';
+}
 
 export const TakvimAyarlariSayfasi: React.FC<any> = () => {
     const renkler = useRenkler();
@@ -312,10 +888,18 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
 
     const [cihazTakvimleri, setCihazTakvimleri] = useState<Array<{ id: string; title: string; color: string }>>([]);
     const [takvimYukleniyor, setTakvimYukleniyor] = useState(false);
-    const [temizleniyor, setTemizleniyor] = useState(false);
+    const [temizleModaliGorunur, setTemizleModaliGorunur] = useState(false);
+    const [bildirim, setBildirim] = useState<Bildirim | null>(null);
+    const bildirimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const fadeAnim = useRef(new Animated.Value(0)).current;
     const slideAnim = useRef(new Animated.Value(20)).current;
+
+    const bildirimGoster = useCallback((mesaj: string, tip: Bildirim['tip']) => {
+        if (bildirimTimerRef.current) clearTimeout(bildirimTimerRef.current);
+        setBildirim({ mesaj, tip });
+        bildirimTimerRef.current = setTimeout(() => setBildirim(null), 5000);
+    }, []);
 
     useEffect(() => {
         dispatch(takvimAyarlariniYukle());
@@ -323,13 +907,11 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
             Animated.timing(fadeAnim, { toValue: 1, duration: 350, useNativeDriver: true }),
             Animated.timing(slideAnim, { toValue: 0, duration: 350, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
         ]).start();
+        return () => { if (bildirimTimerRef.current) clearTimeout(bildirimTimerRef.current); };
     }, []);
 
-    // Takvim izni sadece entegrasyon aktif olduğunda istenir (App Store/Play politikalari)
     useEffect(() => {
-        if (ayarlar.aktif) {
-            takvimleriniYenile();
-        }
+        if (ayarlar.aktif) takvimleriniYenile();
     }, [ayarlar.aktif]);
 
     const takvimleriniYenile = async () => {
@@ -337,14 +919,6 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
         const takvimler = await TakvimServisi.getInstance().cihazTakvimleriniGetir();
         setCihazTakvimleri(takvimler);
         setTakvimYukleniyor(false);
-    };
-
-    const handleAktifToggle = (val: boolean) => {
-        dispatch(takvimAyarlariniGuncelle({ aktif: val }));
-    };
-
-    const handleTakvimSec = (id: string, adi: string) => {
-        dispatch(takvimAyarlariniGuncelle({ takvimId: id, takvimAdi: adi }));
     };
 
     const handleVakitAyarDegistir = (vakit: TakvimVakitAdi, yeni: Partial<VakitTakvimAyari>) => {
@@ -356,66 +930,30 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
         }));
     };
 
-    const handleEtkinlikleriTemizle = async () => {
-        await butonTiklandiFeedback();
-        if (!ayarlar.takvimId) {
-            Alert.alert('Takvim Seçin', 'Lütfen önce bir takvim seçin.');
-            return;
-        }
-        Alert.alert(
-            'Etkinlikleri Temizle',
-            'Bu takvimde Namaz Akışı tarafından oluşturulmuş tüm etkinlikler silinecek. Devam edilsin mi?',
-            [
-                { text: 'İptal', style: 'cancel' },
-                {
-                    text: 'Temizle',
-                    style: 'destructive',
-                    onPress: async () => {
-                        setTemizleniyor(true);
-                        try {
-                            await TakvimServisi.getInstance().eskiOlaylariTemizle(ayarlar.takvimId!, 31);
-                            Alert.alert('Tamamlandı', 'Takvim etkinlikleri temizlendi.');
-                        } catch {
-                            Alert.alert('Hata', 'Etkinlikler temizlenirken hata oluştu.');
-                        } finally {
-                            setTemizleniyor(false);
-                        }
-                    },
-                },
-            ]
-        );
-    };
-
     const handleOlaylariOlustur = async () => {
         await butonTiklandiFeedback();
+
         if (!ayarlar.takvimId) {
-            Alert.alert('Takvim Seçin', 'Lütfen önce bir takvim seçin.');
+            bildirimGoster('Önce bir takvim seçin.', 'bilgi');
             return;
         }
         if (!koordinatlar) {
-            Alert.alert('Konum Bulunamadı', 'Lütfen önce konum ayarlarından konumunuzu belirleyin.');
+            bildirimGoster('Konum bulunamadı. Lütfen konum ayarlarını kontrol edin.', 'hata');
             return;
         }
+
         const result = await dispatch(takvimOlaylariniOlustur({ ayarlar, koordinatlar }));
         if (takvimOlaylariniOlustur.fulfilled.match(result)) {
-            Alert.alert('Başarılı', `${result.payload.olusturulanSayi} takvim etkinliği oluşturuldu.`);
+            bildirimGoster(`${result.payload.olusturulanSayi} etkinlik takvime eklendi.`, 'basari');
         } else {
-            Alert.alert('Hata', String(result.payload) || 'Etkinlikler oluşturulurken bir hata oluştu.');
+            bildirimGoster(String(result.payload) || 'Etkinlikler oluşturulurken hata oluştu.', 'hata');
         }
     };
 
-    // Bugünün vakitleri (önizleme için)
     const bugunVakitler = useMemo(() => {
-        const hesaplayici = NamazVaktiHesaplayiciServisi.getInstance();
-        const sonuclar = hesaplayici.getGunlukVakitler(new Date());
+        const sonuclar = NamazVaktiHesaplayiciServisi.getInstance().getGunlukVakitler(new Date());
         if (!sonuclar) return null;
-        return {
-            imsak:  sonuclar.imsak,
-            ogle:   sonuclar.ogle,
-            ikindi: sonuclar.ikindi,
-            aksam:  sonuclar.aksam,
-            yatsi:  sonuclar.yatsi,
-        } as Record<TakvimVakitAdi, Date>;
+        return { imsak: sonuclar.imsak, ogle: sonuclar.ogle, ikindi: sonuclar.ikindi, aksam: sonuclar.aksam, yatsi: sonuclar.yatsi } as Record<TakvimVakitAdi, Date>;
     }, []);
 
     const bugunCikisVakitleri = useMemo(() => {
@@ -423,11 +961,9 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
         const hesaplayici = NamazVaktiHesaplayiciServisi.getInstance();
         const bugunTum = hesaplayici.getGunlukVakitler(new Date());
         if (!bugunTum) return null;
-
         const yarinTarih = new Date();
         yarinTarih.setDate(yarinTarih.getDate() + 1);
         const yarinTum = hesaplayici.getGunlukVakitler(yarinTarih);
-
         return {
             imsak:  bugunTum.gunes,
             ogle:   bugunTum.ikindi,
@@ -442,6 +978,12 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
         [ayarlar.vakitAyarlari]
     );
 
+    const olusturButonuMesaji = !ayarlar.takvimId
+        ? 'Takvim seçilmedi'
+        : !koordinatlar
+            ? 'Konum bulunamadı'
+            : null;
+
     return (
         <SafeAreaView className="flex-1" style={{ backgroundColor: renkler.arkaplan }} edges={['bottom', 'left', 'right']}>
             <ScrollView
@@ -455,7 +997,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                     <TouchableOpacity
                         className="flex-row items-center p-4 rounded-2xl mb-4"
                         style={{ backgroundColor: ayarlar.aktif ? renkler.birincil : renkler.kartArkaplan }}
-                        onPress={() => handleAktifToggle(!ayarlar.aktif)}
+                        onPress={() => dispatch(takvimAyarlariniGuncelle({ aktif: !ayarlar.aktif }))}
                         activeOpacity={0.8}
                     >
                         <View
@@ -470,46 +1012,36 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                             />
                         </View>
                         <View className="flex-1">
-                            <Text
-                                className="text-base font-semibold"
-                                style={{ color: ayarlar.aktif ? '#FFF' : renkler.metin }}
-                            >
+                            <Text className="text-base font-semibold" style={{ color: ayarlar.aktif ? '#FFF' : renkler.metin }}>
                                 Takvim Entegrasyonu
                             </Text>
-                            <Text
-                                className="text-xs mt-0.5"
-                                style={{ color: ayarlar.aktif ? 'rgba(255,255,255,0.75)' : renkler.metinIkincil }}
-                            >
-                                {ayarlar.aktif ? 'Aktif — etkinlikler oluşturulacak' : 'Namaz vakitlerini takvime ekle'}
+                            <Text className="text-xs mt-0.5" style={{ color: ayarlar.aktif ? 'rgba(255,255,255,0.75)' : renkler.metinIkincil }}>
+                                {ayarlar.aktif ? 'Aktif — etkinlikler oluşturulabilir' : 'Namaz vakitlerini takvime ekle'}
                             </Text>
                         </View>
                         <Switch
                             value={ayarlar.aktif}
-                            onValueChange={handleAktifToggle}
+                            onValueChange={v => { dispatch(takvimAyarlariniGuncelle({ aktif: v })); }}
                             trackColor={{ false: renkler.sinir, true: 'rgba(255,255,255,0.4)' }}
                             thumbColor="#FFF"
                         />
                     </TouchableOpacity>
 
-                    {/* Pasif durumu */}
-                    {!ayarlar.aktif && (
-                        <View
-                            className="items-center p-10 rounded-2xl"
-                            style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
-                        >
-                            <FontAwesome5 name="calendar-times" size={48} color={renkler.metinIkincil} />
-                            <Text className="text-base font-semibold mt-4 text-center" style={{ color: renkler.metin }}>
-                                Takvim Entegrasyonu Kapalı
-                            </Text>
-                            <Text className="text-xs text-center mt-2" style={{ color: renkler.metinIkincil }}>
-                                Aktifleştirerek namaz vakitlerini cihaz takviminize otomatik ekleyebilirsiniz.
-                            </Text>
-                        </View>
-                    )}
+                    {/* ── Pasif ── */}
+                    {!ayarlar.aktif && <OzellikBilgi />}
 
-                    {/* Aktif içerik */}
+                    {/* ── Aktif ── */}
                     {ayarlar.aktif && (
                         <>
+                            {/* Bildirim Banneri */}
+                            {bildirim && (
+                                <BildirimBanneri
+                                    mesaj={bildirim.mesaj}
+                                    tip={bildirim.tip}
+                                    onKapat={() => setBildirim(null)}
+                                />
+                            )}
+
                             {/* Takvim Seçici */}
                             <View
                                 className="rounded-2xl p-4 mb-4"
@@ -533,9 +1065,15 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 </View>
 
                                 {cihazTakvimleri.length === 0 ? (
-                                    <Text className="text-sm text-center py-4" style={{ color: renkler.metinIkincil }}>
-                                        Cihazınızda düzenlenebilir takvim bulunamadı.
-                                    </Text>
+                                    <View className="items-center py-5">
+                                        <FontAwesome5 name="calendar-times" size={28} color={renkler.metinIkincil} />
+                                        <Text className="text-sm text-center mt-2" style={{ color: renkler.metinIkincil }}>
+                                            Cihazınızda düzenlenebilir takvim bulunamadı.
+                                        </Text>
+                                        <Text className="text-xs text-center mt-1" style={{ color: renkler.metinIkincil }}>
+                                            Cihazınıza bir Google veya iCloud hesabı ekleyin.
+                                        </Text>
+                                    </View>
                                 ) : (
                                     cihazTakvimleri.map(takvim => {
                                         const secili = ayarlar.takvimId === takvim.id;
@@ -548,22 +1086,17 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                                     borderWidth: 1,
                                                     borderColor: secili ? renkler.birincil : renkler.sinir,
                                                 }}
-                                                onPress={() => handleTakvimSec(takvim.id, takvim.title)}
+                                                onPress={() => dispatch(takvimAyarlariniGuncelle({ takvimId: takvim.id, takvimAdi: takvim.title }))}
                                                 activeOpacity={0.7}
                                             >
-                                                <View
-                                                    className="w-3 h-3 rounded-full mr-3"
-                                                    style={{ backgroundColor: takvim.color }}
-                                                />
+                                                <View className="w-3 h-3 rounded-full mr-3" style={{ backgroundColor: takvim.color }} />
                                                 <Text
                                                     className="flex-1 text-sm"
                                                     style={{ color: secili ? renkler.birincil : renkler.metin, fontWeight: secili ? '600' : '400' }}
                                                 >
                                                     {takvim.title}
                                                 </Text>
-                                                {secili && (
-                                                    <FontAwesome5 name="check" size={12} color={renkler.birincil} />
-                                                )}
+                                                {secili && <FontAwesome5 name="check" size={12} color={renkler.birincil} />}
                                             </TouchableOpacity>
                                         );
                                     })
@@ -613,10 +1146,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                                 onPress={() => dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: gun }))}
                                                 activeOpacity={0.7}
                                             >
-                                                <Text
-                                                    className="text-sm font-semibold"
-                                                    style={{ color: secili ? '#FFF' : renkler.metinIkincil }}
-                                                >
+                                                <Text className="text-sm font-semibold" style={{ color: secili ? '#FFF' : renkler.metinIkincil }}>
                                                     {gun} Gün
                                                 </Text>
                                             </TouchableOpacity>
@@ -635,8 +1165,8 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 </Text>
                                 {aktifVakitler.length === 0 ? (
                                     <View className="items-center py-6">
-                                        <FontAwesome5 name="calendar-minus" size={32} color={renkler.metinIkincil} />
-                                        <Text className="text-sm text-center mt-3" style={{ color: renkler.metinIkincil }}>
+                                        <FontAwesome5 name="calendar-minus" size={28} color={renkler.metinIkincil} />
+                                        <Text className="text-sm text-center mt-3 leading-5" style={{ color: renkler.metinIkincil }}>
                                             Henüz aktif vakit seçilmedi.{'\n'}Vakit Ayarları bölümünden vakit seçin.
                                         </Text>
                                     </View>
@@ -654,12 +1184,12 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 )}
                             </View>
 
-                            {/* Butonlar */}
+                            {/* Oluştur Butonu */}
                             <TouchableOpacity
                                 className="flex-row items-center justify-center p-4 rounded-2xl mb-2"
-                                style={{ backgroundColor: renkler.birincil }}
+                                style={{ backgroundColor: olayOlusturuluyor ? `${renkler.birincil}80` : renkler.birincil }}
                                 onPress={handleOlaylariOlustur}
-                                disabled={olayOlusturuluyor || temizleniyor}
+                                disabled={olayOlusturuluyor}
                                 activeOpacity={0.8}
                             >
                                 {olayOlusturuluyor ? (
@@ -674,27 +1204,27 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 )}
                             </TouchableOpacity>
 
+                            {olusturButonuMesaji && (
+                                <View className="flex-row items-center justify-center mb-2 gap-1.5">
+                                    <FontAwesome5 name="info-circle" size={12} color={renkler.metinIkincil} />
+                                    <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
+                                        {olusturButonuMesaji}
+                                    </Text>
+                                </View>
+                            )}
+
+                            {/* Temizle Butonu */}
                             <TouchableOpacity
                                 className="flex-row items-center justify-center p-3.5 rounded-2xl mb-3"
-                                style={{
-                                    borderWidth: 1,
-                                    borderColor: '#EF4444',
-                                    backgroundColor: `#EF444415`,
-                                }}
-                                onPress={handleEtkinlikleriTemizle}
-                                disabled={olayOlusturuluyor || temizleniyor}
+                                style={{ borderWidth: 1, borderColor: '#EF4444', backgroundColor: '#EF444415' }}
+                                onPress={async () => { await butonTiklandiFeedback(); setTemizleModaliGorunur(true); }}
+                                disabled={olayOlusturuluyor}
                                 activeOpacity={0.8}
                             >
-                                {temizleniyor ? (
-                                    <ActivityIndicator color="#EF4444" />
-                                ) : (
-                                    <>
-                                        <FontAwesome5 name="calendar-times" size={15} color="#EF4444" solid style={{ marginRight: 8 }} />
-                                        <Text className="text-sm font-semibold" style={{ color: '#EF4444' }}>
-                                            Mevcut Etkinlikleri Temizle
-                                        </Text>
-                                    </>
-                                )}
+                                <FontAwesome5 name="broom" size={14} color="#EF4444" style={{ marginRight: 8 }} />
+                                <Text className="text-sm font-semibold" style={{ color: '#EF4444' }}>
+                                    Etkinlikleri Temizle
+                                </Text>
                             </TouchableOpacity>
 
                             {/* Bilgi Notu */}
@@ -702,15 +1232,10 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 className="flex-row items-start p-4 rounded-xl"
                                 style={{ backgroundColor: `${renkler.birincil}10` }}
                             >
-                                <FontAwesome5
-                                    name="info-circle"
-                                    size={14}
-                                    color={renkler.birincil}
-                                    style={{ marginTop: 1, marginRight: 8 }}
-                                />
+                                <FontAwesome5 name="info-circle" size={14} color={renkler.birincil} style={{ marginTop: 1, marginRight: 8 }} />
                                 <Text className="flex-1 text-xs leading-5" style={{ color: renkler.metinIkincil }}>
                                     Etkinlikler her oluşturmada öncekiler silinerek yeniden oluşturulur.
-                                    Ayarlarınızı değiştirdikten sonra "Olayları Oluştur" butonuna tekrar basmanız gerekir.
+                                    Ayarları değiştirdikten sonra "Olayları Oluştur" butonuna tekrar basın.
                                 </Text>
                             </View>
                         </>
@@ -719,6 +1244,19 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                     <View className="h-10" />
                 </Animated.View>
             </ScrollView>
+
+            {/* Temizle Modalı */}
+            <TemizleModali
+                gorunur={temizleModaliGorunur}
+                onKapat={() => setTemizleModaliGorunur(false)}
+                onTemizlendi={(silinen, ozet) => {
+                    setTemizleModaliGorunur(false);
+                    bildirimGoster(`${silinen} etkinlik temizlendi. (${ozet})`, 'basari');
+                }}
+                secilenTakvimId={ayarlar.takvimId}
+                secilenTakvimAdi={ayarlar.takvimAdi}
+                cihazTakvimleri={cihazTakvimleri}
+            />
         </SafeAreaView>
     );
 };

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -312,6 +312,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
 
     const [cihazTakvimleri, setCihazTakvimleri] = useState<Array<{ id: string; title: string; color: string }>>([]);
     const [takvimYukleniyor, setTakvimYukleniyor] = useState(false);
+    const [temizleniyor, setTemizleniyor] = useState(false);
 
     const fadeAnim = useRef(new Animated.Value(0)).current;
     const slideAnim = useRef(new Animated.Value(20)).current;
@@ -353,6 +354,36 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                 [vakit]: { ...ayarlar.vakitAyarlari[vakit], ...yeni },
             },
         }));
+    };
+
+    const handleEtkinlikleriTemizle = async () => {
+        await butonTiklandiFeedback();
+        if (!ayarlar.takvimId) {
+            Alert.alert('Takvim Seçin', 'Lütfen önce bir takvim seçin.');
+            return;
+        }
+        Alert.alert(
+            'Etkinlikleri Temizle',
+            'Bu takvimde Namaz Akışı tarafından oluşturulmuş tüm etkinlikler silinecek. Devam edilsin mi?',
+            [
+                { text: 'İptal', style: 'cancel' },
+                {
+                    text: 'Temizle',
+                    style: 'destructive',
+                    onPress: async () => {
+                        setTemizleniyor(true);
+                        try {
+                            await TakvimServisi.getInstance().eskiOlaylariTemizle(ayarlar.takvimId!, 31);
+                            Alert.alert('Tamamlandı', 'Takvim etkinlikleri temizlendi.');
+                        } catch {
+                            Alert.alert('Hata', 'Etkinlikler temizlenirken hata oluştu.');
+                        } finally {
+                            setTemizleniyor(false);
+                        }
+                    },
+                },
+            ]
+        );
     };
 
     const handleOlaylariOlustur = async () => {
@@ -623,12 +654,12 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 )}
                             </View>
 
-                            {/* Etkinlik Oluştur Butonu */}
+                            {/* Butonlar */}
                             <TouchableOpacity
-                                className="flex-row items-center justify-center p-4 rounded-2xl mb-3"
+                                className="flex-row items-center justify-center p-4 rounded-2xl mb-2"
                                 style={{ backgroundColor: renkler.birincil }}
                                 onPress={handleOlaylariOlustur}
-                                disabled={olayOlusturuluyor}
+                                disabled={olayOlusturuluyor || temizleniyor}
                                 activeOpacity={0.8}
                             >
                                 {olayOlusturuluyor ? (
@@ -638,6 +669,29 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                         <FontAwesome5 name="calendar-plus" size={16} color="#FFF" solid style={{ marginRight: 8 }} />
                                         <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
                                             Olayları Oluştur ({ayarlar.kaciGunIlerisi} gün)
+                                        </Text>
+                                    </>
+                                )}
+                            </TouchableOpacity>
+
+                            <TouchableOpacity
+                                className="flex-row items-center justify-center p-3.5 rounded-2xl mb-3"
+                                style={{
+                                    borderWidth: 1,
+                                    borderColor: '#EF4444',
+                                    backgroundColor: `#EF444415`,
+                                }}
+                                onPress={handleEtkinlikleriTemizle}
+                                disabled={olayOlusturuluyor || temizleniyor}
+                                activeOpacity={0.8}
+                            >
+                                {temizleniyor ? (
+                                    <ActivityIndicator color="#EF4444" />
+                                ) : (
+                                    <>
+                                        <FontAwesome5 name="calendar-times" size={15} color="#EF4444" solid style={{ marginRight: 8 }} />
+                                        <Text className="text-sm font-semibold" style={{ color: '#EF4444' }}>
+                                            Mevcut Etkinlikleri Temizle
                                         </Text>
                                     </>
                                 )}

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -1,0 +1,664 @@
+/**
+ * Takvim Entegrasyonu Ayarlari Sayfasi
+ * Namaz vakitleri icin cihaz takvimi etkinlikleri yapilandirmasi
+ */
+
+import * as React from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import {
+    View,
+    Text,
+    ScrollView,
+    TouchableOpacity,
+    Switch,
+    ActivityIndicator,
+    Alert,
+    Animated,
+    Easing,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import { useRenkler } from '../../core/theme';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import {
+    takvimAyarlariniYukle,
+    takvimAyarlariniGuncelle,
+    takvimOlaylariniOlustur,
+    type TakvimVakitAdi,
+    type VakitTakvimAyari,
+    type BaslangicTipi,
+} from '../store/takvimSlice';
+import { TakvimServisi } from '../../domain/services/TakvimServisi';
+import { NamazVaktiHesaplayiciServisi } from '../../domain/services/NamazVaktiHesaplayiciServisi';
+import { useFeedback } from '../../core/feedback';
+
+const THROTTLE_SURESI = 100;
+
+const VAKIT_GORUNTU_ADLARI: Record<TakvimVakitAdi, string> = {
+    imsak:  'Sabah',
+    ogle:   'Öğle',
+    ikindi: 'İkindi',
+    aksam:  'Akşam',
+    yatsi:  'Yatsı',
+};
+
+const VAKIT_SIRASI: TakvimVakitAdi[] = ['imsak', 'ogle', 'ikindi', 'aksam', 'yatsi'];
+
+// ─── SayisalSecici ────────────────────────────────────────────────────────────
+
+interface SayisalSeciciProps {
+    deger: number;
+    min: number;
+    max: number;
+    adim?: number;
+    birim?: string;
+    onChange: (yeniDeger: number) => void;
+    renk: string;
+}
+
+const SayisalSecici: React.FC<SayisalSeciciProps> = ({
+    deger, min, max, adim = 1, birim = 'dk', onChange, renk,
+}) => {
+    const renkler = useRenkler();
+    const sonTiklamaRef = useRef<number>(0);
+
+    const throttleKontrol = useCallback((): boolean => {
+        const simdi = Date.now();
+        if (simdi - sonTiklamaRef.current < THROTTLE_SURESI) return false;
+        sonTiklamaRef.current = simdi;
+        return true;
+    }, []);
+
+    const azalt = useCallback(() => {
+        if (!throttleKontrol()) return;
+        onChange(Math.max(min, deger - adim));
+    }, [deger, min, adim, onChange, throttleKontrol]);
+
+    const artir = useCallback(() => {
+        if (!throttleKontrol()) return;
+        onChange(Math.min(max, deger + adim));
+    }, [deger, max, adim, onChange, throttleKontrol]);
+
+    return (
+        <View className="flex-row items-center rounded-lg overflow-hidden border" style={{ borderColor: renkler.sinir }}>
+            <TouchableOpacity
+                className="w-9 h-9 items-center justify-center"
+                style={{ backgroundColor: deger <= min ? renkler.sinir : renk }}
+                onPress={azalt}
+                disabled={deger <= min}
+                activeOpacity={0.7}
+            >
+                <FontAwesome5 name="minus" size={12} color="#FFF" />
+            </TouchableOpacity>
+            <View
+                className="px-3 h-9 items-center justify-center flex-row min-w-[80px]"
+                style={{ backgroundColor: renkler.kartArkaplan }}
+            >
+                <Text className="text-base font-bold mr-1" style={{ color: renkler.metin }}>{deger}</Text>
+                <Text className="text-xs" style={{ color: renkler.metinIkincil }}>{birim}</Text>
+            </View>
+            <TouchableOpacity
+                className="w-9 h-9 items-center justify-center"
+                style={{ backgroundColor: deger >= max ? renkler.sinir : renk }}
+                onPress={artir}
+                disabled={deger >= max}
+                activeOpacity={0.7}
+            >
+                <FontAwesome5 name="plus" size={12} color="#FFF" />
+            </TouchableOpacity>
+        </View>
+    );
+};
+
+// ─── VakitAyarSatiri ──────────────────────────────────────────────────────────
+
+interface VakitAyarSatiriProps {
+    vakitAdi: TakvimVakitAdi;
+    gorununumAdi: string;
+    ayar: VakitTakvimAyari;
+    onChange: (yeni: Partial<VakitTakvimAyari>) => void;
+    sonMu: boolean;
+}
+
+const BASLANGIC_TIPLERI: { tip: BaslangicTipi; etiket: string }[] = [
+    { tip: 'vakit_oncesi',  etiket: 'Çıkmadan Önce' },
+    { tip: 'vakit_girisi',  etiket: 'Vakitte' },
+    { tip: 'vakit_sonrasi', etiket: 'Vakitten Sonra' },
+];
+
+const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
+    vakitAdi, gorununumAdi, ayar, onChange, sonMu,
+}) => {
+    const renkler = useRenkler();
+
+    return (
+        <View
+            className="py-3"
+            style={!sonMu ? { borderBottomWidth: 1, borderBottomColor: renkler.sinir } : undefined}
+        >
+            {/* Vakit başlığı + toggle */}
+            <View className="flex-row justify-between items-center">
+                <Text className="text-sm font-semibold" style={{ color: renkler.metin }}>
+                    {gorununumAdi} Vakti
+                </Text>
+                <Switch
+                    value={ayar.aktif}
+                    onValueChange={v => onChange({ aktif: v })}
+                    trackColor={{ false: renkler.sinir, true: `${renkler.birincil}60` }}
+                    thumbColor={ayar.aktif ? renkler.birincil : '#f4f3f4'}
+                />
+            </View>
+
+            {/* Aktifse detay ayarlar */}
+            {ayar.aktif && (
+                <View className="mt-3 gap-3">
+                    {/* Başlangıç tipi seçici */}
+                    <View>
+                        <Text className="text-xs mb-2" style={{ color: renkler.metinIkincil }}>
+                            Etkinlik Ne Zaman Başlasın
+                        </Text>
+                        <View className="flex-row gap-1">
+                            {BASLANGIC_TIPLERI.map(({ tip, etiket }) => {
+                                const secili = ayar.baslangicTipi === tip;
+                                return (
+                                    <TouchableOpacity
+                                        key={tip}
+                                        onPress={() => onChange({ baslangicTipi: tip })}
+                                        className="flex-1 py-2 px-1 rounded-lg items-center"
+                                        style={{
+                                            backgroundColor: secili ? renkler.birincil : `${renkler.birincil}15`,
+                                            borderWidth: 1,
+                                            borderColor: secili ? renkler.birincil : renkler.sinir,
+                                        }}
+                                        activeOpacity={0.7}
+                                    >
+                                        <Text
+                                            className="text-xs font-semibold text-center"
+                                            style={{ color: secili ? '#FFF' : renkler.metinIkincil }}
+                                            numberOfLines={2}
+                                        >
+                                            {etiket}
+                                        </Text>
+                                    </TouchableOpacity>
+                                );
+                            })}
+                        </View>
+                    </View>
+
+                    {/* Dakika seçici — sadece önce/sonra durumunda */}
+                    {ayar.baslangicTipi !== 'vakit_girisi' && (
+                        <View className="flex-row justify-between items-center">
+                            <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
+                                {ayar.baslangicTipi === 'vakit_oncesi' ? 'Kaç dk önce' : 'Kaç dk sonra'}
+                            </Text>
+                            <SayisalSecici
+                                deger={ayar.dakika || 5}
+                                min={1}
+                                max={60}
+                                adim={5}
+                                birim="dk"
+                                onChange={v => onChange({ dakika: v })}
+                                renk={renkler.birincil}
+                            />
+                        </View>
+                    )}
+
+                    {/* Süre seçici */}
+                    <View className="flex-row justify-between items-center">
+                        <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
+                            Etkinlik Süresi
+                        </Text>
+                        <SayisalSecici
+                            deger={ayar.sureDakika}
+                            min={5}
+                            max={120}
+                            adim={5}
+                            birim="dk"
+                            onChange={v => onChange({ sureDakika: v })}
+                            renk={renkler.birincil}
+                        />
+                    </View>
+                </View>
+            )}
+        </View>
+    );
+};
+
+// ─── Önizleme ─────────────────────────────────────────────────────────────────
+
+interface OnizlemeSatiriProps {
+    vakitAdi: TakvimVakitAdi;
+    gorununumAdi: string;
+    ayar: VakitTakvimAyari;
+    bugunVakitler: Record<TakvimVakitAdi, Date> | null;
+    bugunCikisVakitleri: Record<TakvimVakitAdi, Date> | null;
+}
+
+function saatFormatla(tarih: Date): string {
+    const s = tarih.getHours().toString().padStart(2, '0');
+    const d = tarih.getMinutes().toString().padStart(2, '0');
+    return `${s}:${d}`;
+}
+
+const OnizlemeSatiri: React.FC<OnizlemeSatiriProps> = ({
+    vakitAdi, gorununumAdi, ayar, bugunVakitler, bugunCikisVakitleri,
+}) => {
+    const renkler = useRenkler();
+
+    if (!bugunVakitler || !bugunCikisVakitleri) return null;
+
+    const girisSaati = bugunVakitler[vakitAdi];
+    const cikisSaati = bugunCikisVakitleri[vakitAdi];
+
+    let startDate: Date;
+    const ms = (ayar.dakika || 0) * 60 * 1000;
+    switch (ayar.baslangicTipi) {
+        case 'vakit_girisi':
+            startDate = new Date(girisSaati);
+            break;
+        case 'vakit_sonrasi':
+            startDate = new Date(girisSaati.getTime() + ms);
+            break;
+        case 'vakit_oncesi':
+            startDate = new Date(cikisSaati.getTime() - ms);
+            break;
+    }
+    const endDate = new Date(startDate.getTime() + ayar.sureDakika * 60 * 1000);
+
+    const baslangicAciklamasi = (() => {
+        switch (ayar.baslangicTipi) {
+            case 'vakit_girisi':  return 'Vakit girince';
+            case 'vakit_sonrasi': return `Vakitten ${ayar.dakika || 0} dk sonra`;
+            case 'vakit_oncesi':  return `Vakit çıkmadan ${ayar.dakika || 0} dk önce`;
+        }
+    })();
+
+    return (
+        <View
+            className="flex-row items-start py-3 px-3 rounded-xl mb-2"
+            style={{ backgroundColor: `${renkler.birincil}10` }}
+        >
+            <View
+                className="w-8 h-8 rounded-full items-center justify-center mr-3 mt-0.5"
+                style={{ backgroundColor: `${renkler.birincil}20` }}
+            >
+                <FontAwesome5 name="calendar-check" size={14} color={renkler.birincil} />
+            </View>
+            <View className="flex-1">
+                <Text className="text-sm font-semibold mb-1" style={{ color: renkler.metin }}>
+                    {gorununumAdi} Namazı
+                </Text>
+                <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
+                    {saatFormatla(startDate)} – {saatFormatla(endDate)}
+                    {'  '}({ayar.sureDakika} dk)
+                </Text>
+                <Text className="text-xs mt-0.5" style={{ color: renkler.metinIkincil }}>
+                    {baslangicAciklamasi}
+                </Text>
+            </View>
+        </View>
+    );
+};
+
+// ─── Ana Ekran ────────────────────────────────────────────────────────────────
+
+export const TakvimAyarlariSayfasi: React.FC<any> = () => {
+    const renkler = useRenkler();
+    const dispatch = useAppDispatch();
+    const { butonTiklandiFeedback } = useFeedback();
+
+    const { ayarlar, olayOlusturuluyor } = useAppSelector(state => state.takvim);
+    const koordinatlar = useAppSelector(state => state.konum.koordinatlar);
+
+    const [cihazTakvimleri, setCihazTakvimleri] = useState<Array<{ id: string; title: string; color: string }>>([]);
+    const [takvimYukleniyor, setTakvimYukleniyor] = useState(false);
+
+    const fadeAnim = useRef(new Animated.Value(0)).current;
+    const slideAnim = useRef(new Animated.Value(20)).current;
+
+    useEffect(() => {
+        dispatch(takvimAyarlariniYukle());
+        takvimleriniYenile();
+        Animated.parallel([
+            Animated.timing(fadeAnim, { toValue: 1, duration: 350, useNativeDriver: true }),
+            Animated.timing(slideAnim, { toValue: 0, duration: 350, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+        ]).start();
+    }, []);
+
+    const takvimleriniYenile = async () => {
+        setTakvimYukleniyor(true);
+        const takvimler = await TakvimServisi.getInstance().cihazTakvimleriniGetir();
+        setCihazTakvimleri(takvimler);
+        setTakvimYukleniyor(false);
+    };
+
+    const handleAktifToggle = (val: boolean) => {
+        dispatch(takvimAyarlariniGuncelle({ aktif: val }));
+    };
+
+    const handleTakvimSec = (id: string, adi: string) => {
+        dispatch(takvimAyarlariniGuncelle({ takvimId: id, takvimAdi: adi }));
+    };
+
+    const handleVakitAyarDegistir = (vakit: TakvimVakitAdi, yeni: Partial<VakitTakvimAyari>) => {
+        dispatch(takvimAyarlariniGuncelle({
+            vakitAyarlari: {
+                ...ayarlar.vakitAyarlari,
+                [vakit]: { ...ayarlar.vakitAyarlari[vakit], ...yeni },
+            },
+        }));
+    };
+
+    const handleOlaylariOlustur = async () => {
+        await butonTiklandiFeedback();
+        if (!ayarlar.takvimId) {
+            Alert.alert('Takvim Seçin', 'Lütfen önce bir takvim seçin.');
+            return;
+        }
+        if (!koordinatlar) {
+            Alert.alert('Konum Bulunamadı', 'Lütfen önce konum ayarlarından konumunuzu belirleyin.');
+            return;
+        }
+        const result = await dispatch(takvimOlaylariniOlustur({ ayarlar, koordinatlar }));
+        if (takvimOlaylariniOlustur.fulfilled.match(result)) {
+            Alert.alert('Başarılı', `${result.payload.olusturulanSayi} takvim etkinliği oluşturuldu.`);
+        } else {
+            Alert.alert('Hata', String(result.payload) || 'Etkinlikler oluşturulurken bir hata oluştu.');
+        }
+    };
+
+    // Bugünün vakitleri (önizleme için)
+    const bugunVakitler = useMemo(() => {
+        const hesaplayici = NamazVaktiHesaplayiciServisi.getInstance();
+        const sonuclar = hesaplayici.getGunlukVakitler(new Date());
+        if (!sonuclar) return null;
+        return {
+            imsak:  sonuclar.imsak,
+            ogle:   sonuclar.ogle,
+            ikindi: sonuclar.ikindi,
+            aksam:  sonuclar.aksam,
+            yatsi:  sonuclar.yatsi,
+        } as Record<TakvimVakitAdi, Date>;
+    }, []);
+
+    const bugunCikisVakitleri = useMemo(() => {
+        if (!bugunVakitler) return null;
+        const hesaplayici = NamazVaktiHesaplayiciServisi.getInstance();
+        const bugunTum = hesaplayici.getGunlukVakitler(new Date());
+        if (!bugunTum) return null;
+
+        const yarinTarih = new Date();
+        yarinTarih.setDate(yarinTarih.getDate() + 1);
+        const yarinTum = hesaplayici.getGunlukVakitler(yarinTarih);
+
+        return {
+            imsak:  bugunTum.gunes,
+            ogle:   bugunTum.ikindi,
+            ikindi: bugunTum.aksam,
+            aksam:  bugunTum.yatsi,
+            yatsi:  yarinTum ? yarinTum.imsak : bugunTum.yatsi,
+        } as Record<TakvimVakitAdi, Date>;
+    }, [bugunVakitler]);
+
+    const aktifVakitler = useMemo(
+        () => VAKIT_SIRASI.filter(v => ayarlar.vakitAyarlari[v].aktif),
+        [ayarlar.vakitAyarlari]
+    );
+
+    return (
+        <SafeAreaView className="flex-1" style={{ backgroundColor: renkler.arkaplan }} edges={['bottom', 'left', 'right']}>
+            <ScrollView
+                className="flex-1"
+                contentContainerStyle={{ padding: 16, paddingBottom: 40 }}
+                showsVerticalScrollIndicator={false}
+            >
+                <Animated.View style={{ opacity: fadeAnim, transform: [{ translateY: slideAnim }] }}>
+
+                    {/* Master Toggle */}
+                    <TouchableOpacity
+                        className="flex-row items-center p-4 rounded-2xl mb-4"
+                        style={{ backgroundColor: ayarlar.aktif ? renkler.birincil : renkler.kartArkaplan }}
+                        onPress={() => handleAktifToggle(!ayarlar.aktif)}
+                        activeOpacity={0.8}
+                    >
+                        <View
+                            className="w-11 h-11 rounded-xl items-center justify-center mr-3"
+                            style={{ backgroundColor: ayarlar.aktif ? 'rgba(255,255,255,0.2)' : `${renkler.birincil}15` }}
+                        >
+                            <FontAwesome5
+                                name="calendar-alt"
+                                size={20}
+                                color={ayarlar.aktif ? '#FFF' : renkler.birincil}
+                                solid
+                            />
+                        </View>
+                        <View className="flex-1">
+                            <Text
+                                className="text-base font-semibold"
+                                style={{ color: ayarlar.aktif ? '#FFF' : renkler.metin }}
+                            >
+                                Takvim Entegrasyonu
+                            </Text>
+                            <Text
+                                className="text-xs mt-0.5"
+                                style={{ color: ayarlar.aktif ? 'rgba(255,255,255,0.75)' : renkler.metinIkincil }}
+                            >
+                                {ayarlar.aktif ? 'Aktif — etkinlikler oluşturulacak' : 'Namaz vakitlerini takvime ekle'}
+                            </Text>
+                        </View>
+                        <Switch
+                            value={ayarlar.aktif}
+                            onValueChange={handleAktifToggle}
+                            trackColor={{ false: renkler.sinir, true: 'rgba(255,255,255,0.4)' }}
+                            thumbColor="#FFF"
+                        />
+                    </TouchableOpacity>
+
+                    {/* Pasif durumu */}
+                    {!ayarlar.aktif && (
+                        <View
+                            className="items-center p-10 rounded-2xl"
+                            style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                        >
+                            <FontAwesome5 name="calendar-times" size={48} color={renkler.metinIkincil} />
+                            <Text className="text-base font-semibold mt-4 text-center" style={{ color: renkler.metin }}>
+                                Takvim Entegrasyonu Kapalı
+                            </Text>
+                            <Text className="text-xs text-center mt-2" style={{ color: renkler.metinIkincil }}>
+                                Aktifleştirerek namaz vakitlerini cihaz takviminize otomatik ekleyebilirsiniz.
+                            </Text>
+                        </View>
+                    )}
+
+                    {/* Aktif içerik */}
+                    {ayarlar.aktif && (
+                        <>
+                            {/* Takvim Seçici */}
+                            <View
+                                className="rounded-2xl p-4 mb-4"
+                                style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                            >
+                                <View className="flex-row justify-between items-center mb-3">
+                                    <Text className="text-xs font-bold tracking-wider" style={{ color: renkler.metinIkincil }}>
+                                        TAKVİM SEÇİMİ
+                                    </Text>
+                                    <TouchableOpacity
+                                        onPress={takvimleriniYenile}
+                                        className="flex-row items-center gap-1 px-2 py-1 rounded-lg"
+                                        style={{ backgroundColor: `${renkler.birincil}15` }}
+                                    >
+                                        {takvimYukleniyor
+                                            ? <ActivityIndicator size={12} color={renkler.birincil} />
+                                            : <FontAwesome5 name="sync-alt" size={12} color={renkler.birincil} />
+                                        }
+                                        <Text className="text-xs" style={{ color: renkler.birincil }}>Yenile</Text>
+                                    </TouchableOpacity>
+                                </View>
+
+                                {cihazTakvimleri.length === 0 ? (
+                                    <Text className="text-sm text-center py-4" style={{ color: renkler.metinIkincil }}>
+                                        Cihazınızda düzenlenebilir takvim bulunamadı.
+                                    </Text>
+                                ) : (
+                                    cihazTakvimleri.map(takvim => {
+                                        const secili = ayarlar.takvimId === takvim.id;
+                                        return (
+                                            <TouchableOpacity
+                                                key={takvim.id}
+                                                className="flex-row items-center py-2.5 px-3 rounded-xl mb-1"
+                                                style={{
+                                                    backgroundColor: secili ? `${renkler.birincil}15` : 'transparent',
+                                                    borderWidth: 1,
+                                                    borderColor: secili ? renkler.birincil : renkler.sinir,
+                                                }}
+                                                onPress={() => handleTakvimSec(takvim.id, takvim.title)}
+                                                activeOpacity={0.7}
+                                            >
+                                                <View
+                                                    className="w-3 h-3 rounded-full mr-3"
+                                                    style={{ backgroundColor: takvim.color }}
+                                                />
+                                                <Text
+                                                    className="flex-1 text-sm"
+                                                    style={{ color: secili ? renkler.birincil : renkler.metin, fontWeight: secili ? '600' : '400' }}
+                                                >
+                                                    {takvim.title}
+                                                </Text>
+                                                {secili && (
+                                                    <FontAwesome5 name="check" size={12} color={renkler.birincil} />
+                                                )}
+                                            </TouchableOpacity>
+                                        );
+                                    })
+                                )}
+                            </View>
+
+                            {/* Vakit Ayarları */}
+                            <View
+                                className="rounded-2xl p-4 mb-4"
+                                style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                            >
+                                <Text className="text-xs font-bold tracking-wider mb-3" style={{ color: renkler.metinIkincil }}>
+                                    VAKİT AYARLARI
+                                </Text>
+                                {VAKIT_SIRASI.map((vakit, idx) => (
+                                    <VakitAyarSatiri
+                                        key={vakit}
+                                        vakitAdi={vakit}
+                                        gorununumAdi={VAKIT_GORUNTU_ADLARI[vakit]}
+                                        ayar={ayarlar.vakitAyarlari[vakit]}
+                                        onChange={yeni => handleVakitAyarDegistir(vakit, yeni)}
+                                        sonMu={idx === VAKIT_SIRASI.length - 1}
+                                    />
+                                ))}
+                            </View>
+
+                            {/* Kaç Gün İlerisi */}
+                            <View
+                                className="rounded-2xl p-4 mb-4"
+                                style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                            >
+                                <Text className="text-xs font-bold tracking-wider mb-3" style={{ color: renkler.metinIkincil }}>
+                                    KAÇ GÜN İLERİSİ
+                                </Text>
+                                <View className="flex-row gap-2">
+                                    {([7, 14, 30] as const).map(gun => {
+                                        const secili = ayarlar.kaciGunIlerisi === gun;
+                                        return (
+                                            <TouchableOpacity
+                                                key={gun}
+                                                className="flex-1 py-2.5 rounded-xl items-center"
+                                                style={{
+                                                    backgroundColor: secili ? renkler.birincil : `${renkler.birincil}10`,
+                                                    borderWidth: 1,
+                                                    borderColor: secili ? renkler.birincil : renkler.sinir,
+                                                }}
+                                                onPress={() => dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: gun }))}
+                                                activeOpacity={0.7}
+                                            >
+                                                <Text
+                                                    className="text-sm font-semibold"
+                                                    style={{ color: secili ? '#FFF' : renkler.metinIkincil }}
+                                                >
+                                                    {gun} Gün
+                                                </Text>
+                                            </TouchableOpacity>
+                                        );
+                                    })}
+                                </View>
+                            </View>
+
+                            {/* Önizleme */}
+                            <View
+                                className="rounded-2xl p-4 mb-4"
+                                style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                            >
+                                <Text className="text-xs font-bold tracking-wider mb-3" style={{ color: renkler.metinIkincil }}>
+                                    BUGÜN İÇİN ÖNİZLEME
+                                </Text>
+                                {aktifVakitler.length === 0 ? (
+                                    <View className="items-center py-6">
+                                        <FontAwesome5 name="calendar-minus" size={32} color={renkler.metinIkincil} />
+                                        <Text className="text-sm text-center mt-3" style={{ color: renkler.metinIkincil }}>
+                                            Henüz aktif vakit seçilmedi.{'\n'}Vakit Ayarları bölümünden vakit seçin.
+                                        </Text>
+                                    </View>
+                                ) : (
+                                    aktifVakitler.map(vakit => (
+                                        <OnizlemeSatiri
+                                            key={vakit}
+                                            vakitAdi={vakit}
+                                            gorununumAdi={VAKIT_GORUNTU_ADLARI[vakit]}
+                                            ayar={ayarlar.vakitAyarlari[vakit]}
+                                            bugunVakitler={bugunVakitler}
+                                            bugunCikisVakitleri={bugunCikisVakitleri}
+                                        />
+                                    ))
+                                )}
+                            </View>
+
+                            {/* Etkinlik Oluştur Butonu */}
+                            <TouchableOpacity
+                                className="flex-row items-center justify-center p-4 rounded-2xl mb-3"
+                                style={{ backgroundColor: renkler.birincil }}
+                                onPress={handleOlaylariOlustur}
+                                disabled={olayOlusturuluyor}
+                                activeOpacity={0.8}
+                            >
+                                {olayOlusturuluyor ? (
+                                    <ActivityIndicator color="#FFF" />
+                                ) : (
+                                    <>
+                                        <FontAwesome5 name="calendar-plus" size={16} color="#FFF" solid style={{ marginRight: 8 }} />
+                                        <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                            Olayları Oluştur ({ayarlar.kaciGunIlerisi} gün)
+                                        </Text>
+                                    </>
+                                )}
+                            </TouchableOpacity>
+
+                            {/* Bilgi Notu */}
+                            <View
+                                className="flex-row items-start p-4 rounded-xl"
+                                style={{ backgroundColor: `${renkler.birincil}10` }}
+                            >
+                                <FontAwesome5
+                                    name="info-circle"
+                                    size={14}
+                                    color={renkler.birincil}
+                                    style={{ marginTop: 1, marginRight: 8 }}
+                                />
+                                <Text className="flex-1 text-xs leading-5" style={{ color: renkler.metinIkincil }}>
+                                    Etkinlikler her oluşturmada öncekiler silinerek yeniden oluşturulur.
+                                    Ayarlarınızı değiştirdikten sonra "Olayları Oluştur" butonuna tekrar basmanız gerekir.
+                                </Text>
+                            </View>
+                        </>
+                    )}
+
+                    <View className="h-10" />
+                </Animated.View>
+            </ScrollView>
+        </SafeAreaView>
+    );
+};

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -18,6 +18,9 @@ import {
     Animated,
     Easing,
     Dimensions,
+    Linking,
+    Platform,
+    StyleSheet,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
@@ -34,6 +37,7 @@ import {
 import { TakvimServisi } from '../../domain/services/TakvimServisi';
 import { NamazVaktiHesaplayiciServisi } from '../../domain/services/NamazVaktiHesaplayiciServisi';
 import { useFeedback } from '../../core/feedback';
+import { useDonanimGeriTusu } from '../hooks/useDonanimGeriTusu';
 
 const { height: EKRAN_YUKSEKLIGI } = Dimensions.get('window');
 const THROTTLE_SURESI = 100;
@@ -410,9 +414,181 @@ const OzellikBilgi: React.FC = () => {
     );
 };
 
+// ─── Takvim uygulamasını aç ─────────────────────────────────────────────────
+
+async function takvimUygulamasiniAc(): Promise<boolean> {
+    // Android: takvim provider intent · iOS: calshow scheme
+    const url = Platform.OS === 'ios'
+        ? 'calshow:'
+        : 'content://com.android.calendar/time/';
+    try {
+        await Linking.openURL(url);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// ─── BasariIcerigi (paylaşılan başarı ekranı) ────────────────────────────────
+
+interface OzetSatir {
+    ikon: string;
+    etiket: string;
+    deger: string;
+}
+
+interface BasariIcerigiProps {
+    tip: 'olusturma' | 'temizleme';
+    baslik: string;
+    altBaslik: string;
+    satirlar: OzetSatir[];
+    onTakvimiAc: () => void;
+    onKapat: () => void;
+}
+
+const BasariIcerigi: React.FC<BasariIcerigiProps> = ({
+    tip, baslik, altBaslik, satirlar, onTakvimiAc, onKapat,
+}) => {
+    const renkler = useRenkler();
+    const renk = tip === 'olusturma' ? '#22C55E' : '#EF4444';
+
+    const ikonScale = useRef(new Animated.Value(0)).current;
+    const halkaScale = useRef(new Animated.Value(0)).current;
+    const halkaOpacity = useRef(new Animated.Value(0.45)).current;
+    const icerikOpacity = useRef(new Animated.Value(0)).current;
+    const icerikY = useRef(new Animated.Value(14)).current;
+
+    useEffect(() => {
+        Animated.sequence([
+            Animated.spring(ikonScale, {
+                toValue: 1, friction: 5, tension: 140, useNativeDriver: true,
+            }),
+        ]).start();
+
+        Animated.loop(
+            Animated.parallel([
+                Animated.timing(halkaScale, {
+                    toValue: 1, duration: 1400, easing: Easing.out(Easing.ease), useNativeDriver: true,
+                }),
+                Animated.timing(halkaOpacity, {
+                    toValue: 0, duration: 1400, easing: Easing.out(Easing.ease), useNativeDriver: true,
+                }),
+            ])
+        ).start();
+
+        Animated.parallel([
+            Animated.timing(icerikOpacity, {
+                toValue: 1, duration: 320, delay: 140, useNativeDriver: true,
+            }),
+            Animated.timing(icerikY, {
+                toValue: 0, duration: 320, delay: 140, easing: Easing.out(Easing.cubic), useNativeDriver: true,
+            }),
+        ]).start();
+    }, []);
+
+    return (
+        <View className="px-6 pt-2 pb-1 items-center">
+            {/* Animasyonlu ikon + pulse halka */}
+            <View className="items-center justify-center mb-4" style={{ width: 96, height: 96 }}>
+                <Animated.View
+                    style={{
+                        position: 'absolute',
+                        width: 96, height: 96, borderRadius: 48,
+                        backgroundColor: renk,
+                        opacity: halkaOpacity,
+                        transform: [{ scale: halkaScale.interpolate({ inputRange: [0, 1], outputRange: [0.7, 1.35] }) }],
+                    }}
+                />
+                <Animated.View
+                    style={{
+                        width: 76, height: 76, borderRadius: 38,
+                        backgroundColor: `${renk}1A`,
+                        alignItems: 'center', justifyContent: 'center',
+                        transform: [{ scale: ikonScale }],
+                    }}
+                >
+                    <View
+                        style={{
+                            width: 52, height: 52, borderRadius: 26,
+                            backgroundColor: renk,
+                            alignItems: 'center', justifyContent: 'center',
+                        }}
+                    >
+                        <FontAwesome5 name="check" size={24} color="#FFF" />
+                    </View>
+                </Animated.View>
+            </View>
+
+            <Animated.View
+                style={{ opacity: icerikOpacity, transform: [{ translateY: icerikY }], alignSelf: 'stretch' }}
+            >
+                <Text className="text-lg font-bold text-center" style={{ color: renkler.metin }}>
+                    {baslik}
+                </Text>
+                <Text className="text-sm text-center mt-1 leading-5" style={{ color: renkler.metinIkincil }}>
+                    {altBaslik}
+                </Text>
+
+                {/* Özet kartı */}
+                <View
+                    className="rounded-2xl mt-5 mb-5 overflow-hidden"
+                    style={{ borderWidth: 1, borderColor: renkler.sinir }}
+                >
+                    {satirlar.map((s, i) => (
+                        <View
+                            key={s.etiket}
+                            className="flex-row items-center px-4 py-3"
+                            style={{
+                                borderBottomWidth: i < satirlar.length - 1 ? 1 : 0,
+                                borderBottomColor: renkler.sinir,
+                            }}
+                        >
+                            <View
+                                className="w-8 h-8 rounded-lg items-center justify-center mr-3"
+                                style={{ backgroundColor: `${renk}15` }}
+                            >
+                                <FontAwesome5 name={s.ikon} size={13} color={renk} />
+                            </View>
+                            <Text className="text-sm flex-1" style={{ color: renkler.metinIkincil }}>
+                                {s.etiket}
+                            </Text>
+                            <Text className="text-sm font-semibold ml-2 text-right flex-shrink" style={{ color: renkler.metin }} numberOfLines={1}>
+                                {s.deger}
+                            </Text>
+                        </View>
+                    ))}
+                </View>
+
+                {/* CTA */}
+                <TouchableOpacity
+                    className="flex-row items-center justify-center p-4 rounded-2xl mb-2.5"
+                    style={{ backgroundColor: renkler.birincil }}
+                    onPress={onTakvimiAc}
+                    activeOpacity={0.85}
+                >
+                    <FontAwesome5 name="external-link-alt" size={14} color="#FFF" style={{ marginRight: 8 }} />
+                    <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                        Takvim Uygulamasını Aç
+                    </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                    className="items-center justify-center p-3.5 rounded-2xl"
+                    style={{ backgroundColor: renkler.arkaplan, borderWidth: 1, borderColor: renkler.sinir }}
+                    onPress={onKapat}
+                    activeOpacity={0.7}
+                >
+                    <Text className="text-sm font-semibold" style={{ color: renkler.metinIkincil }}>
+                        Tamam
+                    </Text>
+                </TouchableOpacity>
+            </Animated.View>
+        </View>
+    );
+};
+
 // ─── TemizleModali ────────────────────────────────────────────────────────────
 
-type TemizleAdim = 'kriter' | 'taraniyor' | 'onay';
+type TemizleAdim = 'kriter' | 'taraniyor' | 'onay' | 'tamamlandi';
 type TakvimModTipi = 'secili' | 'tumu';
 
 interface BulunanEtkinlik {
@@ -425,7 +601,6 @@ interface BulunanEtkinlik {
 interface TemizleModaliProps {
     gorunur: boolean;
     onKapat: () => void;
-    onTemizlendi: (silinen: number, ozet: string) => void;
     secilenTakvimId: string | null;
     secilenTakvimAdi: string | null;
     cihazTakvimleri: Array<{ id: string; title: string; color: string }>;
@@ -438,7 +613,7 @@ const ARALIK_PRESETLER: { gun: number; etiket: string; aciklama: string }[] = [
 ];
 
 const TemizleModali: React.FC<TemizleModaliProps> = ({
-    gorunur, onKapat, onTemizlendi,
+    gorunur, onKapat,
     secilenTakvimId, secilenTakvimAdi, cihazTakvimleri,
 }) => {
     const renkler = useRenkler();
@@ -452,6 +627,7 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
     );
     const [bulunanEtkinlikler, setBulunanEtkinlikler] = useState<BulunanEtkinlik[]>([]);
     const [siliniyor, setSiliniyor] = useState(false);
+    const [silinenSayi, setSilinenSayi] = useState(0);
 
     useEffect(() => {
         if (!gorunur) {
@@ -462,6 +638,7 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
             setSecilenVakitler(new Set<TakvimVakitAdi>(VAKIT_SIRASI));
             setBulunanEtkinlikler([]);
             setSiliniyor(false);
+            setSilinenSayi(0);
         }
     }, [gorunur]);
 
@@ -521,17 +698,34 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
         try {
             const ids = bulunanEtkinlikler.map(e => e.id);
             const silinen = await TakvimServisi.getInstance().etkinlikleriSil(ids);
-
-            const takvimOzeti = takvimMod === 'tumu' ? 'Tüm takvimler' : (secilenTakvimAdi ?? 'Seçili takvim');
-            const vakitOzeti = secilenVakitler.size === VAKIT_SIRASI.length
-                ? 'tüm vakitler'
-                : Array.from(secilenVakitler).map(v => VAKIT_GORUNTU_ADLARI[v]).join(', ');
-            onTemizlendi(silinen, `${takvimOzeti} · ${aralikGun} gün · ${vakitOzeti}`);
-            onKapat();
+            setSilinenSayi(silinen);
+            setSiliniyor(false);
+            setAdim('tamamlandi');
         } catch {
             setSiliniyor(false);
         }
     };
+
+    const handleTakvimiAc = async () => {
+        await takvimUygulamasiniAc();
+    };
+
+    const temizlemeOzetSatirlari: OzetSatir[] = [
+        { ikon: 'trash-alt', etiket: 'Silinen', deger: `${silinenSayi} etkinlik` },
+        {
+            ikon: takvimMod === 'tumu' ? 'layer-group' : 'bookmark',
+            etiket: 'Takvim',
+            deger: takvimMod === 'tumu' ? 'Tüm takvimler' : (secilenTakvimAdi ?? 'Seçili takvim'),
+        },
+        { ikon: 'clock', etiket: 'Aralık', deger: `${aralikGun} gün` },
+        {
+            ikon: 'list-ul',
+            etiket: 'Vakitler',
+            deger: secilenVakitler.size === VAKIT_SIRASI.length
+                ? 'Tüm vakitler'
+                : Array.from(secilenVakitler).map(v => VAKIT_GORUNTU_ADLARI[v]).join(', '),
+        },
+    ];
 
     const takvimRengi = (tid: string) =>
         cihazTakvimleri.find(t => t.id === tid)?.color ?? '#007AFF';
@@ -556,20 +750,34 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
 
     const taraButonuAktif = takvimMod === 'secili' ? !!secilenTakvimId : cihazTakvimleri.length > 0;
 
+    // Android donanim geri tusu + backdrop dokunusu: adima gore akilli davranis
+    const handleGeriIstegi = useCallback(() => {
+        if (siliniyor) return;
+        if (adim === 'onay') setAdim('kriter');
+        else if (adim === 'taraniyor') { /* tarama suruyor, yok say */ }
+        else onKapat();
+    }, [siliniyor, adim, onKapat]);
+
+    // New Architecture'da Modal onRequestClose guvenilir degil → BackHandler ile garanti
+    useDonanimGeriTusu(gorunur, handleGeriIstegi);
+
     return (
-        <Modal visible={gorunur} animationType="slide" transparent statusBarTranslucent>
-            <TouchableWithoutFeedback onPress={adim === 'kriter' ? onKapat : undefined}>
-                <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' }}>
-                    <TouchableWithoutFeedback>
-                        <View
-                            style={{
-                                backgroundColor: renkler.kartArkaplan,
-                                borderTopLeftRadius: 24,
-                                borderTopRightRadius: 24,
-                                height: EKRAN_YUKSEKLIGI * 0.87,
-                                paddingBottom: 32,
-                            }}
-                        >
+        <Modal visible={gorunur} animationType="slide" transparent statusBarTranslucent onRequestClose={handleGeriIstegi}>
+            <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+                {/* Backdrop — absolute sibling: FlatList/ScrollView gesture'larini engellemez */}
+                <TouchableWithoutFeedback onPress={adim === 'kriter' ? onKapat : undefined}>
+                    <View style={[StyleSheet.absoluteFill, { backgroundColor: 'rgba(0,0,0,0.5)' }]} />
+                </TouchableWithoutFeedback>
+
+                <View
+                    style={{
+                        backgroundColor: renkler.kartArkaplan,
+                        borderTopLeftRadius: 24,
+                        borderTopRightRadius: 24,
+                        height: EKRAN_YUKSEKLIGI * 0.87,
+                        paddingBottom: 32,
+                    }}
+                >
                             {/* Handle */}
                             <View className="items-center pt-3 pb-2">
                                 <View
@@ -903,10 +1111,27 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
                                     </View>
                                 </View>
                             )}
-                        </View>
-                    </TouchableWithoutFeedback>
+
+                            {/* ── Aşama: Tamamlandı (başarı) ── */}
+                            {adim === 'tamamlandi' && (
+                                <ScrollView
+                                    showsVerticalScrollIndicator={false}
+                                    contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
+                                >
+                                    <BasariIcerigi
+                                        tip="temizleme"
+                                        baslik="Etkinlikler Temizlendi"
+                                        altBaslik={silinenSayi > 0
+                                            ? 'Seçtiğin etkinlikler takvimden başarıyla silindi.'
+                                            : 'Belirtilen kriterlerde silinecek etkinlik kalmadı.'}
+                                        satirlar={temizlemeOzetSatirlari}
+                                        onTakvimiAc={handleTakvimiAc}
+                                        onKapat={onKapat}
+                                    />
+                                </ScrollView>
+                            )}
                 </View>
-            </TouchableWithoutFeedback>
+            </View>
         </Modal>
     );
 };
@@ -930,6 +1155,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
     const [takvimYukleniyor, setTakvimYukleniyor] = useState(false);
     const [temizleModaliGorunur, setTemizleModaliGorunur] = useState(false);
     const [ozelGunAktif, setOzelGunAktif] = useState(false);
+    const [olusturmaSonucu, setOlusturmaSonucu] = useState<{ sayi: number } | null>(null);
     const [bildirim, setBildirim] = useState<Bildirim | null>(null);
     const bildirimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -985,7 +1211,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
 
         const result = await dispatch(takvimOlaylariniOlustur({ ayarlar, koordinatlar }));
         if (takvimOlaylariniOlustur.fulfilled.match(result)) {
-            bildirimGoster(`${result.payload.olusturulanSayi} etkinlik takvime eklendi.`, 'basari');
+            setOlusturmaSonucu({ sayi: result.payload.olusturulanSayi });
         } else {
             bildirimGoster(String(result.payload) || 'Etkinlikler oluşturulurken hata oluştu.', 'hata');
         }
@@ -1018,6 +1244,10 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
         () => VAKIT_SIRASI.filter(v => ayarlar.vakitAyarlari[v].aktif),
         [ayarlar.vakitAyarlari]
     );
+
+    // Oluşturma başarı modalında donanım geri tuşu modalı kapatsın (ekrandan çıkmasın)
+    const sonucModaliniKapat = useCallback(() => setOlusturmaSonucu(null), []);
+    useDonanimGeriTusu(olusturmaSonucu !== null, sonucModaliniKapat);
 
     const olusturButonuMesaji = !ayarlar.takvimId
         ? 'Takvim seçilmedi'
@@ -1325,14 +1555,60 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
             <TemizleModali
                 gorunur={temizleModaliGorunur}
                 onKapat={() => setTemizleModaliGorunur(false)}
-                onTemizlendi={(silinen, ozet) => {
-                    setTemizleModaliGorunur(false);
-                    bildirimGoster(`${silinen} etkinlik temizlendi. (${ozet})`, 'basari');
-                }}
                 secilenTakvimId={ayarlar.takvimId}
                 secilenTakvimAdi={ayarlar.takvimAdi}
                 cihazTakvimleri={cihazTakvimleri}
             />
+
+            {/* Oluşturma Başarı Modalı */}
+            <Modal
+                visible={olusturmaSonucu !== null}
+                animationType="slide"
+                transparent
+                statusBarTranslucent
+                onRequestClose={() => setOlusturmaSonucu(null)}
+            >
+                <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+                    <TouchableWithoutFeedback onPress={() => setOlusturmaSonucu(null)}>
+                        <View style={[StyleSheet.absoluteFill, { backgroundColor: 'rgba(0,0,0,0.5)' }]} />
+                    </TouchableWithoutFeedback>
+                    <View
+                        style={{
+                            backgroundColor: renkler.kartArkaplan,
+                            borderTopLeftRadius: 24,
+                            borderTopRightRadius: 24,
+                            paddingBottom: 32,
+                        }}
+                    >
+                        <View className="items-center pt-3 pb-1">
+                            <View style={{ width: 40, height: 4, borderRadius: 2, backgroundColor: renkler.sinir }} />
+                        </View>
+                        {olusturmaSonucu && (
+                            <BasariIcerigi
+                                tip="olusturma"
+                                baslik="Etkinlikler Oluşturuldu"
+                                altBaslik={olusturmaSonucu.sayi > 0
+                                    ? 'Namaz vakitlerin takvimine başarıyla eklendi.'
+                                    : 'Eklenecek aktif vakit bulunamadı. Vakit ayarlarını kontrol et.'}
+                                satirlar={[
+                                    { ikon: 'calendar-check', etiket: 'Oluşturulan', deger: `${olusturmaSonucu.sayi} etkinlik` },
+                                    { ikon: 'bookmark', etiket: 'Takvim', deger: ayarlar.takvimAdi ?? '—' },
+                                    { ikon: 'clock', etiket: 'Süre', deger: `${ayarlar.kaciGunIlerisi} gün` },
+                                    {
+                                        ikon: 'list-ul',
+                                        etiket: 'Vakitler',
+                                        deger: aktifVakitler.length === VAKIT_SIRASI.length
+                                            ? 'Tüm vakitler'
+                                            : aktifVakitler.map(v => VAKIT_GORUNTU_ADLARI[v]).join(', ') || '—',
+                                    },
+                                ]}
+                                onTakvimiAc={() => { takvimUygulamasiniAc(); }}
+                                onKapat={() => setOlusturmaSonucu(null)}
+                            />
+                        )}
+                    </View>
+                </View>
+            </Modal>
         </SafeAreaView>
     );
 };

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -192,7 +192,7 @@ const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
                                 {ayar.baslangicTipi === 'vakit_oncesi' ? 'Kaç dk önce' : 'Kaç dk sonra'}
                             </Text>
                             <SayisalSecici
-                                deger={ayar.dakika || 5}
+                                deger={ayar.dakika}
                                 min={1}
                                 max={60}
                                 adim={5}
@@ -318,12 +318,18 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
 
     useEffect(() => {
         dispatch(takvimAyarlariniYukle());
-        takvimleriniYenile();
         Animated.parallel([
             Animated.timing(fadeAnim, { toValue: 1, duration: 350, useNativeDriver: true }),
             Animated.timing(slideAnim, { toValue: 0, duration: 350, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
         ]).start();
     }, []);
+
+    // Takvim izni sadece entegrasyon aktif olduğunda istenir (App Store/Play politikalari)
+    useEffect(() => {
+        if (ayarlar.aktif) {
+            takvimleriniYenile();
+        }
+    }, [ayarlar.aktif]);
 
     const takvimleriniYenile = async () => {
         setTakvimYukleniyor(true);
@@ -488,7 +494,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                         style={{ backgroundColor: `${renkler.birincil}15` }}
                                     >
                                         {takvimYukleniyor
-                                            ? <ActivityIndicator size={12} color={renkler.birincil} />
+                                            ? <ActivityIndicator size="small" color={renkler.birincil} />
                                             : <FontAwesome5 name="sync-alt" size={12} color={renkler.birincil} />
                                         }
                                         <Text className="text-xs" style={{ color: renkler.birincil }}>Yenile</Text>

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -431,7 +431,7 @@ interface TemizleModaliProps {
     cihazTakvimleri: Array<{ id: string; title: string; color: string }>;
 }
 
-const ARALIK_PRESETLER: { gun: 7 | 30 | 90; etiket: string; aciklama: string }[] = [
+const ARALIK_PRESETLER: { gun: number; etiket: string; aciklama: string }[] = [
     { gun: 7,  etiket: '7 Gün',  aciklama: 'Bu hafta' },
     { gun: 30, etiket: '30 Gün', aciklama: 'Bu ay' },
     { gun: 90, etiket: '90 Gün', aciklama: '3 ay' },
@@ -445,7 +445,8 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
 
     const [adim, setAdim] = useState<TemizleAdim>('kriter');
     const [takvimMod, setTakvimMod] = useState<TakvimModTipi>('secili');
-    const [aralikGun, setAralikGun] = useState<7 | 30 | 90>(30);
+    const [aralikGun, setAralikGun] = useState<number>(30);
+    const [ozelAralikAktif, setOzelAralikAktif] = useState(false);
     const [secilenVakitler, setSecilenVakitler] = useState<Set<TakvimVakitAdi>>(
         new Set<TakvimVakitAdi>(VAKIT_SIRASI)
     );
@@ -457,6 +458,7 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
             setAdim('kriter');
             setTakvimMod('secili');
             setAralikGun(30);
+            setOzelAralikAktif(false);
             setSecilenVakitler(new Set<TakvimVakitAdi>(VAKIT_SIRASI));
             setBulunanEtkinlikler([]);
             setSiliniyor(false);
@@ -564,7 +566,7 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
                                 backgroundColor: renkler.kartArkaplan,
                                 borderTopLeftRadius: 24,
                                 borderTopRightRadius: 24,
-                                maxHeight: EKRAN_YUKSEKLIGI * 0.87,
+                                height: EKRAN_YUKSEKLIGI * 0.87,
                                 paddingBottom: 32,
                             }}
                         >
@@ -667,9 +669,9 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
                                     <Text className="text-xs font-bold tracking-wider mb-2" style={{ color: renkler.metinIkincil }}>
                                         ZAMAN ARALIĞI (BUGÜNDEN İTİBAREN)
                                     </Text>
-                                    <View className="flex-row gap-2 mb-4">
+                                    <View className="flex-row gap-2 mb-2">
                                         {ARALIK_PRESETLER.map(({ gun, etiket, aciklama }) => {
-                                            const secili = aralikGun === gun;
+                                            const secili = !ozelAralikAktif && aralikGun === gun;
                                             return (
                                                 <TouchableOpacity
                                                     key={gun}
@@ -679,7 +681,7 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
                                                         borderWidth: 1,
                                                         borderColor: secili ? renkler.birincil : renkler.sinir,
                                                     }}
-                                                    onPress={() => setAralikGun(gun)}
+                                                    onPress={() => { setAralikGun(gun); setOzelAralikAktif(false); }}
                                                     activeOpacity={0.7}
                                                 >
                                                     <Text className="text-sm font-bold" style={{ color: secili ? '#FFF' : renkler.metin }}>
@@ -691,7 +693,45 @@ const TemizleModali: React.FC<TemizleModaliProps> = ({
                                                 </TouchableOpacity>
                                             );
                                         })}
+                                        <TouchableOpacity
+                                            className="flex-1 py-3 rounded-2xl items-center"
+                                            style={{
+                                                backgroundColor: ozelAralikAktif ? renkler.birincil : renkler.arkaplan,
+                                                borderWidth: 1,
+                                                borderColor: ozelAralikAktif ? renkler.birincil : renkler.sinir,
+                                            }}
+                                            onPress={() => {
+                                                if (!ozelAralikAktif) {
+                                                    const presetler = ARALIK_PRESETLER.map(p => p.gun);
+                                                    if (presetler.includes(aralikGun)) setAralikGun(60);
+                                                }
+                                                setOzelAralikAktif(true);
+                                            }}
+                                            activeOpacity={0.7}
+                                        >
+                                            <Text className="text-sm font-bold" style={{ color: ozelAralikAktif ? '#FFF' : renkler.metin }}>
+                                                Özel
+                                            </Text>
+                                            <Text className="text-xs mt-0.5" style={{ color: ozelAralikAktif ? 'rgba(255,255,255,0.75)' : renkler.metinIkincil }}>
+                                                Gün gir
+                                            </Text>
+                                        </TouchableOpacity>
                                     </View>
+                                    {ozelAralikAktif && (
+                                        <View className="flex-row items-center justify-between mt-1 mb-2">
+                                            <Text className="text-sm" style={{ color: renkler.metin }}>Gün sayısı</Text>
+                                            <SayisalSecici
+                                                deger={aralikGun}
+                                                min={1}
+                                                max={365}
+                                                adim={1}
+                                                birim="gün"
+                                                onChange={setAralikGun}
+                                                renk={renkler.birincil}
+                                            />
+                                        </View>
+                                    )}
+                                    <View className="mb-1" />
 
                                     {/* Vakitler */}
                                     <View className="flex-row items-center justify-between mb-2">
@@ -889,6 +929,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
     const [cihazTakvimleri, setCihazTakvimleri] = useState<Array<{ id: string; title: string; color: string }>>([]);
     const [takvimYukleniyor, setTakvimYukleniyor] = useState(false);
     const [temizleModaliGorunur, setTemizleModaliGorunur] = useState(false);
+    const [ozelGunAktif, setOzelGunAktif] = useState(false);
     const [bildirim, setBildirim] = useState<Bildirim | null>(null);
     const bildirimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -1131,9 +1172,9 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 <Text className="text-xs font-bold tracking-wider mb-3" style={{ color: renkler.metinIkincil }}>
                                     KAÇ GÜN İLERİSİ
                                 </Text>
-                                <View className="flex-row gap-2">
+                                <View className="flex-row gap-2 mb-2">
                                     {([7, 14, 30] as const).map(gun => {
-                                        const secili = ayarlar.kaciGunIlerisi === gun;
+                                        const secili = !ozelGunAktif && ayarlar.kaciGunIlerisi === gun;
                                         return (
                                             <TouchableOpacity
                                                 key={gun}
@@ -1143,7 +1184,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                                     borderWidth: 1,
                                                     borderColor: secili ? renkler.birincil : renkler.sinir,
                                                 }}
-                                                onPress={() => dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: gun }))}
+                                                onPress={() => { dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: gun })); setOzelGunAktif(false); }}
                                                 activeOpacity={0.7}
                                             >
                                                 <Text className="text-sm font-semibold" style={{ color: secili ? '#FFF' : renkler.metinIkincil }}>
@@ -1152,7 +1193,42 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                             </TouchableOpacity>
                                         );
                                     })}
+                                    <TouchableOpacity
+                                        className="flex-1 py-2.5 rounded-xl items-center"
+                                        style={{
+                                            backgroundColor: ozelGunAktif ? renkler.birincil : `${renkler.birincil}10`,
+                                            borderWidth: 1,
+                                            borderColor: ozelGunAktif ? renkler.birincil : renkler.sinir,
+                                        }}
+                                        onPress={() => {
+                                            if (!ozelGunAktif) {
+                                                if ([7, 14, 30].includes(ayarlar.kaciGunIlerisi)) {
+                                                    dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: 60 }));
+                                                }
+                                            }
+                                            setOzelGunAktif(true);
+                                        }}
+                                        activeOpacity={0.7}
+                                    >
+                                        <Text className="text-sm font-semibold" style={{ color: ozelGunAktif ? '#FFF' : renkler.metinIkincil }}>
+                                            Özel
+                                        </Text>
+                                    </TouchableOpacity>
                                 </View>
+                                {ozelGunAktif && (
+                                    <View className="flex-row items-center justify-between mt-1">
+                                        <Text className="text-sm" style={{ color: renkler.metin }}>Gün sayısı</Text>
+                                        <SayisalSecici
+                                            deger={ayarlar.kaciGunIlerisi}
+                                            min={1}
+                                            max={90}
+                                            adim={1}
+                                            birim="gün"
+                                            onChange={v => dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: v }))}
+                                            renk={renkler.birincil}
+                                        />
+                                    </View>
+                                )}
                             </View>
 
                             {/* Önizleme */}

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -127,15 +127,7 @@ const SayisalSecici: React.FC<SayisalSeciciProps> = ({
     );
 };
 
-// ─── VakitAyarSatiri ──────────────────────────────────────────────────────────
-
-interface VakitAyarSatiriProps {
-    vakitAdi: TakvimVakitAdi;
-    gorununumAdi: string;
-    ayar: VakitTakvimAyari;
-    onChange: (yeni: Partial<VakitTakvimAyari>) => void;
-    sonMu: boolean;
-}
+// ─── VakitSatiri (kompakt satır) ──────────────────────────────────────────────
 
 const BASLANGIC_TIPLERI: { tip: BaslangicTipi; etiket: string; aciklama: string }[] = [
     { tip: 'vakit_oncesi',  etiket: 'Çıkmadan Önce', aciklama: 'Vakit bitmeden X dk önce' },
@@ -143,96 +135,68 @@ const BASLANGIC_TIPLERI: { tip: BaslangicTipi; etiket: string; aciklama: string 
     { tip: 'vakit_sonrasi', etiket: 'Vakitten Sonra', aciklama: 'Vakit girdikten X dk sonra' },
 ];
 
-const VakitAyarSatiri: React.FC<VakitAyarSatiriProps> = ({
-    vakitAdi, gorununumAdi, ayar, onChange, sonMu,
-}) => {
+function vakitOzetMetni(ayar: VakitTakvimAyari): string {
+    if (!ayar.aktif) return 'Kapalı — eklenmeyecek';
+    const baslangic =
+        ayar.baslangicTipi === 'vakit_girisi' ? 'Vakitte başlar'
+        : ayar.baslangicTipi === 'vakit_oncesi' ? `Çıkmadan ${ayar.dakika} dk önce`
+        : `Vakitten ${ayar.dakika} dk sonra`;
+    return `${baslangic} · ${ayar.sureDakika} dk`;
+}
+
+interface VakitSatiriProps {
+    gorununumAdi: string;
+    ayar: VakitTakvimAyari;
+    onAc: () => void;
+    onToggle: (v: boolean) => void;
+    sonMu: boolean;
+}
+
+const VakitSatiri: React.FC<VakitSatiriProps> = ({ gorununumAdi, ayar, onAc, onToggle, sonMu }) => {
     const renkler = useRenkler();
 
     return (
-        <View
-            className="py-3"
+        <TouchableOpacity
+            className="flex-row items-center py-3"
             style={!sonMu ? { borderBottomWidth: 1, borderBottomColor: renkler.sinir } : undefined}
+            onPress={onAc}
+            activeOpacity={0.6}
         >
-            <View className="flex-row justify-between items-center">
+            <View
+                className="w-9 h-9 rounded-xl items-center justify-center mr-3"
+                style={{ backgroundColor: ayar.aktif ? `${renkler.birincil}15` : renkler.arkaplan }}
+            >
+                <FontAwesome5
+                    name={ayar.aktif ? 'check' : 'minus'}
+                    size={13}
+                    color={ayar.aktif ? renkler.birincil : renkler.metinIkincil}
+                />
+            </View>
+            <View className="flex-1">
                 <Text className="text-sm font-semibold" style={{ color: renkler.metin }}>
                     {gorununumAdi} Vakti
                 </Text>
-                <Switch
-                    value={ayar.aktif}
-                    onValueChange={v => onChange({ aktif: v })}
-                    trackColor={{ false: renkler.sinir, true: `${renkler.birincil}60` }}
-                    thumbColor={ayar.aktif ? renkler.birincil : '#f4f3f4'}
-                />
+                <Text
+                    className="text-xs mt-0.5"
+                    style={{ color: ayar.aktif ? renkler.birincil : renkler.metinIkincil }}
+                    numberOfLines={1}
+                >
+                    {vakitOzetMetni(ayar)}
+                </Text>
             </View>
-
-            {ayar.aktif && (
-                <View className="mt-3 gap-3">
-                    <View>
-                        <Text className="text-xs mb-2" style={{ color: renkler.metinIkincil }}>
-                            Etkinlik Ne Zaman Başlasın
-                        </Text>
-                        <View className="flex-row gap-1">
-                            {BASLANGIC_TIPLERI.map(({ tip, etiket }) => {
-                                const secili = ayar.baslangicTipi === tip;
-                                return (
-                                    <TouchableOpacity
-                                        key={tip}
-                                        onPress={() => onChange({ baslangicTipi: tip })}
-                                        className="flex-1 py-2 px-1 rounded-lg items-center"
-                                        style={{
-                                            backgroundColor: secili ? renkler.birincil : `${renkler.birincil}15`,
-                                            borderWidth: 1,
-                                            borderColor: secili ? renkler.birincil : renkler.sinir,
-                                        }}
-                                        activeOpacity={0.7}
-                                    >
-                                        <Text
-                                            className="text-xs font-semibold text-center"
-                                            style={{ color: secili ? '#FFF' : renkler.metinIkincil }}
-                                            numberOfLines={2}
-                                        >
-                                            {etiket}
-                                        </Text>
-                                    </TouchableOpacity>
-                                );
-                            })}
-                        </View>
-                    </View>
-
-                    {ayar.baslangicTipi !== 'vakit_girisi' && (
-                        <View className="flex-row justify-between items-center">
-                            <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
-                                {ayar.baslangicTipi === 'vakit_oncesi' ? 'Kaç dk önce' : 'Kaç dk sonra'}
-                            </Text>
-                            <SayisalSecici
-                                deger={ayar.dakika}
-                                min={1}
-                                max={60}
-                                adim={5}
-                                birim="dk"
-                                onChange={v => onChange({ dakika: v })}
-                                renk={renkler.birincil}
-                            />
-                        </View>
-                    )}
-
-                    <View className="flex-row justify-between items-center">
-                        <Text className="text-xs" style={{ color: renkler.metinIkincil }}>
-                            Etkinlik Süresi
-                        </Text>
-                        <SayisalSecici
-                            deger={ayar.sureDakika}
-                            min={5}
-                            max={120}
-                            adim={5}
-                            birim="dk"
-                            onChange={v => onChange({ sureDakika: v })}
-                            renk={renkler.birincil}
-                        />
-                    </View>
-                </View>
-            )}
-        </View>
+            <FontAwesome5
+                name="sliders-h"
+                size={13}
+                color={renkler.metinIkincil}
+                style={{ marginRight: 12, opacity: 0.55 }}
+            />
+            <Switch
+                value={ayar.aktif}
+                onValueChange={onToggle}
+                trackColor={{ false: renkler.sinir, true: `${renkler.birincil}60` }}
+                thumbColor={ayar.aktif ? renkler.birincil : '#f4f3f4'}
+            />
+        </TouchableOpacity>
     );
 };
 
@@ -306,6 +270,199 @@ const OnizlemeSatiri: React.FC<OnizlemeSatiriProps> = ({
                 </Text>
             </View>
         </View>
+    );
+};
+
+// ─── VakitEditorModali (bottom-sheet) ─────────────────────────────────────────
+
+interface VakitEditorModaliProps {
+    gorunur: boolean;
+    onKapat: () => void;
+    vakitAdi: TakvimVakitAdi | null;
+    ayar: VakitTakvimAyari | null;
+    onChange: (yeni: Partial<VakitTakvimAyari>) => void;
+    bugunVakitler: Record<TakvimVakitAdi, Date> | null;
+    bugunCikisVakitleri: Record<TakvimVakitAdi, Date> | null;
+}
+
+const VakitEditorModali: React.FC<VakitEditorModaliProps> = ({
+    gorunur, onKapat, vakitAdi, ayar, onChange, bugunVakitler, bugunCikisVakitleri,
+}) => {
+    const renkler = useRenkler();
+    useDonanimGeriTusu(gorunur, onKapat);
+
+    // Kapanış slide-out'u sırasında içerik kaybolmasın diye son geçerli değeri tut
+    const snapRef = useRef<{ vakitAdi: TakvimVakitAdi; ayar: VakitTakvimAyari } | null>(null);
+    if (vakitAdi && ayar) snapRef.current = { vakitAdi, ayar };
+    const snap = snapRef.current;
+
+    const aktifVakit = vakitAdi ?? snap?.vakitAdi ?? null;
+    const aktifAyar = ayar ?? snap?.ayar ?? null;
+    const gorununumAdi = aktifVakit ? VAKIT_GORUNTU_ADLARI[aktifVakit] : '';
+
+    return (
+        <Modal visible={gorunur} animationType="slide" transparent statusBarTranslucent onRequestClose={onKapat}>
+            <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+                <TouchableWithoutFeedback onPress={onKapat}>
+                    <View style={[StyleSheet.absoluteFill, { backgroundColor: 'rgba(0,0,0,0.5)' }]} />
+                </TouchableWithoutFeedback>
+
+                <View
+                    style={{
+                        backgroundColor: renkler.kartArkaplan,
+                        borderTopLeftRadius: 24,
+                        borderTopRightRadius: 24,
+                        paddingBottom: 32,
+                    }}
+                >
+                    {/* Handle */}
+                    <View className="items-center pt-3 pb-1">
+                        <View style={{ width: 40, height: 4, borderRadius: 2, backgroundColor: renkler.sinir }} />
+                    </View>
+
+                    {aktifVakit && aktifAyar && (
+                        <View className="px-5 pt-2">
+                            {/* Başlık + aktiflik */}
+                            <View className="flex-row items-center mb-4">
+                                <View
+                                    className="w-11 h-11 rounded-2xl items-center justify-center mr-3"
+                                    style={{ backgroundColor: `${renkler.birincil}15` }}
+                                >
+                                    <FontAwesome5 name="clock" size={18} color={renkler.birincil} solid />
+                                </View>
+                                <View className="flex-1">
+                                    <Text className="text-base font-bold" style={{ color: renkler.metin }}>
+                                        {gorununumAdi} Namazı
+                                    </Text>
+                                    <Text className="text-xs mt-0.5" style={{ color: renkler.metinIkincil }}>
+                                        {aktifAyar.aktif ? 'Bu vakit takvime eklenecek' : 'Bu vakit şu an kapalı'}
+                                    </Text>
+                                </View>
+                                <Switch
+                                    value={aktifAyar.aktif}
+                                    onValueChange={v => onChange({ aktif: v })}
+                                    trackColor={{ false: renkler.sinir, true: `${renkler.birincil}60` }}
+                                    thumbColor={aktifAyar.aktif ? renkler.birincil : '#f4f3f4'}
+                                />
+                            </View>
+
+                            {aktifAyar.aktif ? (
+                                <View className="gap-4">
+                                    {/* Başlangıç tipi */}
+                                    <View>
+                                        <Text className="text-xs font-bold tracking-wider mb-2" style={{ color: renkler.metinIkincil }}>
+                                            ETKİNLİK NE ZAMAN BAŞLASIN
+                                        </Text>
+                                        <View className="flex-row gap-2">
+                                            {BASLANGIC_TIPLERI.map(({ tip, etiket, aciklama }) => {
+                                                const secili = aktifAyar.baslangicTipi === tip;
+                                                return (
+                                                    <TouchableOpacity
+                                                        key={tip}
+                                                        onPress={() => onChange({ baslangicTipi: tip })}
+                                                        className="flex-1 py-3 px-1 rounded-2xl items-center"
+                                                        style={{
+                                                            backgroundColor: secili ? renkler.birincil : `${renkler.birincil}10`,
+                                                            borderWidth: 1,
+                                                            borderColor: secili ? renkler.birincil : renkler.sinir,
+                                                        }}
+                                                        activeOpacity={0.7}
+                                                    >
+                                                        <Text
+                                                            className="text-xs font-bold text-center"
+                                                            style={{ color: secili ? '#FFF' : renkler.metin }}
+                                                            numberOfLines={2}
+                                                        >
+                                                            {etiket}
+                                                        </Text>
+                                                        <Text
+                                                            className="text-[10px] text-center mt-1 leading-3"
+                                                            style={{ color: secili ? 'rgba(255,255,255,0.8)' : renkler.metinIkincil }}
+                                                            numberOfLines={2}
+                                                        >
+                                                            {aciklama}
+                                                        </Text>
+                                                    </TouchableOpacity>
+                                                );
+                                            })}
+                                        </View>
+                                    </View>
+
+                                    {/* Dakika (offset) */}
+                                    {aktifAyar.baslangicTipi !== 'vakit_girisi' && (
+                                        <View className="flex-row justify-between items-center">
+                                            <Text className="text-sm" style={{ color: renkler.metin }}>
+                                                {aktifAyar.baslangicTipi === 'vakit_oncesi' ? 'Kaç dk önce' : 'Kaç dk sonra'}
+                                            </Text>
+                                            <SayisalSecici
+                                                deger={aktifAyar.dakika}
+                                                min={1}
+                                                max={60}
+                                                adim={5}
+                                                birim="dk"
+                                                onChange={v => onChange({ dakika: v })}
+                                                renk={renkler.birincil}
+                                            />
+                                        </View>
+                                    )}
+
+                                    {/* Süre */}
+                                    <View className="flex-row justify-between items-center">
+                                        <Text className="text-sm" style={{ color: renkler.metin }}>
+                                            Etkinlik süresi
+                                        </Text>
+                                        <SayisalSecici
+                                            deger={aktifAyar.sureDakika}
+                                            min={5}
+                                            max={120}
+                                            adim={5}
+                                            birim="dk"
+                                            onChange={v => onChange({ sureDakika: v })}
+                                            renk={renkler.birincil}
+                                        />
+                                    </View>
+
+                                    {/* Bugün için mini önizleme */}
+                                    {bugunVakitler && bugunCikisVakitleri && (
+                                        <View>
+                                            <Text className="text-xs font-bold tracking-wider mb-2" style={{ color: renkler.metinIkincil }}>
+                                                BUGÜN İÇİN ÖNİZLEME
+                                            </Text>
+                                            <OnizlemeSatiri
+                                                vakitAdi={aktifVakit}
+                                                gorununumAdi={gorununumAdi}
+                                                ayar={aktifAyar}
+                                                bugunVakitler={bugunVakitler}
+                                                bugunCikisVakitleri={bugunCikisVakitleri}
+                                            />
+                                        </View>
+                                    )}
+                                </View>
+                            ) : (
+                                <View className="items-center py-8">
+                                    <FontAwesome5 name="bell-slash" size={28} color={renkler.metinIkincil} />
+                                    <Text className="text-sm text-center mt-3 leading-5" style={{ color: renkler.metinIkincil }}>
+                                        Bu vakit için etkinlik oluşturulmayacak.{'\n'}Ayarlamak için yukarıdan aç.
+                                    </Text>
+                                </View>
+                            )}
+
+                            {/* Tamam */}
+                            <TouchableOpacity
+                                className="items-center justify-center p-4 rounded-2xl mt-5"
+                                style={{ backgroundColor: renkler.birincil }}
+                                onPress={onKapat}
+                                activeOpacity={0.85}
+                            >
+                                <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                    Tamam
+                                </Text>
+                            </TouchableOpacity>
+                        </View>
+                    )}
+                </View>
+            </View>
+        </Modal>
     );
 };
 
@@ -1155,6 +1312,7 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
     const [takvimYukleniyor, setTakvimYukleniyor] = useState(false);
     const [temizleModaliGorunur, setTemizleModaliGorunur] = useState(false);
     const [ozelGunAktif, setOzelGunAktif] = useState(false);
+    const [aktifVakitEditor, setAktifVakitEditor] = useState<TakvimVakitAdi | null>(null);
     const [olusturmaSonucu, setOlusturmaSonucu] = useState<{ sayi: number } | null>(null);
     const [bildirim, setBildirim] = useState<Bildirim | null>(null);
     const bildirimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1379,16 +1537,19 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 className="rounded-2xl p-4 mb-4"
                                 style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
                             >
-                                <Text className="text-xs font-bold tracking-wider mb-3" style={{ color: renkler.metinIkincil }}>
+                                <Text className="text-xs font-bold tracking-wider mb-1" style={{ color: renkler.metinIkincil }}>
                                     VAKİT AYARLARI
                                 </Text>
+                                <Text className="text-xs mb-2" style={{ color: renkler.metinIkincil }}>
+                                    Ayarlamak için bir vakte dokun
+                                </Text>
                                 {VAKIT_SIRASI.map((vakit, idx) => (
-                                    <VakitAyarSatiri
+                                    <VakitSatiri
                                         key={vakit}
-                                        vakitAdi={vakit}
                                         gorununumAdi={VAKIT_GORUNTU_ADLARI[vakit]}
                                         ayar={ayarlar.vakitAyarlari[vakit]}
-                                        onChange={yeni => handleVakitAyarDegistir(vakit, yeni)}
+                                        onAc={() => setAktifVakitEditor(vakit)}
+                                        onToggle={v => handleVakitAyarDegistir(vakit, { aktif: v })}
                                         sonMu={idx === VAKIT_SIRASI.length - 1}
                                     />
                                 ))}
@@ -1550,6 +1711,17 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                     <View className="h-10" />
                 </Animated.View>
             </ScrollView>
+
+            {/* Vakit Editör Modalı */}
+            <VakitEditorModali
+                gorunur={aktifVakitEditor !== null}
+                onKapat={() => setAktifVakitEditor(null)}
+                vakitAdi={aktifVakitEditor}
+                ayar={aktifVakitEditor ? ayarlar.vakitAyarlari[aktifVakitEditor] : null}
+                onChange={yeni => { if (aktifVakitEditor) handleVakitAyarDegistir(aktifVakitEditor, yeni); }}
+                bugunVakitler={bugunVakitler}
+                bugunCikisVakitleri={bugunCikisVakitleri}
+            />
 
             {/* Temizle Modalı */}
             <TemizleModali

--- a/src/presentation/screens/index.ts
+++ b/src/presentation/screens/index.ts
@@ -23,3 +23,4 @@ export { MuhafizAyarlariSayfasi } from './MuhafizAyarlariSayfasi';
 export { HakkindaSayfasi } from './HakkindaSayfasi';
 export { RamazanAyarlariSayfasi } from './RamazanAyarlariSayfasi';
 export { DebugLogsSayfasi } from './DebugLogsSayfasi';
+export { TakvimAyarlariSayfasi } from './TakvimAyarlariSayfasi';

--- a/src/presentation/screens/index.ts
+++ b/src/presentation/screens/index.ts
@@ -24,3 +24,4 @@ export { HakkindaSayfasi } from './HakkindaSayfasi';
 export { RamazanAyarlariSayfasi } from './RamazanAyarlariSayfasi';
 export { DebugLogsSayfasi } from './DebugLogsSayfasi';
 export { TakvimAyarlariSayfasi } from './TakvimAyarlariSayfasi';
+export { NelerYeniSayfasi } from './NelerYeniSayfasi';

--- a/src/presentation/store/__tests__/ozelliklerSlice.test.ts
+++ b/src/presentation/store/__tests__/ozelliklerSlice.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Ozellikler Slice Testleri
+ * Yeni özellik duyuru durumu (görülen / kart kapatılan) yönetimi
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import ozelliklerReducer, {
+    ozellikleriYukle,
+    ozellikGorulduIsaretle,
+    ozellikKartiKapat,
+} from '../ozelliklerSlice';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    setItem: jest.fn(() => Promise.resolve()),
+    getItem: jest.fn(() => Promise.resolve(null)),
+    removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+describe('ozelliklerSlice', () => {
+    function storeOlustur() {
+        return configureStore({
+            reducer: { ozellikler: ozelliklerReducer },
+            middleware: (getDefaultMiddleware) =>
+                getDefaultMiddleware({ serializableCheck: false }),
+        });
+    }
+
+    let store: ReturnType<typeof storeOlustur>;
+
+    beforeEach(() => {
+        store = storeOlustur();
+        jest.clearAllMocks();
+    });
+
+    it('başlangıç state boş dizilerle başlar', () => {
+        const state = store.getState().ozellikler;
+        expect(state.gorulenIdler).toEqual([]);
+        expect(state.kapatilanKartIdler).toEqual([]);
+        expect(state.yuklendi).toBe(false);
+    });
+
+    it('AsyncStorage boşsa varsayılan boş durum yüklenir ve yuklendi=true olur', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+        await store.dispatch(ozellikleriYukle());
+        const state = store.getState().ozellikler;
+        expect(state.gorulenIdler).toEqual([]);
+        expect(state.yuklendi).toBe(true);
+    });
+
+    it('kayıtlı durum yüklenir', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+            JSON.stringify({ gorulenIdler: ['a'], kapatilanKartIdler: ['b'] })
+        );
+        await store.dispatch(ozellikleriYukle());
+        const state = store.getState().ozellikler;
+        expect(state.gorulenIdler).toEqual(['a']);
+        expect(state.kapatilanKartIdler).toEqual(['b']);
+    });
+
+    it('eksik alanlı kayıt güvenli şekilde merge edilir', async () => {
+        (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+            JSON.stringify({ gorulenIdler: ['x'] })
+        );
+        await store.dispatch(ozellikleriYukle());
+        const state = store.getState().ozellikler;
+        expect(state.gorulenIdler).toEqual(['x']);
+        expect(state.kapatilanKartIdler).toEqual([]);
+    });
+
+    it('ozellikGorulduIsaretle tek id ekler ve kaydeder', async () => {
+        await store.dispatch(ozellikGorulduIsaretle('takvim-entegrasyonu'));
+        const state = store.getState().ozellikler;
+        expect(state.gorulenIdler).toContain('takvim-entegrasyonu');
+        expect(AsyncStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('ozellikGorulduIsaretle dizi kabul eder ve tekrarları teklestirir', async () => {
+        await store.dispatch(ozellikGorulduIsaretle(['a', 'b']));
+        await store.dispatch(ozellikGorulduIsaretle(['b', 'c']));
+        const state = store.getState().ozellikler;
+        expect([...state.gorulenIdler].sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('ozellikKartiKapat kartı kapatır ama görülenleri etkilemez', async () => {
+        await store.dispatch(ozellikKartiKapat('takvim-entegrasyonu'));
+        const state = store.getState().ozellikler;
+        expect(state.kapatilanKartIdler).toContain('takvim-entegrasyonu');
+        expect(state.gorulenIdler).toEqual([]);
+    });
+});

--- a/src/presentation/store/__tests__/takvimSlice.test.ts
+++ b/src/presentation/store/__tests__/takvimSlice.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Takvim Slice Testleri
+ * Redux state yonetimi icin birim testleri
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import takvimReducer, {
+    takvimAyarlariniYukle,
+    takvimAyarlariniGuncelle,
+    VARSAYILAN_TAKVIM_AYARLARI,
+    type TakvimAyarlari,
+    type VakitTakvimAyari,
+} from '../takvimSlice';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    setItem: jest.fn(() => Promise.resolve()),
+    getItem: jest.fn(() => Promise.resolve(null)),
+    removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+// takvimOlaylariniOlustur TakvimServisi'ni dinamik import eder, mock'luyoruz
+jest.mock('../../../domain/services/TakvimServisi', () => ({
+    TakvimServisi: {
+        getInstance: jest.fn(() => ({
+            takvimOlaylariOlustur: jest.fn(() => Promise.resolve(14)),
+        })),
+    },
+}));
+
+describe('takvimSlice', () => {
+    let store: ReturnType<typeof storeOlustur>;
+
+    function storeOlustur() {
+        return configureStore({
+            reducer: { takvim: takvimReducer },
+            middleware: (getDefaultMiddleware) =>
+                getDefaultMiddleware({ serializableCheck: false }),
+        });
+    }
+
+    beforeEach(() => {
+        store = storeOlustur();
+        jest.clearAllMocks();
+    });
+
+    // ─── Başlangıç State ──────────────────────────────────────────────────────
+
+    describe('Baslangic State', () => {
+        it('varsayilan state dogru olmali', () => {
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.aktif).toBe(false);
+            expect(state.ayarlar.takvimId).toBeNull();
+            expect(state.ayarlar.kaciGunIlerisi).toBe(7);
+            expect(state.yukleniyor).toBe(false);
+            expect(state.olayOlusturuluyor).toBe(false);
+            expect(state.hata).toBeNull();
+        });
+
+        it('tum vakitler varsayilan olarak pasif olmali', () => {
+            const state = store.getState().takvim;
+            const vakitler = ['imsak', 'ogle', 'ikindi', 'aksam', 'yatsi'] as const;
+
+            vakitler.forEach(vakit => {
+                expect(state.ayarlar.vakitAyarlari[vakit].aktif).toBe(false);
+                expect(state.ayarlar.vakitAyarlari[vakit].baslangicTipi).toBe('vakit_girisi');
+            });
+        });
+    });
+
+    // ─── takvimAyarlariniYukle ────────────────────────────────────────────────
+
+    describe('takvimAyarlariniYukle', () => {
+        it('AsyncStorage bossa varsayilan state kalir', async () => {
+            (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+            await store.dispatch(takvimAyarlariniYukle());
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.aktif).toBe(false);
+            expect(state.yukleniyor).toBe(false);
+            expect(state.hata).toBeNull();
+        });
+
+        it('kayitli ayarlar yuklenince state guncellenir', async () => {
+            const kayitli: Partial<TakvimAyarlari> = {
+                aktif: true,
+                takvimId: 'test-cal-123',
+                takvimAdi: 'Kişisel',
+                kaciGunIlerisi: 14,
+            };
+            (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(kayitli));
+
+            await store.dispatch(takvimAyarlariniYukle());
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.aktif).toBe(true);
+            expect(state.ayarlar.takvimId).toBe('test-cal-123');
+            expect(state.ayarlar.kaciGunIlerisi).toBe(14);
+            expect(state.yukleniyor).toBe(false);
+        });
+
+        it('yuklemede eksik vakit ayarlari varsayilanla merge edilir', async () => {
+            const kayitli: Partial<TakvimAyarlari> = {
+                aktif: true,
+                vakitAyarlari: {
+                    ...VARSAYILAN_TAKVIM_AYARLARI.vakitAyarlari,
+                    ogle: { aktif: true, sureDakika: 10, baslangicTipi: 'vakit_oncesi', dakika: 15 },
+                },
+            };
+            (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(kayitli));
+
+            await store.dispatch(takvimAyarlariniYukle());
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.vakitAyarlari.ogle.aktif).toBe(true);
+            expect(state.ayarlar.vakitAyarlari.ogle.sureDakika).toBe(10);
+            expect(state.ayarlar.vakitAyarlari.ogle.baslangicTipi).toBe('vakit_oncesi');
+            // diger vakitler varsayilan kalmali
+            expect(state.ayarlar.vakitAyarlari.ikindi.aktif).toBe(false);
+        });
+
+        it('AsyncStorage hatasi durumunda state bozulmamali', async () => {
+            (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('Storage error'));
+
+            await store.dispatch(takvimAyarlariniYukle());
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.aktif).toBe(false);
+            expect(state.yukleniyor).toBe(false);
+        });
+
+        it('yukleme pending aninda yukleniyor true olmali', () => {
+            const state = takvimReducer(undefined, {
+                type: takvimAyarlariniYukle.pending.type,
+            });
+
+            expect(state.yukleniyor).toBe(true);
+        });
+    });
+
+    // ─── takvimAyarlariniGuncelle ─────────────────────────────────────────────
+
+    describe('takvimAyarlariniGuncelle', () => {
+        it('aktif bayragi guncellenir ve AsyncStorage e kaydedilir', async () => {
+            (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+            await store.dispatch(takvimAyarlariniGuncelle({ aktif: true }));
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.aktif).toBe(true);
+            expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+            const kaydedilen = JSON.parse((AsyncStorage.setItem as jest.Mock).mock.calls[0][1]);
+            expect(kaydedilen.aktif).toBe(true);
+        });
+
+        it('takvimId secimi guncellenir', async () => {
+            (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+            await store.dispatch(takvimAyarlariniGuncelle({ takvimId: 'cal-456', takvimAdi: 'İş' }));
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.takvimId).toBe('cal-456');
+            expect(state.ayarlar.takvimAdi).toBe('İş');
+        });
+
+        it('kaciGunIlerisi degeri guncellenir', async () => {
+            (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+            await store.dispatch(takvimAyarlariniGuncelle({ kaciGunIlerisi: 30 }));
+            const state = store.getState().takvim;
+
+            expect(state.ayarlar.kaciGunIlerisi).toBe(30);
+        });
+
+        it('vakit ayari guncellenince diger vakitler bozulmaz', async () => {
+            (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+            const ogleAyari: VakitTakvimAyari = {
+                aktif: true,
+                sureDakika: 10,
+                baslangicTipi: 'vakit_oncesi',
+                dakika: 15,
+            };
+
+            await store.dispatch(takvimAyarlariniGuncelle({
+                vakitAyarlari: {
+                    ...VARSAYILAN_TAKVIM_AYARLARI.vakitAyarlari,
+                    ogle: ogleAyari,
+                },
+            }));
+
+            const state = store.getState().takvim;
+            expect(state.ayarlar.vakitAyarlari.ogle.aktif).toBe(true);
+            expect(state.ayarlar.vakitAyarlari.ogle.sureDakika).toBe(10);
+            expect(state.ayarlar.vakitAyarlari.ogle.baslangicTipi).toBe('vakit_oncesi');
+            expect(state.ayarlar.vakitAyarlari.imsak.aktif).toBe(false);
+        });
+
+        it('kaydetme hatasi durumunda hata state e yazilir', async () => {
+            (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('Write error'));
+
+            await store.dispatch(takvimAyarlariniGuncelle({ aktif: true }));
+            const state = store.getState().takvim;
+
+            expect(state.hata).toBeTruthy();
+        });
+    });
+
+    // ─── takvimOlaylariniOlustur ──────────────────────────────────────────────
+
+    describe('takvimOlaylariniOlustur', () => {
+        it('olay olusturma sirasinda olayOlusturuluyor true olmali', () => {
+            const { takvimOlaylariniOlustur } = jest.requireActual('../takvimSlice');
+            const state = takvimReducer(undefined, {
+                type: takvimOlaylariniOlustur.pending.type,
+            });
+
+            expect(state.olayOlusturuluyor).toBe(true);
+            expect(state.hata).toBeNull();
+        });
+
+        it('fulfilled olunca olayOlusturuluyor false olmali', () => {
+            const { takvimOlaylariniOlustur } = jest.requireActual('../takvimSlice');
+            const state = takvimReducer(undefined, {
+                type: takvimOlaylariniOlustur.fulfilled.type,
+                payload: { olusturulanSayi: 14 },
+            });
+
+            expect(state.olayOlusturuluyor).toBe(false);
+        });
+
+        it('rejected olunca olayOlusturuluyor false ve hata dolu olmali', () => {
+            const { takvimOlaylariniOlustur } = jest.requireActual('../takvimSlice');
+            const state = takvimReducer(undefined, {
+                type: takvimOlaylariniOlustur.rejected.type,
+                payload: 'Takvim izni reddedildi',
+            });
+
+            expect(state.olayOlusturuluyor).toBe(false);
+            expect(state.hata).toBe('Takvim izni reddedildi');
+        });
+    });
+});

--- a/src/presentation/store/ozelliklerSlice.ts
+++ b/src/presentation/store/ozelliklerSlice.ts
@@ -1,0 +1,113 @@
+/**
+ * Yeni Özellik Duyuruları State Yönetimi
+ *
+ * İki seviyeli durum:
+ *   - gorulenIdler:       kullanıcı özelliği açtı/gördü → rozet kalkar
+ *   - kapatilanKartIdler: tanıtım kartı kapatıldı → kart bir daha gelmez (rozet kalır)
+ */
+
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DEPOLAMA_ANAHTARLARI } from '../../core/constants/UygulamaSabitleri';
+import { Logger } from '../../core/utils/Logger';
+import type { RootState } from './store';
+
+interface OzelliklerKalici {
+    gorulenIdler: string[];
+    kapatilanKartIdler: string[];
+}
+
+interface OzelliklerState extends OzelliklerKalici {
+    yuklendi: boolean;
+}
+
+const initialState: OzelliklerState = {
+    gorulenIdler: [],
+    kapatilanKartIdler: [],
+    yuklendi: false,
+};
+
+async function kaydet(durum: OzelliklerKalici): Promise<void> {
+    await AsyncStorage.setItem(DEPOLAMA_ANAHTARLARI.GORULEN_OZELLIKLER, JSON.stringify(durum));
+}
+
+export const ozellikleriYukle = createAsyncThunk(
+    'ozellikler/yukle',
+    async () => {
+        try {
+            const veri = await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.GORULEN_OZELLIKLER);
+            if (!veri) return { gorulenIdler: [], kapatilanKartIdler: [] } as OzelliklerKalici;
+            const parsed = JSON.parse(veri) as Partial<OzelliklerKalici>;
+            return {
+                gorulenIdler: parsed.gorulenIdler ?? [],
+                kapatilanKartIdler: parsed.kapatilanKartIdler ?? [],
+            } as OzelliklerKalici;
+        } catch (hata) {
+            Logger.error('OzelliklerSlice', 'Görülen özellikler yüklenemedi', hata);
+            return { gorulenIdler: [], kapatilanKartIdler: [] } as OzelliklerKalici;
+        }
+    }
+);
+
+export const ozellikGorulduIsaretle = createAsyncThunk(
+    'ozellikler/gorulduIsaretle',
+    async (id: string | string[], { getState }) => {
+        const state = getState() as RootState;
+        const mevcut = state.ozellikler;
+        const yeniIdler = Array.isArray(id) ? id : [id];
+        const gorulenIdler = Array.from(new Set([...mevcut.gorulenIdler, ...yeniIdler]));
+        const durum: OzelliklerKalici = {
+            gorulenIdler,
+            kapatilanKartIdler: mevcut.kapatilanKartIdler,
+        };
+        try {
+            await kaydet(durum);
+        } catch (hata) {
+            Logger.error('OzelliklerSlice', 'Görüldü işaretlenemedi', hata);
+        }
+        return durum;
+    }
+);
+
+export const ozellikKartiKapat = createAsyncThunk(
+    'ozellikler/kartiKapat',
+    async (id: string, { getState }) => {
+        const state = getState() as RootState;
+        const mevcut = state.ozellikler;
+        const kapatilanKartIdler = Array.from(new Set([...mevcut.kapatilanKartIdler, id]));
+        const durum: OzelliklerKalici = {
+            gorulenIdler: mevcut.gorulenIdler,
+            kapatilanKartIdler,
+        };
+        try {
+            await kaydet(durum);
+        } catch (hata) {
+            Logger.error('OzelliklerSlice', 'Kart kapatılamadı', hata);
+        }
+        return durum;
+    }
+);
+
+const ozelliklerSlice = createSlice({
+    name: 'ozellikler',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(ozellikleriYukle.fulfilled, (state, action) => {
+                state.gorulenIdler = action.payload.gorulenIdler;
+                state.kapatilanKartIdler = action.payload.kapatilanKartIdler;
+                state.yuklendi = true;
+            })
+            .addCase(ozellikGorulduIsaretle.fulfilled, (state, action) => {
+                state.gorulenIdler = action.payload.gorulenIdler;
+                state.kapatilanKartIdler = action.payload.kapatilanKartIdler;
+            })
+            .addCase(ozellikKartiKapat.fulfilled, (state, action) => {
+                state.gorulenIdler = action.payload.gorulenIdler;
+                state.kapatilanKartIdler = action.payload.kapatilanKartIdler;
+            });
+    },
+});
+
+export default ozelliklerSlice.reducer;

--- a/src/presentation/store/store.ts
+++ b/src/presentation/store/store.ts
@@ -14,6 +14,7 @@ import iftarSayacReducer from './iftarSayacSlice';
 import sahurSayacReducer from './sahurSayacSlice';
 import guncellemeReducer from './guncellemeSlice';
 import kazaReducer from './kazaSlice';
+import takvimReducer from './takvimSlice';
 
 export const store = configureStore({
   reducer: {
@@ -28,6 +29,7 @@ export const store = configureStore({
     sahurSayac: sahurSayacReducer,
     guncelleme: guncellemeReducer,
     kaza: kazaReducer,
+    takvim: takvimReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/presentation/store/store.ts
+++ b/src/presentation/store/store.ts
@@ -15,6 +15,7 @@ import sahurSayacReducer from './sahurSayacSlice';
 import guncellemeReducer from './guncellemeSlice';
 import kazaReducer from './kazaSlice';
 import takvimReducer from './takvimSlice';
+import ozelliklerReducer from './ozelliklerSlice';
 
 export const store = configureStore({
   reducer: {
@@ -30,6 +31,7 @@ export const store = configureStore({
     guncelleme: guncellemeReducer,
     kaza: kazaReducer,
     takvim: takvimReducer,
+    ozellikler: ozelliklerReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/presentation/store/takvimSlice.ts
+++ b/src/presentation/store/takvimSlice.ts
@@ -42,7 +42,7 @@ const VARSAYILAN_VAKIT_AYARI: VakitTakvimAyari = {
     aktif: false,
     sureDakika: 15,
     baslangicTipi: 'vakit_girisi',
-    dakika: 0,
+    dakika: 5,
 };
 
 export const VARSAYILAN_TAKVIM_AYARLARI: TakvimAyarlari = {
@@ -92,18 +92,23 @@ export const takvimAyarlariniYukle = createAsyncThunk(
 
 export const takvimAyarlariniGuncelle = createAsyncThunk(
     'takvim/guncelle',
-    async (degisiklik: Partial<TakvimAyarlari>, { getState }) => {
-        const state = getState() as RootState;
-        const mevcutAyarlar = state.takvim.ayarlar;
-        const yeniAyarlar: TakvimAyarlari = {
-            ...mevcutAyarlar,
-            ...degisiklik,
-            vakitAyarlari: degisiklik.vakitAyarlari
-                ? { ...mevcutAyarlar.vakitAyarlari, ...degisiklik.vakitAyarlari }
-                : mevcutAyarlar.vakitAyarlari,
-        };
-        await AsyncStorage.setItem(DEPOLAMA_ANAHTARLARI.TAKVIM_AYARLARI, JSON.stringify(yeniAyarlar));
-        return yeniAyarlar;
+    async (degisiklik: Partial<TakvimAyarlari>, { getState, rejectWithValue }) => {
+        try {
+            const state = getState() as RootState;
+            const mevcutAyarlar = state.takvim.ayarlar;
+            const yeniAyarlar: TakvimAyarlari = {
+                ...mevcutAyarlar,
+                ...degisiklik,
+                vakitAyarlari: degisiklik.vakitAyarlari
+                    ? { ...mevcutAyarlar.vakitAyarlari, ...degisiklik.vakitAyarlari }
+                    : mevcutAyarlar.vakitAyarlari,
+            };
+            await AsyncStorage.setItem(DEPOLAMA_ANAHTARLARI.TAKVIM_AYARLARI, JSON.stringify(yeniAyarlar));
+            return yeniAyarlar;
+        } catch (hata: any) {
+            Logger.error('TakvimSlice', 'Ayarlar kaydedilemedi', hata);
+            return rejectWithValue(hata?.message || 'Ayarlar kaydedilemedi');
+        }
     }
 );
 
@@ -144,6 +149,10 @@ const takvimSlice = createSlice({
             })
             .addCase(takvimAyarlariniGuncelle.fulfilled, (state, action) => {
                 state.ayarlar = action.payload;
+                state.hata = null;
+            })
+            .addCase(takvimAyarlariniGuncelle.rejected, (state, action) => {
+                state.hata = action.payload as string;
             })
             .addCase(takvimOlaylariniOlustur.pending, (state) => {
                 state.olayOlusturuluyor = true;

--- a/src/presentation/store/takvimSlice.ts
+++ b/src/presentation/store/takvimSlice.ts
@@ -1,0 +1,162 @@
+/**
+ * Takvim Entegrasyonu State Yonetimi
+ * Namaz vakitleri icin cihaz takvimi etkinlikleri ayarlari
+ */
+
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DEPOLAMA_ANAHTARLARI } from '../../core/constants/UygulamaSabitleri';
+import { Logger } from '../../core/utils/Logger';
+import type { RootState } from './store';
+
+export type TakvimVakitAdi = 'imsak' | 'ogle' | 'ikindi' | 'aksam' | 'yatsi';
+
+export type BaslangicTipi =
+    | 'vakit_oncesi'   // vakit cikismadan X dk once
+    | 'vakit_girisi'   // tam vakit girince
+    | 'vakit_sonrasi'; // vakit girdikten X dk sonra
+
+export interface VakitTakvimAyari {
+    aktif: boolean;
+    sureDakika: number;
+    baslangicTipi: BaslangicTipi;
+    dakika: number;
+}
+
+export interface TakvimAyarlari {
+    aktif: boolean;
+    takvimId: string | null;
+    takvimAdi: string | null;
+    kaciGunIlerisi: 7 | 14 | 30;
+    vakitAyarlari: Record<TakvimVakitAdi, VakitTakvimAyari>;
+}
+
+interface TakvimState {
+    ayarlar: TakvimAyarlari;
+    yukleniyor: boolean;
+    olayOlusturuluyor: boolean;
+    hata: string | null;
+}
+
+const VARSAYILAN_VAKIT_AYARI: VakitTakvimAyari = {
+    aktif: false,
+    sureDakika: 15,
+    baslangicTipi: 'vakit_girisi',
+    dakika: 0,
+};
+
+export const VARSAYILAN_TAKVIM_AYARLARI: TakvimAyarlari = {
+    aktif: false,
+    takvimId: null,
+    takvimAdi: null,
+    kaciGunIlerisi: 7,
+    vakitAyarlari: {
+        imsak:  { ...VARSAYILAN_VAKIT_AYARI },
+        ogle:   { ...VARSAYILAN_VAKIT_AYARI },
+        ikindi: { ...VARSAYILAN_VAKIT_AYARI },
+        aksam:  { ...VARSAYILAN_VAKIT_AYARI },
+        yatsi:  { ...VARSAYILAN_VAKIT_AYARI },
+    },
+};
+
+const initialState: TakvimState = {
+    ayarlar: VARSAYILAN_TAKVIM_AYARLARI,
+    yukleniyor: false,
+    olayOlusturuluyor: false,
+    hata: null,
+};
+
+export const takvimAyarlariniYukle = createAsyncThunk(
+    'takvim/yukle',
+    async () => {
+        try {
+            const veri = await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.TAKVIM_AYARLARI);
+            if (veri) {
+                const parsed = JSON.parse(veri) as Partial<TakvimAyarlari>;
+                return {
+                    ...VARSAYILAN_TAKVIM_AYARLARI,
+                    ...parsed,
+                    vakitAyarlari: {
+                        ...VARSAYILAN_TAKVIM_AYARLARI.vakitAyarlari,
+                        ...parsed.vakitAyarlari,
+                    },
+                } as TakvimAyarlari;
+            }
+            return null;
+        } catch (hata) {
+            Logger.error('TakvimSlice', 'Takvim ayarlari yuklenemedi', hata);
+            return null;
+        }
+    }
+);
+
+export const takvimAyarlariniGuncelle = createAsyncThunk(
+    'takvim/guncelle',
+    async (degisiklik: Partial<TakvimAyarlari>, { getState }) => {
+        const state = getState() as RootState;
+        const mevcutAyarlar = state.takvim.ayarlar;
+        const yeniAyarlar: TakvimAyarlari = {
+            ...mevcutAyarlar,
+            ...degisiklik,
+            vakitAyarlari: degisiklik.vakitAyarlari
+                ? { ...mevcutAyarlar.vakitAyarlari, ...degisiklik.vakitAyarlari }
+                : mevcutAyarlar.vakitAyarlari,
+        };
+        await AsyncStorage.setItem(DEPOLAMA_ANAHTARLARI.TAKVIM_AYARLARI, JSON.stringify(yeniAyarlar));
+        return yeniAyarlar;
+    }
+);
+
+export const takvimOlaylariniOlustur = createAsyncThunk(
+    'takvim/olayOlustur',
+    async (
+        { ayarlar, koordinatlar }: { ayarlar: TakvimAyarlari; koordinatlar: { lat: number; lng: number } },
+        { rejectWithValue }
+    ) => {
+        try {
+            const { TakvimServisi } = await import('../../domain/services/TakvimServisi');
+            const sayi = await TakvimServisi.getInstance().takvimOlaylariOlustur(ayarlar, koordinatlar);
+            return { olusturulanSayi: sayi };
+        } catch (hata: any) {
+            Logger.error('TakvimSlice', 'Olaylar olusturulamadi', hata);
+            return rejectWithValue(hata?.message || 'Bilinmeyen hata');
+        }
+    }
+);
+
+const takvimSlice = createSlice({
+    name: 'takvim',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(takvimAyarlariniYukle.pending, (state) => {
+                state.yukleniyor = true;
+            })
+            .addCase(takvimAyarlariniYukle.fulfilled, (state, action) => {
+                state.yukleniyor = false;
+                if (action.payload) {
+                    state.ayarlar = action.payload;
+                }
+            })
+            .addCase(takvimAyarlariniYukle.rejected, (state) => {
+                state.yukleniyor = false;
+            })
+            .addCase(takvimAyarlariniGuncelle.fulfilled, (state, action) => {
+                state.ayarlar = action.payload;
+            })
+            .addCase(takvimOlaylariniOlustur.pending, (state) => {
+                state.olayOlusturuluyor = true;
+                state.hata = null;
+            })
+            .addCase(takvimOlaylariniOlustur.fulfilled, (state) => {
+                state.olayOlusturuluyor = false;
+            })
+            .addCase(takvimOlaylariniOlustur.rejected, (state, action) => {
+                state.olayOlusturuluyor = false;
+                state.hata = action.payload as string;
+            });
+    },
+});
+
+export default takvimSlice.reducer;

--- a/src/presentation/store/takvimSlice.ts
+++ b/src/presentation/store/takvimSlice.ts
@@ -27,7 +27,7 @@ export interface TakvimAyarlari {
     aktif: boolean;
     takvimId: string | null;
     takvimAdi: string | null;
-    kaciGunIlerisi: 7 | 14 | 30;
+    kaciGunIlerisi: number;
     vakitAyarlari: Record<TakvimVakitAdi, VakitTakvimAyari>;
 }
 


### PR DESCRIPTION
## Özet

Closes #75 — Namaz vakitleri için cihaz takvim entegrasyonu. Süreç içinde takvim UX'i derinleştirildi, uygulama geneli modal geri tuşu sorunu çözüldü ve config-driven bir **yeni özellik duyuru sistemi** eklendi.

---

## 1) Takvim Entegrasyonu
- **expo-calendar** + `adhan` ile vakit bazlı etkinlik oluşturma. Her vakit için **süre** ve **başlangıç** (vakitte / çıkmadan önce / sonra) ayrı ayarlanır.
- Etkinlikler eklenen **her gün için o günün gerçek vakitlerine** göre hesaplanır (gün bazlı `PrayerTimes`).
- **Esnek gün sayısı**: oluştururken 7/14/30 + Özel; temizlerken 7/30/90 + Özel (serbest gün girişi).
- **Bottom-sheet vakit editörü**: vakit ayarları kompakt satırlara taşındı, dokununca alttan editör açılır (aktiflik, başlangıç tipi, süre ve o vakte özel canlı önizleme). Sayfa kısaldı, canlı önizleme korundu.
- **Seçici temizleme**: takvim, tarih aralığı ve vakit bazlı silme.
- **Animasyonlu başarı ekranı** (oluşturma + silme): spring ikon + pulse halka + özet kartı + "Takvim Uygulamasını Aç" CTA.

## 2) Hata düzeltmeleri
- **Temizleme listesi scroll takılması**: backdrop, içeriği saran `TouchableWithoutFeedback` yerine `absoluteFill` ile kardeş yapıldı → FlatList gesture'ı serbest.
- **Sheet yüksekliği**: `maxHeight` → `height`, böylece `flex:1` çocuklar düzgün çalışır.

## 3) Modal donanım geri tuşu (tüm ekranlar)
- New Architecture (Fabric) altında RN `<Modal>` `onRequestClose` Android geri tuşunda güvenilir tetiklenmiyordu.
- `useDonanimGeriTusu` (BackHandler tabanlı) hook'u eklendi ve **9 modala** uygulandı (Takvim, Konum, KazaDefteri sihirbaz adım-geri, Toparlanma, SeriKartı, Paylaşım, ÖzelGün, Kutlama, KonumİzniDisclosure).

## 4) Yeni Özellik Duyuru Sistemi (config-driven)
- **Tek kaynak**: `src/core/constants/YeniOzellikler.ts` — yeni özellik = diziye 1 satır.
- **Yüzeyler** (çekirdek namaz akışına dokunmadan, yalnızca Ayarlar'da, pull modunda):
  - Ayarlar tab nokta rozeti + menüde "Yeni" rozeti
  - Ayarlar üstü kapatılabilir tanıtım kartı (CTA)
  - Accordion **"Neler Yeni"** sayfası (kapalıyken dikkat çekici başlık + özet ~%70 anlaşılır, dokununca açılır detay)
- **Akıllı durum** (`ozelliklerSlice`): `gorulenIdler` rozeti kaldırır, `kapatilanKartIdler` kartı gizler. AsyncStorage kalıcılığı.
- Geriye dönük: **Ana Ekran Widget'ları (v0.21.0)** kataloğa eklendi (önceki sürümde duyuru altyapısı yoktu).
- Tüm kullanıcı metinleri **kibar "siz" dili**ne çevrildi.

## 5) CI / Sürümleme
- APK = **Gradle** (`android-build.yml`); AAB = EAS (`expo-build.yml`) → Play Store **internal** track'e otomatik submit.
- `eas.json`: `appVersionSource: local`. CI'da AAB `versionCode` = build anında timestamp (`date +%s`), runner'da local commit (push yok).

## 6) Testler & Dokümantasyon
- `takvimSlice` (15), **`TakvimServisi` (15, yeni)**, `ozelliklerSlice` (7) testleri.
- **CLAUDE.md** eklendi: mimari, kibar dil kuralı, modal geri tuşu/bottom-sheet tuzakları, duyuru reçetesi, CI sürümleme.
- Tüm paket yeşil: **36 suite / 361 test**, `tsc` temiz.

## Başlangıç tipleri
| Başlangıç Tipi | Açıklama |
|---|---|
| Çıkmadan Önce | Vakit bitmeden X dk önce etkinlik başlar |
| Vakitte | Tam vakit girince etkinlik başlar |
| Vakitten Sonra | Vakit girdikten X dk sonra etkinlik başlar |

## Test planı
- [ ] Ayarlar → Takvim Entegrasyonu: takvim seç, vakitleri bottom-sheet'ten ayarla, önizlemeyi doğrula
- [ ] "Olayları Oluştur" → animasyonlu başarı modalı + "Takvim Uygulamasını Aç"
- [ ] Temizleme: özel gün aralığı + "Etkinlikleri Tara" + liste scroll + silme başarı ekranı
- [ ] Tüm modallarda donanım geri tuşu kapatıyor mu
- [ ] Ayarlar: tab noktası + "Yeni" rozeti + tanıtım kartı + "Neler Yeni" accordion
- [ ] Expo build (preview/production) → internal track'e gittiğini doğrula

https://claude.ai/code/session_01NGeqVKL9odk19oStYpczCv