### PR TITLE
SayisalSecici bileşeninde erişilebilirlik iyileştirmesi (touch target boyutları)

### DIFF
--- a/src/presentation/components/common/SayisalSecici.tsx
+++ b/src/presentation/components/common/SayisalSecici.tsx
@@ -59,7 +59,7 @@ export const SayisalSecici: React.FC<SayisalSeciciProps> = ({
   return (
     <View className="flex-row items-center rounded-lg overflow-hidden border" style={{ borderColor: renkler.sinir }}>
       <TouchableOpacity
-        className="w-9 h-9 items-center justify-center"
+        className="w-11 h-11 items-center justify-center"
         style={{ backgroundColor: deger <= min ? renkler.sinir : renk }}
         onPress={azalt}
         disabled={deger <= min}
@@ -70,14 +70,14 @@ export const SayisalSecici: React.FC<SayisalSeciciProps> = ({
         <FontAwesome5 name="minus" size={12} color="#FFF" />
       </TouchableOpacity>
       <View
-        className="px-3 h-9 items-center justify-center flex-row"
+        className="px-3 h-11 items-center justify-center flex-row"
         style={{ backgroundColor: renkler.kartArkaplan, minWidth: degerGenisligi }}
       >
         <Text className="text-base font-bold mr-1" style={{ color: renkler.metin }}>{deger}</Text>
         <Text className="text-xs" style={{ color: renkler.metinIkincil }}>{birim}</Text>
       </View>
       <TouchableOpacity
-        className="w-9 h-9 items-center justify-center"
+        className="w-11 h-11 items-center justify-center"
         style={{ backgroundColor: deger >= max ? renkler.sinir : renk }}
         onPress={artir}
         disabled={deger >= max}


### PR DESCRIPTION
Bu çalışmada uygulamanın arayüz kalitesi (UX) ve erişilebilirlik denetimi gerçekleştirildi. 

**Bulgu:** `src/presentation/components/common/SayisalSecici.tsx` dosyasında artır/azalt düğmelerinin dokunma (touch target) boyutu 36x36 px (`w-9 h-9`) olup, ~44x44 px olan erişilebilirlik minimum değerinin altındaydı.

**Kullanıcıya etkisi:** Daha küçük ekranlı cihazlarda ve motor becerileri sınırlı olan kullanıcılarda bu butonlara dokunmak zor ve hedefini kaçırmaya meyilli hale geliyordu, bu da uygulamanın WCAG dokunma alanı standartlarını ihlal etmesine sebep oluyordu.

**Düzeltme:** İlgili buton boyutları ve kapsayıcı görünüm (view) yükseklikleri `w-11 h-11` (44x44 dp) yapılarak dokunma alanları erişilebilir standartlara getirildi.

**Doğrulama:** `npm run verify` komutu çalıştırıldı ve tüm kontroller başarıyla geçti.

---
*PR created automatically by Jules for task [10808362831780968694](https://jules.google.com/task/10808362831780968694) started by @furkanisikay*