### PR TITLE
ci: kalite kapıları — coverage ratchet eşiği + CI coverage özeti (Faz 1-C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,13 @@ jobs:
             echo "|---------|-------|"
             echo "| Unit Tests | ${{ steps.tests.outcome == 'success' && '✅ Basarili' || '❌ Basarisiz' }} |"
             echo ""
-            if [ -f coverage/lcov.info ]; then
+            if [ -f coverage/coverage-summary.json ]; then
+              echo "#### 📊 Coverage (eşik: S50 / B35 / F40 / L50)"
+              echo ""
+              echo "| Metrik | % | Kapsam |"
+              echo "|--------|---|--------|"
+              node -e 'const t=require("./coverage/coverage-summary.json").total; const ad={lines:"Lines",statements:"Statements",functions:"Functions",branches:"Branches"}; for(const k of ["lines","statements","functions","branches"]) console.log(`| ${ad[k]} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`);' >> $GITHUB_STEP_SUMMARY
+            elif [ -f coverage/lcov.info ]; then
               echo "> 📊 Coverage raporu artifact olarak yuklendi."
             fi
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
             echo "|---------|-------|"
             echo "| Unit Tests | ${{ steps.tests.outcome == 'success' && '✅ Basarili' || '❌ Basarisiz' }} |"
             echo ""
+            # NOT: aşağıdaki "S50 / B35 / F40 / L50" etiketi yalnız bilgi amaçlı; eşik
+            # değerleri jest.config.js > coverageThreshold'da zorlanır — orayı değiştirirken bu etiketi de güncelle.
             if [ -f coverage/coverage-summary.json ]; then
               echo "#### 📊 Coverage (eşik: S50 / B35 / F40 / L50)"
               echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: 🧪 Testleri calistir
         id: tests
-        run: npm test -- --coverage --coverageReporters=text --coverageReporters=lcov
+        run: npm test -- --coverage
 
       - name: 📊 Coverage artifact
         uses: actions/upload-artifact@v7

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,18 @@ module.exports = {
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|expo-.*|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|adhan|@expo/vector-icons|expo-modules-core)"
   ],
+  // CI özeti coverage/coverage-summary.json'u okur (Task 2); text+lcov korunur.
+  coverageReporters: ["text", "lcov", "json-summary"],
+  // Ratchet: mevcut seviyenin birkaç puan altı → erozyonu durdurur, mevcut suite'i bloklamaz.
+  // Coverage yükseldikçe bu tabanlar da yükseltilmeli (yukarı doğru ratchet).
+  coverageThreshold: {
+    global: {
+      statements: 50,
+      branches: 35,
+      functions: 40,
+      lines: 50,
+    },
+  },
   coverageDirectory: "coverage",
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 };


### PR DESCRIPTION
## Özet
CI/CD Faz 1 — **Component C (Kalite kapıları)**. Test coverage erozyonunu durduran zorunlu bir taban (ratchet) + CI özetinde gerçek coverage raporu. Spec/plan: `docs/superpowers/specs/2026-06-24-ci-cd-guclendirme-design.md` (C) · `docs/superpowers/plans/2026-06-24-ci-cd-faz1-koruma-kalite.md` (Task 1-2).

## Değişiklikler
- **`jest.config.js`** — `coverageThreshold` (global: statements 50 / branches 35 / functions 40 / lines 50). Mevcut seviyenin (S52.46 / B37.22 / F42.57 / L53.2) birkaç puan altı → erozyonu durdurur, mevcut suite'i bloklamaz (yukarı doğru ratchet'lenmeli). `json-summary` reporter eklendi (`text`+`lcov` korundu).
- **`.github/workflows/ci.yml`** — test job özetine `coverage-summary.json`'dan parse edilen gerçek coverage % tablosu (`$GITHUB_STEP_SUMMARY`); coverage komutu config reporter'larını kullanacak şekilde sadeleştirildi.

## Yakalanan bug (review)
Final/opus review **CRITICAL** yakaladı: CI test komutundaki `--coverageReporters=text --coverageReporters=lcov` CLI bayrakları jest config'in reporter dizisini **override** ediyordu (merge değil) → CI'da `json-summary` düşüyor → `coverage-summary.json` hiç üretilmiyor → tablo ölü. Komut `npm test -- --coverage`'a çevrildi (config reporter'ları geçerli olsun); gerçek CI komutuyla `coverage-summary.json`'ın üretildiği doğrulandı.

## Doğrulama
- `npm run verify`: **70 suite / 1001 test PASS**, yeni lint warning yok.
- Eşik mevcut kodda geçiyor; negatif test (geçici `lines:99`) eşiğin gerçekten fail ettiğini kanıtladı, sonra geri alındı.
- Subagent-driven (opus): Task 1 (Approved, sıfır bulgu) · Task 2 (1 Critical fix → re-review Approved) · final whole-branch review (opus): **Ready to merge YES**, sıfır Critical/Important.

## Not
- Bu PR **A (master branch protection, Task 3-5)** içermez — o, `RELEASE_TOKEN` ön koşuluna bağlı, ayrı gelecek.
- Master'a merge auto-release tetikler (~24dk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
