### PR TITLE
fix(ci): release workflow actions:write izni + Release adım sırası

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -39,6 +39,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write   # expo-build.yml'i createWorkflowDispatch ile tetiklemek icin gerekli
 
 env:
   NODE_VERSION: '20'
@@ -473,28 +474,6 @@ jobs:
           git push origin HEAD:${{ github.ref_name }}
           git push origin ${{ steps.version.outputs.version_tag }}
 
-      - name: 📦 EAS Build Tetikle — Internal Testing
-        if: inputs.build_type == 'release' && success()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const version = '${{ steps.version.outputs.version }}';
-            const versionCode = require('./app.json').expo.android.versionCode;
-            console.log(`🚀 EAS Build tetikleniyor: v${version} (versionCode: ${versionCode})`);
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'expo-build.yml',
-              ref: 'master',
-              inputs: {
-                build_aab: 'true',
-                build_apk: 'false',
-                internal_a_gonder: 'true',
-              },
-            });
-            console.log('✅ EAS Build kuyruğa alındı → internal track');
-
       - name: 🚀 GitHub Release (Release)
         if: inputs.build_type == 'release' && success()
         uses: softprops/action-gh-release@v2
@@ -521,6 +500,30 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub Release yayinlandiktan SONRA EAS internal build'i tetikle.
+      # Boylece dispatch bir sorun yasarsa (orn. izin/agi) release yine de yayinda kalir.
+      - name: 📦 EAS Build Tetikle — Internal Testing
+        if: inputs.build_type == 'release' && success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ steps.version.outputs.version }}';
+            const versionCode = require('./app.json').expo.android.versionCode;
+            console.log(`🚀 EAS Build tetikleniyor: v${version} (versionCode: ${versionCode})`);
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'expo-build.yml',
+              ref: 'master',
+              inputs: {
+                build_aab: 'true',
+                build_apk: 'false',
+                internal_a_gonder: 'true',
+              },
+            });
+            console.log('✅ EAS Build kuyruğa alındı → internal track');
 
       # ==========================================
       # Build Ozeti

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Yeni bir özellik eklediğinde kullanıcıya duyurmak için **tek yer**: `src/co
 
 ## CI / Sürümleme
 - APK = **Gradle** (`android-build.yml`), EAS DEĞİL. AAB = EAS (`expo-build.yml`) → Play Store internal track'e otomatik submit.
-- **`android-build.yml` başka workflow'u (`expo-build.yml`) `createWorkflowDispatch` ile tetikler → workflow `permissions:` bloğunda `actions: write` ZORUNLU**, yoksa 403 "Resource not accessible by integration". `contents: write` tek başına yetmez.
+- **`android-build.yml` başka workflow'u (`expo-build.yml`) `createWorkflowDispatch` ile tetikler → izin, hedef değil TETİKLEYEN workflow'da (`android-build.yml`) gerekir: `permissions:` bloğunda `actions: write` ZORUNLU**, yoksa 403 "Resource not accessible by integration". `contents: write` tek başına yetmez.
 - Release adım sırası: önce **GitHub Release yayınla**, EN SON EAS dispatch. Aksi halde dispatch patlarsa release hiç oluşmaz (v0.23.0'da bu yaşandı).
 - `eas.json`: `appVersionSource: local`. CI'da AAB `versionCode` = build anında `date +%s` (timestamp); runner'da local commit edilir, push edilmez.
 - Geliştirme branch'i: `claude/feature-development-*`. Push sonrası PR aç (ready, draft değil).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ Yeni bir özellik eklediğinde kullanıcıya duyurmak için **tek yer**: `src/co
 
 ## CI / Sürümleme
 - APK = **Gradle** (`android-build.yml`), EAS DEĞİL. AAB = EAS (`expo-build.yml`) → Play Store internal track'e otomatik submit.
+- **`android-build.yml` başka workflow'u (`expo-build.yml`) `createWorkflowDispatch` ile tetikler → workflow `permissions:` bloğunda `actions: write` ZORUNLU**, yoksa 403 "Resource not accessible by integration". `contents: write` tek başına yetmez.
+- Release adım sırası: önce **GitHub Release yayınla**, EN SON EAS dispatch. Aksi halde dispatch patlarsa release hiç oluşmaz (v0.23.0'da bu yaşandı).
 - `eas.json`: `appVersionSource: local`. CI'da AAB `versionCode` = build anında `date +%s` (timestamp); runner'da local commit edilir, push edilmez.
 - Geliştirme branch'i: `claude/feature-development-*`. Push sonrası PR aç (ready, draft değil).
 


### PR DESCRIPTION
## Sorun

Master merge sonrası **"🚀 Otomatik Release"** job'u patlıyordu. Build başarılı (APK üretildi, `v0.23.0` tag'i push edildi) ama `expo-build.yml`'i `createWorkflowDispatch` ile tetikleyen adım **403 "Resource not accessible by integration"** verip job'u kırdı.

```
🚀 EAS Build tetikleniyor: v0.23.0 (versionCode: 48)
RequestError [HttpError]: Resource not accessible by integration  (status: 403)
'x-accepted-github-permissions': 'actions=write'
```

### Kök neden
- `permissions:` bloğunda yalnızca `contents: write` vardı. Başka bir workflow'u dispatch etmek için **`actions: write`** gerekli. (`git push` çalıştı çünkü `contents: write` yeterliydi.)
- Ayrıca **EAS tetikleme adımı, GitHub Release adımından önceydi** → dispatch patlayınca GitHub Release sayfası hiç oluşmadı (tag push edildi ama release yok).

## Düzeltme
- `permissions:` → `actions: write` eklendi.
- Adım sırası değişti: **GitHub Release → EAS dispatch** (release artık dispatch'e bağımlı değil; dispatch ileride sorun yaşasa bile release yayında kalır).
- CLAUDE.md CI bölümüne bu gotcha eklendi.

## Not (v0.23.0 kurtarma)
Bu run yarıda kaldığı için `v0.23.0` tag'i var ama **GitHub Release sayfası ve Play Store internal build oluşmadı**. Bu PR gelecek release'leri düzeltir; 0.23.0'ın internal build'i için `expo-build.yml` manuel tetiklenebilir (kullanıcı onayıyla).

https://claude.ai/code/session_01NGeqVKL9odk19oStYpczCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGeqVKL9odk19oStYpczCv)_