### PR TITLE
test: yüksek-değerli katmanlarda coverage yükseltme + klasör-bazlı eşik (%53→%64, domain %94, data %91)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -34,15 +34,18 @@ module.exports = {
   ],
   // CI özeti coverage/coverage-summary.json'u okur (Task 2); text+lcov korunur.
   coverageReporters: ["text", "lcov", "json-summary"],
-  // Ratchet: mevcut seviyenin birkaç puan altı → erozyonu durdurur, mevcut suite'i bloklamaz.
-  // Coverage yükseldikçe bu tabanlar da yükseltilmeli (yukarı doğru ratchet).
+  // Klasör-bazlı ratchet (mühendislik toleranslı). Kritik iş mantığı (domain) ve veri
+  // katmanı YÜKSEKTE kilitli → erozyonları engellenir, yukarı ratchet'lenmeli. Geri kalan
+  // (presentation/UI, core, navigation) tolere edilebilir global tabanla korunur — UI
+  // render testine zorlamadan. Mevcut (2026-06-25): domain 94/87, data 87/63, global L63/B45.
+  // Tabanlar achieved seviyenin birkaç puan altı; coverage yükseldikçe yukarı çekin.
+  // NOT: glob anahtarı (**/*.ts) eşiği HER DOSYAYA ayrı uygular; AGGREGATE (klasör toplamı)
+  // istediğimiz için DİZİN-YOLU anahtarı kullanılır. Dizin-yolu eşleşen dosyaları global'den
+  // düşer, eşik klasör toplamına uygulanır.
   coverageThreshold: {
-    global: {
-      statements: 50,
-      branches: 35,
-      functions: 40,
-      lines: 50,
-    },
+    global: { statements: 35, branches: 20, functions: 30, lines: 35 },
+    "./src/domain/": { statements: 88, branches: 78, functions: 85, lines: 88 },
+    "./src/data/": { statements: 78, branches: 53, functions: 80, lines: 78 },
   },
   coverageDirectory: "coverage",
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,13 +37,15 @@ module.exports = {
   // Klasör-bazlı ratchet (mühendislik toleranslı). Kritik iş mantığı (domain) ve veri
   // katmanı YÜKSEKTE kilitli → erozyonları engellenir, yukarı ratchet'lenmeli. Geri kalan
   // (presentation/UI, core, navigation) tolere edilebilir global tabanla korunur — UI
-  // render testine zorlamadan. Mevcut (2026-06-25): domain 94/87, data 87/63, global L63/B45.
-  // Tabanlar achieved seviyenin birkaç puan altı; coverage yükseldikçe yukarı çekin.
+  // render testine zorlamadan, ama eklenen store-slice/hook kazanımı erimeyecek kadar.
+  // Mevcut (2026-06-25): domain ~94/87, data ~92/64, global toplam L64/B45; global bucket
+  // (domain+data düşülmüş = presentation+core+nav) ~L42/B27. Tabanlar achieved'in birkaç
+  // puan altı; coverage yükseldikçe yukarı çekin.
   // NOT: glob anahtarı (**/*.ts) eşiği HER DOSYAYA ayrı uygular; AGGREGATE (klasör toplamı)
   // istediğimiz için DİZİN-YOLU anahtarı kullanılır. Dizin-yolu eşleşen dosyaları global'den
   // düşer, eşik klasör toplamına uygulanır.
   coverageThreshold: {
-    global: { statements: 35, branches: 20, functions: 30, lines: 35 },
+    global: { statements: 38, branches: 24, functions: 32, lines: 38 },
     "./src/domain/": { statements: 88, branches: 78, functions: 85, lines: 88 },
     "./src/data/": { statements: 78, branches: 53, functions: 80, lines: 78 },
   },

--- a/src/data/local/__tests__/LocalKonumServisi.test.ts
+++ b/src/data/local/__tests__/LocalKonumServisi.test.ts
@@ -1,0 +1,306 @@
+/**
+ * LocalKonumServisi — konum persistence DAVRANIŞ testleri
+ *
+ * Kapsanan davranışlar:
+ * - Getir: veri yok → null ile başarılı; geçerli veri → parse; getItem fırlatırsa → {basarili:false}
+ * - Kaydet: doğru anahtara doğru JSON yazar; setItem fırlatırsa → {basarili:false}
+ * - Kısmi güncelleyiciler (koordinat/GPS/mod/il-ilçe): mevcut ayarları KORUYUP yalnız ilgili
+ *   alanı değiştirir; kayıtlı veri yoksa VARSAYILAN üzerine uygular
+ * - GPS: gpsAdres verilince sonGpsGuncellemesi yenilenir, null verilince ESKİsi korunur
+ * - İl/ilçe: konumModu 'manuel'e çekilir + seciliSehirId = String(ilId)
+ * - Temizle: removeItem çağrılır → veri kalmaz; hata yolu {basarili:false}
+ * - VarMi: kayıt varken true, yokken false, hata olunca false
+ */
+
+import {
+  localKonumAyarlariniGetir,
+  localKonumAyarlariniKaydet,
+  localKoordinatlariGuncelle,
+  localGpsAdresiniGuncelle,
+  localKonumModunuGuncelle,
+  localIlIlceSeciminiGuncelle,
+  localKonumVerileriniTemizle,
+  localKonumVerisiVarMi,
+  VARSAYILAN_KONUM_AYARLARI,
+  type KonumAyarlari,
+} from '../LocalKonumServisi';
+import { DEPOLAMA_ANAHTARLARI } from '../../../core/constants/UygulamaSabitleri';
+
+// In-memory AsyncStorage mock (mock* öneki: jest.mock fabrikası closure dışına erişebilsin).
+// mockFirlat* bayrakları catch dallarını davranışsal test etmeye olanak verir.
+const mockStore = new Map<string, string>();
+const mockHata = {
+  getItem: false,
+  setItem: false,
+  removeItem: false,
+};
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: async (k: string) => {
+      if (mockHata.getItem) throw new Error('getItem patladi');
+      return mockStore.has(k) ? mockStore.get(k)! : null;
+    },
+    setItem: async (k: string, v: string) => {
+      if (mockHata.setItem) throw new Error('setItem patladi');
+      mockStore.set(k, v);
+    },
+    removeItem: async (k: string) => {
+      if (mockHata.removeItem) throw new Error('removeItem patladi');
+      mockStore.delete(k);
+    },
+  },
+}));
+
+// Logger'ı sustur
+jest.mock('../../../core/utils/Logger', () => ({
+  Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const KEY = DEPOLAMA_ANAHTARLARI.KONUM_AYARLARI;
+
+/** Diske yazılı ham JSON'u çözer (test assertion'ları için). */
+const diskOku = (): KonumAyarlari | null => {
+  const ham = mockStore.get(KEY);
+  return ham ? (JSON.parse(ham) as KonumAyarlari) : null;
+};
+
+beforeEach(() => {
+  mockStore.clear();
+  mockHata.getItem = false;
+  mockHata.setItem = false;
+  mockHata.removeItem = false;
+});
+
+describe('localKonumAyarlariniGetir', () => {
+  test('kayıtlı veri yokken null ile başarılı döner (slice varsayılan kullansın)', async () => {
+    const y = await localKonumAyarlariniGetir();
+    expect(y.basarili).toBe(true);
+    expect(y.veri).toBeNull();
+  });
+
+  test('kayıtlı geçerli veriyi parse edip döner', async () => {
+    const kayit: KonumAyarlari = {
+      ...VARSAYILAN_KONUM_AYARLARI,
+      seciliIlAdi: 'Ankara',
+      seciliIlId: 6,
+      konumModu: 'oto',
+    };
+    mockStore.set(KEY, JSON.stringify(kayit));
+
+    const y = await localKonumAyarlariniGetir();
+    expect(y.basarili).toBe(true);
+    expect(y.veri?.seciliIlAdi).toBe('Ankara');
+    expect(y.veri?.seciliIlId).toBe(6);
+    expect(y.veri?.konumModu).toBe('oto');
+  });
+
+  test('AsyncStorage okuması fırlatırsa hata mesajıyla başarısız döner', async () => {
+    mockHata.getItem = true;
+    const y = await localKonumAyarlariniGetir();
+    expect(y.basarili).toBe(false);
+    expect(y.hata).toBe('getItem patladi');
+  });
+});
+
+describe('localKonumAyarlariniKaydet', () => {
+  test('ayarları doğru anahtara JSON olarak yazar', async () => {
+    const ayarlar: KonumAyarlari = {
+      ...VARSAYILAN_KONUM_AYARLARI,
+      seciliIlAdi: 'Izmir',
+      seciliIlId: 35,
+    };
+    const y = await localKonumAyarlariniKaydet(ayarlar);
+
+    expect(y.basarili).toBe(true);
+    expect(diskOku()?.seciliIlAdi).toBe('Izmir');
+    expect(diskOku()?.seciliIlId).toBe(35);
+  });
+
+  test('yazma fırlatırsa başarısız döner ve diske yazılmaz', async () => {
+    mockHata.setItem = true;
+    const y = await localKonumAyarlariniKaydet(VARSAYILAN_KONUM_AYARLARI);
+
+    expect(y.basarili).toBe(false);
+    expect(y.hata).toBe('setItem patladi');
+    expect(mockStore.has(KEY)).toBe(false);
+  });
+});
+
+describe('localKoordinatlariGuncelle', () => {
+  test('mevcut ayarları koruyup yalnız koordinatı değiştirir', async () => {
+    const onceki: KonumAyarlari = {
+      ...VARSAYILAN_KONUM_AYARLARI,
+      seciliIlAdi: 'Bursa',
+      seciliIlId: 16,
+      konumModu: 'oto',
+    };
+    mockStore.set(KEY, JSON.stringify(onceki));
+
+    const yeni = { lat: 40.1885, lng: 29.061 };
+    const y = await localKoordinatlariGuncelle(yeni);
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.koordinatlar).toEqual(yeni);
+    // diğer alanlar korunmalı
+    expect(disk.seciliIlAdi).toBe('Bursa');
+    expect(disk.seciliIlId).toBe(16);
+    expect(disk.konumModu).toBe('oto');
+  });
+
+  test('kayıtlı veri yokken VARSAYILAN üzerine koordinatı uygular', async () => {
+    const yeni = { lat: 1, lng: 2 };
+    const y = await localKoordinatlariGuncelle(yeni);
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.koordinatlar).toEqual(yeni);
+    expect(disk.seciliIlAdi).toBe(VARSAYILAN_KONUM_AYARLARI.seciliIlAdi);
+  });
+});
+
+describe('localGpsAdresiniGuncelle', () => {
+  test('gpsAdres verilince adresi yazar ve sonGpsGuncellemesi tarihini tazeler', async () => {
+    const onceki: KonumAyarlari = {
+      ...VARSAYILAN_KONUM_AYARLARI,
+      sonGpsGuncellemesi: null,
+    };
+    mockStore.set(KEY, JSON.stringify(onceki));
+
+    const adres = { semt: 'Kadikoy', ilce: 'Kadikoy', il: 'Istanbul' };
+    const oncesi = Date.now();
+    const y = await localGpsAdresiniGuncelle(adres);
+    const sonrasi = Date.now();
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.gpsAdres).toEqual(adres);
+    expect(disk.sonGpsGuncellemesi).not.toBeNull();
+    const zaman = new Date(disk.sonGpsGuncellemesi!).getTime();
+    expect(zaman).toBeGreaterThanOrEqual(oncesi);
+    expect(zaman).toBeLessThanOrEqual(sonrasi);
+  });
+
+  test('gpsAdres null verilince adresi temizler ama eski sonGpsGuncellemesi korunur', async () => {
+    const eskiZaman = '2026-01-15T10:00:00.000Z';
+    const onceki: KonumAyarlari = {
+      ...VARSAYILAN_KONUM_AYARLARI,
+      gpsAdres: { semt: 'X', ilce: 'Y', il: 'Z' },
+      sonGpsGuncellemesi: eskiZaman,
+    };
+    mockStore.set(KEY, JSON.stringify(onceki));
+
+    const y = await localGpsAdresiniGuncelle(null);
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.gpsAdres).toBeNull();
+    expect(disk.sonGpsGuncellemesi).toBe(eskiZaman);
+  });
+});
+
+describe('localKonumModunuGuncelle', () => {
+  test('yalnız konum modunu değiştirir, diğer alanları korur', async () => {
+    const onceki: KonumAyarlari = {
+      ...VARSAYILAN_KONUM_AYARLARI,
+      konumModu: 'manuel',
+      seciliIlAdi: 'Konya',
+    };
+    mockStore.set(KEY, JSON.stringify(onceki));
+
+    const y = await localKonumModunuGuncelle('oto');
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.konumModu).toBe('oto');
+    expect(disk.seciliIlAdi).toBe('Konya');
+  });
+});
+
+describe('localIlIlceSeciminiGuncelle', () => {
+  test('il/ilçe alanlarını yazar, modu manuele çeker, seciliSehirId = String(ilId)', async () => {
+    // başlangıçta oto moddaki bir kayıt
+    mockStore.set(
+      KEY,
+      JSON.stringify({ ...VARSAYILAN_KONUM_AYARLARI, konumModu: 'oto' })
+    );
+
+    const koord = { lat: 38.4237, lng: 27.1428 };
+    const y = await localIlIlceSeciminiGuncelle(35, 'Izmir', 5, 'Bornova', koord);
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.konumModu).toBe('manuel');
+    expect(disk.seciliIlId).toBe(35);
+    expect(disk.seciliSehirId).toBe('35');
+    expect(disk.seciliIlAdi).toBe('Izmir');
+    expect(disk.seciliIlceId).toBe(5);
+    expect(disk.seciliIlceAdi).toBe('Bornova');
+    expect(disk.koordinatlar).toEqual(koord);
+  });
+
+  test('ilçe null geçilebilir (sadece il seçimi)', async () => {
+    const y = await localIlIlceSeciminiGuncelle(
+      6,
+      'Ankara',
+      null,
+      '',
+      { lat: 39.9334, lng: 32.8597 }
+    );
+
+    expect(y.basarili).toBe(true);
+    const disk = diskOku()!;
+    expect(disk.seciliIlceId).toBeNull();
+    expect(disk.seciliIlceAdi).toBe('');
+    expect(disk.seciliIlAdi).toBe('Ankara');
+  });
+
+  test('kayıt yazılamazsa başarısız döner', async () => {
+    mockHata.setItem = true;
+    const y = await localIlIlceSeciminiGuncelle(34, 'Istanbul', null, '', {
+      lat: 41,
+      lng: 28,
+    });
+    expect(y.basarili).toBe(false);
+  });
+});
+
+describe('localKonumVerileriniTemizle', () => {
+  test('kayıtlı veriyi siler ve başarılı döner', async () => {
+    mockStore.set(KEY, JSON.stringify(VARSAYILAN_KONUM_AYARLARI));
+
+    const y = await localKonumVerileriniTemizle();
+
+    expect(y.basarili).toBe(true);
+    expect(mockStore.has(KEY)).toBe(false);
+  });
+
+  test('silme fırlatırsa hata mesajıyla başarısız döner', async () => {
+    mockStore.set(KEY, JSON.stringify(VARSAYILAN_KONUM_AYARLARI));
+    mockHata.removeItem = true;
+
+    const y = await localKonumVerileriniTemizle();
+
+    expect(y.basarili).toBe(false);
+    expect(y.hata).toBe('removeItem patladi');
+    // veri silinmeden durur
+    expect(mockStore.has(KEY)).toBe(true);
+  });
+});
+
+describe('localKonumVerisiVarMi', () => {
+  test('kayıt varken true döner', async () => {
+    mockStore.set(KEY, JSON.stringify(VARSAYILAN_KONUM_AYARLARI));
+    expect(await localKonumVerisiVarMi()).toBe(true);
+  });
+
+  test('kayıt yokken false döner', async () => {
+    expect(await localKonumVerisiVarMi()).toBe(false);
+  });
+
+  test('okuma fırlatsa bile (sessizce) false döner', async () => {
+    mockHata.getItem = true;
+    expect(await localKonumVerisiVarMi()).toBe(false);
+  });
+});

--- a/src/data/local/__tests__/LocalSeriServisi.test.ts
+++ b/src/data/local/__tests__/LocalSeriServisi.test.ts
@@ -8,9 +8,38 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DEPOLAMA_ANAHTARLARI } from '../../../core/constants/UygulamaSabitleri';
+import { VARSAYILAN_SERI_AYARLARI } from '../../../core/types/SeriTipleri';
+import type {
+  SeriDurumu,
+  SeriAyarlari,
+  KullaniciRozeti,
+  SeviyeDurumu,
+  OzelGunAyarlari,
+} from '../../../core/types/SeriTipleri';
 import {
   localSeviyeDurumunuGetir,
   localSeriDurumunuGetir,
+  localSeriDurumunuKaydet,
+  localRozetleriGetir,
+  localRozetleriKaydet,
+  localSeviyeDurumunuKaydet,
+  localSeriAyarlariniGetir,
+  localSeriAyarlariniKaydet,
+  localOzelGunAyarlariniGetir,
+  localOzelGunAyarlariniKaydet,
+  VARSAYILAN_OZEL_GUN_AYARLARI,
+  localToplamKilinanNamaziGetir,
+  localToplamKilinanNamaziKaydet,
+  localToplamKilinanNamaziArttir,
+  localToparlanmaSayisiniGetir,
+  localToparlanmaSayisiniArttir,
+  localMukemmelGunSayisiniGetir,
+  localMukemmelGunSayisiniArttir,
+  localMukemmelGunSayisiniKaydet,
+  localBonusPuaniGetir,
+  localBonusPuaniKaydet,
+  localTumSeriVerileriniGetir,
+  localTumSeriVerileriniTemizle,
 } from '../LocalSeriServisi';
 
 describe('LocalSeriServisi - Veri Migrasyonu', () => {
@@ -324,6 +353,457 @@ describe('LocalSeriServisi - Veri Migrasyonu', () => {
       expect(sonuc.veri!.dondurulduMu).toBe(true);
       expect(sonuc.veri!.dondurulmaTarihi).toBe('2026-02-15');
       expect(sonuc.veri!.mevcutSeri).toBe(10);
+    });
+  });
+});
+
+// Hata yolu testlerinde AsyncStorage metodunu gecici olarak red'e cevirir.
+// Resmi @react-native-async-storage jest mock'unda her metot bir jest.fn'dir;
+// mockImplementationOnce ile sadece BIR cagriyi reddederiz -> sonraki test'lerin
+// in-memory store'u etkilenmez, manuel geri-yukleme gerekmez.
+type AsyncMethod = 'getItem' | 'setItem' | 'removeItem';
+const asyncStorageHatasiEnjekteEt = (
+  metot: AsyncMethod,
+  hataMesaji = 'disk hatasi'
+): (() => void) => {
+  (AsyncStorage[metot] as jest.Mock).mockImplementationOnce(() =>
+    Promise.reject(new Error(hataMesaji))
+  );
+  // mockImplementationOnce kendiliginden temizlenir; uyumluluk icin no-op doner.
+  return () => undefined;
+};
+
+describe('LocalSeriServisi - Kaydetme (round-trip) ve hata yollari', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('Seri durumu kaydet/getir', () => {
+    test('kaydedilen seri durumu aynen geri okunur (round-trip)', async () => {
+      const durum: SeriDurumu = {
+        mevcutSeri: 7,
+        enUzunSeri: 12,
+        sonTamGun: '2026-06-20',
+        seriBaslangici: '2026-06-14',
+        toparlanmaDurumu: null,
+        dondurulduMu: false,
+        dondurulmaTarihi: null,
+        sonGuncelleme: '2026-06-20T10:00:00.000Z',
+      };
+
+      const kaydet = await localSeriDurumunuKaydet(durum);
+      expect(kaydet.basarili).toBe(true);
+
+      // Diskte gercekten JSON yazilmis olmali
+      const ham = await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.SERI_DURUMU);
+      expect(ham).toBe(JSON.stringify(durum));
+
+      const getir = await localSeriDurumunuGetir();
+      expect(getir.basarili).toBe(true);
+      expect(getir.veri!.mevcutSeri).toBe(7);
+      expect(getir.veri!.enUzunSeri).toBe(12);
+      expect(getir.veri!.sonTamGun).toBe('2026-06-20');
+    });
+
+    test('setItem reddederse basarili:false + hata mesaji doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('setItem', 'yazma basarisiz');
+      try {
+        const sonuc = await localSeriDurumunuKaydet({
+          mevcutSeri: 1,
+          enUzunSeri: 1,
+          sonTamGun: null,
+          seriBaslangici: null,
+          toparlanmaDurumu: null,
+          dondurulduMu: false,
+          dondurulmaTarihi: null,
+          sonGuncelleme: '2026-06-20T10:00:00.000Z',
+        });
+        expect(sonuc.basarili).toBe(false);
+        expect(sonuc.hata).toBe('yazma basarisiz');
+      } finally {
+        geriYukle();
+      }
+    });
+
+    test('getItem reddederse basarili:false + hata mesaji doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('getItem', 'okuma basarisiz');
+      try {
+        const sonuc = await localSeriDurumunuGetir();
+        expect(sonuc.basarili).toBe(false);
+        expect(sonuc.hata).toBe('okuma basarisiz');
+        expect(sonuc.veri).toBeUndefined();
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Rozet verileri getir/kaydet', () => {
+    test('veri yokken bos (tum tanimli ama kazanilmamis) rozet listesi doner', async () => {
+      const sonuc = await localRozetleriGetir();
+      expect(sonuc.basarili).toBe(true);
+      expect(Array.isArray(sonuc.veri)).toBe(true);
+      expect(sonuc.veri!.length).toBeGreaterThan(0);
+      // Bos liste = hicbiri kazanilmamis
+      expect(sonuc.veri!.every((r) => r.kazanildiMi === false)).toBe(true);
+      expect(sonuc.veri!.every((r) => r.kazanilmaTarihi === null)).toBe(true);
+    });
+
+    test('kaydedilen rozetler aynen geri okunur (round-trip)', async () => {
+      const rozetler: KullaniciRozeti[] = [
+        { rozetId: 'ilk_adim', kazanildiMi: true, kazanilmaTarihi: '2026-06-19' },
+        { rozetId: 'yuz_namaz', kazanildiMi: false, kazanilmaTarihi: null },
+      ];
+
+      const kaydet = await localRozetleriKaydet(rozetler);
+      expect(kaydet.basarili).toBe(true);
+
+      const getir = await localRozetleriGetir();
+      expect(getir.basarili).toBe(true);
+      expect(getir.veri).toEqual(rozetler);
+      // Kazanilan rozet korunmus olmali
+      const ilkAdim = getir.veri!.find((r) => r.rozetId === 'ilk_adim');
+      expect(ilkAdim?.kazanildiMi).toBe(true);
+      expect(ilkAdim?.kazanilmaTarihi).toBe('2026-06-19');
+    });
+
+    test('getItem reddederse basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('getItem');
+      try {
+        const sonuc = await localRozetleriGetir();
+        expect(sonuc.basarili).toBe(false);
+        expect(sonuc.hata).toBe('disk hatasi');
+      } finally {
+        geriYukle();
+      }
+    });
+
+    test('setItem reddederse kaydet basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('setItem');
+      try {
+        const sonuc = await localRozetleriKaydet([]);
+        expect(sonuc.basarili).toBe(false);
+        expect(sonuc.hata).toBe('disk hatasi');
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Seviye durumu kaydet', () => {
+    test('kaydedilen seviye durumu aynen geri okunur (round-trip)', async () => {
+      const seviye: SeviyeDurumu = {
+        mevcutSeviye: 4,
+        toplamPuan: 750,
+        mevcutSeviyePuani: 150,
+        sonrakiSeviyeKalanPuan: 250,
+        rank: 'Mürid',
+        rankIkonu: '💫',
+      };
+
+      const kaydet = await localSeviyeDurumunuKaydet(seviye);
+      expect(kaydet.basarili).toBe(true);
+
+      const getir = await localSeviyeDurumunuGetir();
+      expect(getir.basarili).toBe(true);
+      // rank/rankIkonu zaten dolu -> migrasyon dokunmamali
+      expect(getir.veri).toEqual(seviye);
+    });
+
+    test('setItem reddederse basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('setItem');
+      try {
+        const sonuc = await localSeviyeDurumunuKaydet({
+          mevcutSeviye: 1,
+          toplamPuan: 0,
+          mevcutSeviyePuani: 0,
+          sonrakiSeviyeKalanPuan: 100,
+          rank: 'Mübtedi',
+          rankIkonu: '🌙',
+        });
+        expect(sonuc.basarili).toBe(false);
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Seri ayarlari getir/kaydet', () => {
+    test('veri yokken varsayilan ayarlari doner', async () => {
+      const sonuc = await localSeriAyarlariniGetir();
+      expect(sonuc.basarili).toBe(true);
+      expect(sonuc.veri).toEqual(VARSAYILAN_SERI_AYARLARI);
+    });
+
+    test('kaydedilen ozel ayar varsayilani EZER ve geri okunur', async () => {
+      const ayar: SeriAyarlari = {
+        ...VARSAYILAN_SERI_AYARLARI,
+        tamGunEsigi: 3,
+        bildirimlerAktif: false,
+        bildirimSaati: 22,
+      };
+
+      const kaydet = await localSeriAyarlariniKaydet(ayar);
+      expect(kaydet.basarili).toBe(true);
+
+      const getir = await localSeriAyarlariniGetir();
+      expect(getir.basarili).toBe(true);
+      expect(getir.veri!.tamGunEsigi).toBe(3);
+      expect(getir.veri!.bildirimlerAktif).toBe(false);
+      expect(getir.veri!.bildirimSaati).toBe(22);
+    });
+
+    test('getItem reddederse basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('getItem');
+      try {
+        const sonuc = await localSeriAyarlariniGetir();
+        expect(sonuc.basarili).toBe(false);
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Ozel gun ayarlari getir/kaydet', () => {
+    test('veri yokken VARSAYILAN_OZEL_GUN_AYARLARI doner', async () => {
+      const sonuc = await localOzelGunAyarlariniGetir();
+      expect(sonuc.basarili).toBe(true);
+      expect(sonuc.veri).toEqual(VARSAYILAN_OZEL_GUN_AYARLARI);
+      expect(sonuc.veri!.ozelGunModuAktif).toBe(false);
+      expect(sonuc.veri!.aktifOzelGun).toBeNull();
+      expect(sonuc.veri!.gecmisKayitlar).toEqual([]);
+    });
+
+    test('kaydedilen aktif ozel gun + gecmis kayit round-trip', async () => {
+      const ayar: OzelGunAyarlari = {
+        ozelGunModuAktif: true,
+        aktifOzelGun: {
+          id: 'og-1',
+          baslangicTarihi: '2026-06-18',
+          bitisTarihi: '2026-06-22',
+          aciklama: 'Yolculuk',
+          olusturulmaTarihi: '2026-06-18T08:00:00.000Z',
+        },
+        gecmisKayitlar: [
+          {
+            id: 'og-0',
+            baslangicTarihi: '2026-05-01',
+            bitisTarihi: '2026-05-03',
+            olusturulmaTarihi: '2026-05-01T08:00:00.000Z',
+          },
+        ],
+      };
+
+      const kaydet = await localOzelGunAyarlariniKaydet(ayar);
+      expect(kaydet.basarili).toBe(true);
+
+      const getir = await localOzelGunAyarlariniGetir();
+      expect(getir.basarili).toBe(true);
+      expect(getir.veri).toEqual(ayar);
+      expect(getir.veri!.aktifOzelGun!.aciklama).toBe('Yolculuk');
+      expect(getir.veri!.gecmisKayitlar).toHaveLength(1);
+    });
+
+    test('setItem reddederse kaydet basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('setItem');
+      try {
+        const sonuc = await localOzelGunAyarlariniKaydet(
+          VARSAYILAN_OZEL_GUN_AYARLARI
+        );
+        expect(sonuc.basarili).toBe(false);
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Istatistik sayaclari (toplam/toparlanma/mukemmel gun)', () => {
+    test('toplam kilinan namaz: veri yokken 0 doner', async () => {
+      const sonuc = await localToplamKilinanNamaziGetir();
+      expect(sonuc.basarili).toBe(true);
+      expect(sonuc.veri).toBe(0);
+    });
+
+    test('toplam kilinan namaz kaydet -> string olarak yazar, sayi olarak okunur', async () => {
+      await localToplamKilinanNamaziKaydet(42);
+      const ham = await AsyncStorage.getItem(
+        DEPOLAMA_ANAHTARLARI.TOPLAM_KILILAN_NAMAZ
+      );
+      expect(ham).toBe('42'); // string olarak saklanir
+      const sonuc = await localToplamKilinanNamaziGetir();
+      expect(sonuc.veri).toBe(42); // parseInt ile sayi doner
+    });
+
+    test('toplam kilinan namaz arttir: varsayilan miktar 1 ekler', async () => {
+      await localToplamKilinanNamaziKaydet(10);
+      const sonuc = await localToplamKilinanNamaziArttir();
+      expect(sonuc.basarili).toBe(true);
+      expect(sonuc.veri).toBe(11);
+      // Kalici olmali
+      expect((await localToplamKilinanNamaziGetir()).veri).toBe(11);
+    });
+
+    test('toplam kilinan namaz arttir: ozel miktar ve sifirdan baslama', async () => {
+      // Hic veri yok -> mevcut 0 kabul edilip miktar eklenir
+      const sonuc = await localToplamKilinanNamaziArttir(5);
+      expect(sonuc.veri).toBe(5);
+      const sonuc2 = await localToplamKilinanNamaziArttir(3);
+      expect(sonuc2.veri).toBe(8);
+    });
+
+    test('toparlanma sayisi: arttir her cagrida 1 artar ve kalici olur', async () => {
+      const ilk = await localToparlanmaSayisiniArttir();
+      expect(ilk.veri).toBe(1);
+      const ikinci = await localToparlanmaSayisiniArttir();
+      expect(ikinci.veri).toBe(2);
+      expect((await localToparlanmaSayisiniGetir()).veri).toBe(2);
+    });
+
+    test('toparlanma sayisi getir: veri yokken 0', async () => {
+      expect((await localToparlanmaSayisiniGetir()).veri).toBe(0);
+    });
+
+    test('mukemmel gun: arttir + getir + dogrudan kaydet (set) davranisi', async () => {
+      expect((await localMukemmelGunSayisiniGetir()).veri).toBe(0);
+      const art = await localMukemmelGunSayisiniArttir();
+      expect(art.veri).toBe(1);
+
+      // Kaydet dogrudan set eder (Arttir degil)
+      await localMukemmelGunSayisiniKaydet(9);
+      expect((await localMukemmelGunSayisiniGetir()).veri).toBe(9);
+    });
+
+    test('mukemmel gun kaydet: negatif/ondalik degerleri 0 alt sinir + yuvarlama ile temizler', async () => {
+      // Math.max(0, Math.round(sayi)) -> negatif 0'a, ondalik en yakina yuvarlanir
+      await localMukemmelGunSayisiniKaydet(-3);
+      expect((await localMukemmelGunSayisiniGetir()).veri).toBe(0);
+
+      await localMukemmelGunSayisiniKaydet(4.7);
+      expect((await localMukemmelGunSayisiniGetir()).veri).toBe(5);
+    });
+
+    test('toplam getir: getItem reddederse basarili:false', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('getItem');
+      try {
+        const sonuc = await localToplamKilinanNamaziGetir();
+        expect(sonuc.basarili).toBe(false);
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Bonus puan (kalici defter)', () => {
+    test('anahtar yokken null doner (henuz migrate edilmemis sinyali)', async () => {
+      const sonuc = await localBonusPuaniGetir();
+      expect(sonuc.basarili).toBe(true);
+      // null = anahtar yok; 0 ile karistirilmamali (migrasyon ayrimi kritik)
+      expect(sonuc.veri).toBeNull();
+    });
+
+    test('0 kaydedildiyse null DEGIL 0 doner (migrasyon yapilmis demektir)', async () => {
+      await localBonusPuaniKaydet(0);
+      const sonuc = await localBonusPuaniGetir();
+      expect(sonuc.basarili).toBe(true);
+      expect(sonuc.veri).toBe(0); // null degil
+    });
+
+    test('kaydet: negatif degeri 0 alt sinira ceker, ondaligi yuvarlar', async () => {
+      await localBonusPuaniKaydet(-50);
+      expect((await localBonusPuaniGetir()).veri).toBe(0);
+
+      await localBonusPuaniKaydet(123.4);
+      expect((await localBonusPuaniGetir()).veri).toBe(123);
+    });
+
+    test('getItem reddederse basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('getItem');
+      try {
+        const sonuc = await localBonusPuaniGetir();
+        expect(sonuc.basarili).toBe(false);
+      } finally {
+        geriYukle();
+      }
+    });
+  });
+
+  describe('Toplu islemler (getir/temizle)', () => {
+    test('localTumSeriVerileriniGetir: tum alt alanlari tek seferde toplar', async () => {
+      // Onceden bir kismini diske yaz; geri kalan varsayilanlardan gelmeli
+      await localToplamKilinanNamaziKaydet(30);
+      await localMukemmelGunSayisiniKaydet(4);
+      await localToparlanmaSayisiniArttir(); // 1
+      await localSeriAyarlariniKaydet({
+        ...VARSAYILAN_SERI_AYARLARI,
+        tamGunEsigi: 4,
+      });
+
+      const sonuc = await localTumSeriVerileriniGetir();
+      expect(sonuc.basarili).toBe(true);
+      const v = sonuc.veri!;
+      expect(v.toplamKilinanNamaz).toBe(30);
+      expect(v.mukemmelGunSayisi).toBe(4);
+      expect(v.toparlanmaSayisi).toBe(1);
+      expect(v.ayarlar.tamGunEsigi).toBe(4);
+      // Yazilmayanlar varsayilan/bos durum
+      expect(v.seriDurumu.mevcutSeri).toBe(0);
+      expect(Array.isArray(v.rozetler)).toBe(true);
+      expect(v.seviyeDurumu.mevcutSeviye).toBe(1);
+      expect(v.ozelGunAyarlari.ozelGunModuAktif).toBe(false);
+    });
+
+    test('localTumSeriVerileriniTemizle: istatistik+seri anahtarlarini siler, AYARLARI korur', async () => {
+      // Hem temizlenecek hem korunacak anahtarlari doldur
+      await localSeriDurumunuKaydet({
+        mevcutSeri: 5,
+        enUzunSeri: 9,
+        sonTamGun: '2026-06-20',
+        seriBaslangici: '2026-06-16',
+        toparlanmaDurumu: null,
+        dondurulduMu: false,
+        dondurulmaTarihi: null,
+        sonGuncelleme: '2026-06-20T10:00:00.000Z',
+      });
+      await localToplamKilinanNamaziKaydet(100);
+      await localMukemmelGunSayisiniKaydet(7);
+      await localBonusPuaniKaydet(40);
+      // Ayarlar KORUNMALI (temizlemede silinmiyor)
+      await localSeriAyarlariniKaydet({
+        ...VARSAYILAN_SERI_AYARLARI,
+        tamGunEsigi: 3,
+      });
+
+      const temizle = await localTumSeriVerileriniTemizle();
+      expect(temizle.basarili).toBe(true);
+
+      // Silinenler: ham anahtar artik yok
+      expect(
+        await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.SERI_DURUMU)
+      ).toBeNull();
+      expect(
+        await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.TOPLAM_KILILAN_NAMAZ)
+      ).toBeNull();
+      expect(
+        await AsyncStorage.getItem(DEPOLAMA_ANAHTARLARI.MUKEMMEL_GUN_SAYISI)
+      ).toBeNull();
+      // Bonus puan da silinmeli -> getir tekrar null doner (migrate sifirlandi)
+      expect((await localBonusPuaniGetir()).veri).toBeNull();
+
+      // Korunan: ayarlar hala diskte ve degeri aynen
+      const ayarSonuc = await localSeriAyarlariniGetir();
+      expect(ayarSonuc.veri!.tamGunEsigi).toBe(3);
+    });
+
+    test('temizle: removeItem reddederse basarili:false doner', async () => {
+      const geriYukle = asyncStorageHatasiEnjekteEt('removeItem');
+      try {
+        const sonuc = await localTumSeriVerileriniTemizle();
+        expect(sonuc.basarili).toBe(false);
+        expect(sonuc.hata).toBe('disk hatasi');
+      } finally {
+        geriYukle();
+      }
     });
   });
 });

--- a/src/data/local/__tests__/LocalVakitBildirimServisi.test.ts
+++ b/src/data/local/__tests__/LocalVakitBildirimServisi.test.ts
@@ -1,0 +1,202 @@
+/**
+ * LocalVakitBildirimServisi — vakit bildirim ayarları depolama DAVRANIŞ testleri
+ *
+ * Kapsanan davranışlar:
+ * - getAyarlar: veri yokken varsayılan, geçerli okuma, eksik alan migrasyonu
+ *   (varsayılanla birleştirme), bozuk JSON dayanıklılığı (varsayılana düşer, fırlatmaz)
+ * - saveAyarlar: doğru anahtar+değer (JSON) yazımı, true/false dönüş, hata yolu
+ * - updateVakitAyar: tek alan güncelleme + kalıcılık, dönen nesne, hata yolu null
+ */
+
+import {
+  LocalVakitBildirimServisi,
+  VakitBildirimAyarlari,
+} from '../LocalVakitBildirimServisi';
+import { DEPOLAMA_ANAHTARLARI } from '../../../core/constants/UygulamaSabitleri';
+
+// In-memory AsyncStorage mock (mock* öneki: jest.mock fabrikası erişebilsin).
+// getItem/setItem jest.fn ile sarılı → testte mockImplementationOnce ile hata enjekte edilebilir.
+const mockStore = new Map<string, string>();
+const mockGetItem = jest.fn(async (k: string) =>
+  mockStore.has(k) ? mockStore.get(k)! : null
+);
+const mockSetItem = jest.fn(async (k: string, v: string) => {
+  mockStore.set(k, v);
+});
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (k: string) => mockGetItem(k),
+    setItem: (k: string, v: string) => mockSetItem(k, v),
+    removeItem: async (k: string) => {
+      mockStore.delete(k);
+    },
+  },
+}));
+
+// Logger'ı sustur (hata yollarında gerçek log/timer testi kirletmesin)
+jest.mock('../../../core/utils/Logger', () => ({
+  Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const KEY = DEPOLAMA_ANAHTARLARI.VAKIT_BILDIRIM_AYARLARI;
+
+const VARSAYILAN: VakitBildirimAyarlari = {
+  imsak: false,
+  ogle: false,
+  ikindi: false,
+  aksam: false,
+  yatsi: false,
+};
+
+beforeEach(() => {
+  mockStore.clear();
+  mockGetItem.mockClear();
+  mockSetItem.mockClear();
+});
+
+describe('LocalVakitBildirimServisi.getAyarlar', () => {
+  test('veri yokken tüm vakitler kapalı varsayılan döner', async () => {
+    const ayarlar = await LocalVakitBildirimServisi.getAyarlar();
+    expect(ayarlar).toEqual(VARSAYILAN);
+  });
+
+  test('kayıtlı geçerli ayarları doğru anahtardan okur', async () => {
+    const kayitli: VakitBildirimAyarlari = {
+      imsak: true,
+      ogle: false,
+      ikindi: true,
+      aksam: false,
+      yatsi: true,
+    };
+    mockStore.set(KEY, JSON.stringify(kayitli));
+
+    const ayarlar = await LocalVakitBildirimServisi.getAyarlar();
+
+    expect(ayarlar).toEqual(kayitli);
+    expect(mockGetItem).toHaveBeenCalledWith(KEY);
+  });
+
+  test('eksik alanlı eski kayıtta eksikler varsayılanla (false) tamamlanır', async () => {
+    // Migrasyon davranışı: sadece imsak yazılmış eski biçim
+    mockStore.set(KEY, JSON.stringify({ imsak: true }));
+
+    const ayarlar = await LocalVakitBildirimServisi.getAyarlar();
+
+    expect(ayarlar).toEqual({
+      imsak: true,
+      ogle: false,
+      ikindi: false,
+      aksam: false,
+      yatsi: false,
+    });
+  });
+
+  test('bozuk JSON varsa fırlatmaz, varsayılana düşer', async () => {
+    mockStore.set(KEY, '{bozuk json');
+
+    const ayarlar = await LocalVakitBildirimServisi.getAyarlar();
+
+    expect(ayarlar).toEqual(VARSAYILAN);
+  });
+
+  test('getItem fırlatırsa varsayılana düşer (asla reddetmez)', async () => {
+    mockGetItem.mockImplementationOnce(async () => {
+      throw new Error('disk hatası');
+    });
+
+    const ayarlar = await LocalVakitBildirimServisi.getAyarlar();
+
+    expect(ayarlar).toEqual(VARSAYILAN);
+  });
+});
+
+describe('LocalVakitBildirimServisi.saveAyarlar', () => {
+  test('ayarları doğru anahtara JSON olarak yazar ve true döner', async () => {
+    const ayarlar: VakitBildirimAyarlari = {
+      imsak: true,
+      ogle: true,
+      ikindi: false,
+      aksam: true,
+      yatsi: false,
+    };
+
+    const sonuc = await LocalVakitBildirimServisi.saveAyarlar(ayarlar);
+
+    expect(sonuc).toBe(true);
+    expect(mockSetItem).toHaveBeenCalledWith(KEY, JSON.stringify(ayarlar));
+    // Disk içeriği geri okunabilir olmalı
+    expect(JSON.parse(mockStore.get(KEY)!)).toEqual(ayarlar);
+  });
+
+  test('yazılan değer getAyarlar ile aynen geri okunur (round-trip)', async () => {
+    const ayarlar: VakitBildirimAyarlari = {
+      imsak: false,
+      ogle: true,
+      ikindi: true,
+      aksam: false,
+      yatsi: true,
+    };
+
+    await LocalVakitBildirimServisi.saveAyarlar(ayarlar);
+    const okunan = await LocalVakitBildirimServisi.getAyarlar();
+
+    expect(okunan).toEqual(ayarlar);
+  });
+
+  test('setItem fırlatırsa false döner (fırlatmaz)', async () => {
+    mockSetItem.mockImplementationOnce(async () => {
+      throw new Error('disk dolu');
+    });
+
+    const sonuc = await LocalVakitBildirimServisi.saveAyarlar(VARSAYILAN);
+
+    expect(sonuc).toBe(false);
+  });
+});
+
+describe('LocalVakitBildirimServisi.updateVakitAyar', () => {
+  test('tek vakti açar, diğerlerini korur ve güncel nesneyi döner', async () => {
+    // Başlangıç: yatsi açık
+    mockStore.set(
+      KEY,
+      JSON.stringify({ ...VARSAYILAN, yatsi: true })
+    );
+
+    const sonuc = await LocalVakitBildirimServisi.updateVakitAyar('ogle', true);
+
+    expect(sonuc).toEqual({ ...VARSAYILAN, yatsi: true, ogle: true });
+  });
+
+  test('güncellemeyi diske kalıcı yazar', async () => {
+    await LocalVakitBildirimServisi.updateVakitAyar('ikindi', true);
+
+    const diskten = await LocalVakitBildirimServisi.getAyarlar();
+    expect(diskten.ikindi).toBe(true);
+    // Yazma doğru anahtara gitti
+    expect(mockSetItem).toHaveBeenCalledWith(
+      KEY,
+      JSON.stringify({ ...VARSAYILAN, ikindi: true })
+    );
+  });
+
+  test('mevcut açık bir vakti kapatabilir', async () => {
+    mockStore.set(KEY, JSON.stringify({ ...VARSAYILAN, imsak: true }));
+
+    const sonuc = await LocalVakitBildirimServisi.updateVakitAyar('imsak', false);
+
+    expect(sonuc).toEqual(VARSAYILAN);
+  });
+
+  test('saveAyarlar başarısız olsa bile güncel nesneyi döner (kayıt yutulmaz)', async () => {
+    // updateVakitAyar saveAyarlar dönüşünü beklemez; nesneyi yine de döner
+    mockSetItem.mockImplementationOnce(async () => {
+      throw new Error('disk hatası');
+    });
+
+    const sonuc = await LocalVakitBildirimServisi.updateVakitAyar('aksam', true);
+
+    expect(sonuc).toEqual({ ...VARSAYILAN, aksam: true });
+  });
+});

--- a/src/domain/services/__tests__/ArkaplanGorevServisi.test.ts
+++ b/src/domain/services/__tests__/ArkaplanGorevServisi.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Arka Plan Gorev Servisi - Sinif yonetimi + gorev govdesi testleri
+ *
+ * Bu dosya, ArkaplanGorevKonumCanlandirma.test.ts'nin KAPSAMADIGI yollari test eder:
+ *  - ArkaplanGorevServisi sinifi (singleton, kaydetVeBaslat, durdur, durumKontrol, durumAciklamasi)
+ *  - BILDIRIM_YENILEME_GOREVI gorev govdesi (TaskManager.defineTask'a verilen geri cagri):
+ *    muhafiz ayarlari yok/devre disi/aktif yollari, koordinat secimi, hata -> Failed.
+ *
+ * Konum-canlandirma davranisi (arkaplandanKonumTakibiniYenidenBaslat) zaten
+ * komsu dosyada kapsanmistir; burada gorev govdesi icin ADIM-1 mock'lanir.
+ */
+
+import * as TaskManager from 'expo-task-manager';
+import * as BackgroundFetch from 'expo-background-fetch';
+
+// ---- In-memory AsyncStorage mock (konvansiyon: mock-onekli kapanis disi degisken) ----
+const mockDepo = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    setItem: jest.fn((anahtar: string, deger: string) => {
+        mockDepo.set(anahtar, deger);
+        return Promise.resolve();
+    }),
+    getItem: jest.fn((anahtar: string) =>
+        Promise.resolve(mockDepo.has(anahtar) ? mockDepo.get(anahtar)! : null)
+    ),
+    removeItem: jest.fn((anahtar: string) => {
+        mockDepo.delete(anahtar);
+        return Promise.resolve();
+    }),
+}));
+
+// expo-location: gorev govdesinin ADIM-1'i (arkaplandanKonumTakibiniYenidenBaslat)
+// erken donsun diye takip ayarlari okunmadiginda hicbir sey yapmaz.
+jest.mock('expo-location', () => ({
+    getForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+    getBackgroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+    startLocationUpdatesAsync: jest.fn(() => Promise.resolve()),
+    stopLocationUpdatesAsync: jest.fn(() => Promise.resolve()),
+    Accuracy: { Lowest: 1, Low: 2, Balanced: 3, High: 4, Highest: 5 },
+    ActivityType: { Other: 1 },
+}));
+
+jest.mock('expo-task-manager', () => ({
+    defineTask: jest.fn(),
+    isTaskRegisteredAsync: jest.fn(() => Promise.resolve(false)),
+}));
+
+jest.mock('expo-background-fetch', () => ({
+    registerTaskAsync: jest.fn(() => Promise.resolve()),
+    unregisterTaskAsync: jest.fn(() => Promise.resolve()),
+    getStatusAsync: jest.fn(() => Promise.resolve(3)),
+    BackgroundFetchResult: {
+        NewData: 2,
+        NoData: 1,
+        Failed: 3,
+    },
+    BackgroundFetchStatus: {
+        Restricted: 1,
+        Denied: 2,
+        Available: 3,
+    },
+}));
+
+// Muhafiz servisi: yapilandirVePlanla'ya gecen ayarlari yakalayabilmek icin
+// sabit bir spy referansi tut.
+const mockYapilandirVePlanla = jest.fn<Promise<void>, [unknown]>(() =>
+    Promise.resolve()
+);
+jest.mock('../ArkaplanMuhafizServisi', () => ({
+    ArkaplanMuhafizServisi: {
+        getInstance: jest.fn(() => ({
+            yapilandirVePlanla: mockYapilandirVePlanla,
+        })),
+    },
+}));
+
+import {
+    ArkaplanGorevServisi,
+    BILDIRIM_YENILEME_GOREVI,
+} from '../ArkaplanGorevServisi';
+
+const MUHAFIZ_AYARLARI_ANAHTAR = 'muhafiz_ayarlari';
+const KONUM_DEPOLAMA_ANAHTARI = '@namaz_akisi/konum_ayarlari';
+
+/**
+ * TaskManager.defineTask import sirasinda (modul yuklenirken) BIR KEZ cagrilir.
+ * Gorev geri cagrisini import sonrasi HEMEN yakala; cunku beforeEach'teki
+ * jest.clearAllMocks() defineTask.mock.calls'u temizler (gorev tekrar kaydedilmez,
+ * modul yalnizca ilk import'ta calisir) -> sonradan okunursa kayit kaybolur.
+ */
+const gorevGeriCagrisi: () => Promise<number> = (() => {
+    const cagrilar = (TaskManager.defineTask as jest.Mock).mock.calls;
+    const kayit = cagrilar.find(([ad]) => ad === BILDIRIM_YENILEME_GOREVI);
+    if (!kayit) {
+        throw new Error('BILDIRIM_YENILEME_GOREVI gorevi defineTask ile kaydedilmemis');
+    }
+    return kayit[1] as () => Promise<number>;
+})();
+
+function gorevGeriCagrisiniAl(): () => Promise<number> {
+    return gorevGeriCagrisi;
+}
+
+beforeEach(() => {
+    mockDepo.clear();
+    jest.clearAllMocks();
+});
+
+// =====================================================================
+// BOLUM A: ArkaplanGorevServisi sinifi
+// =====================================================================
+describe('ArkaplanGorevServisi sinifi', () => {
+    describe('getInstance (singleton)', () => {
+        it('her cagrida ayni instance dondurmeli', () => {
+            const a = ArkaplanGorevServisi.getInstance();
+            const b = ArkaplanGorevServisi.getInstance();
+            expect(a).toBe(b);
+        });
+    });
+
+    describe('kaydetVeBaslat', () => {
+        it('gorev kayitli degilse background fetch kaydetmeli ve true donmeli', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+
+            const sonuc = await ArkaplanGorevServisi.getInstance().kaydetVeBaslat();
+
+            expect(sonuc).toBe(true);
+            // Davranis: dogru gorev adi + dogru zamanlama parametreleriyle kayit
+            expect(BackgroundFetch.registerTaskAsync).toHaveBeenCalledTimes(1);
+            expect(BackgroundFetch.registerTaskAsync).toHaveBeenCalledWith(
+                BILDIRIM_YENILEME_GOREVI,
+                expect.objectContaining({
+                    minimumInterval: 15 * 60, // 15 dk -> saniye
+                    stopOnTerminate: false,
+                    startOnBoot: true,
+                })
+            );
+        });
+
+        it('gorev zaten kayitliysa yeniden kaydetmemeli ama true donmeli', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+
+            const sonuc = await ArkaplanGorevServisi.getInstance().kaydetVeBaslat();
+
+            expect(sonuc).toBe(true);
+            expect(BackgroundFetch.registerTaskAsync).not.toHaveBeenCalled();
+        });
+
+        it('kayit sirasinda hata olursa false donmeli (firlatmamali)', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+            (BackgroundFetch.registerTaskAsync as jest.Mock).mockRejectedValue(
+                new Error('register failed')
+            );
+
+            const sonuc = await ArkaplanGorevServisi.getInstance().kaydetVeBaslat();
+
+            expect(sonuc).toBe(false);
+        });
+    });
+
+    describe('durdur', () => {
+        it('gorev kayitliysa unregister cagirmali', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+
+            await ArkaplanGorevServisi.getInstance().durdur();
+
+            expect(BackgroundFetch.unregisterTaskAsync).toHaveBeenCalledWith(
+                BILDIRIM_YENILEME_GOREVI
+            );
+        });
+
+        it('gorev kayitli degilse unregister cagrilmamali', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+
+            await ArkaplanGorevServisi.getInstance().durdur();
+
+            expect(BackgroundFetch.unregisterTaskAsync).not.toHaveBeenCalled();
+        });
+
+        it('durdurma hatasi olursa firlatmamali (sessiz yutmali)', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+            (BackgroundFetch.unregisterTaskAsync as jest.Mock).mockRejectedValue(
+                new Error('unregister failed')
+            );
+
+            await expect(
+                ArkaplanGorevServisi.getInstance().durdur()
+            ).resolves.toBeUndefined();
+        });
+    });
+
+    describe('durumKontrol', () => {
+        it('kayitli durumu ve background fetch status degerini dondurmeli', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+            (BackgroundFetch.getStatusAsync as jest.Mock).mockResolvedValue(
+                BackgroundFetch.BackgroundFetchStatus.Available
+            );
+
+            const durum = await ArkaplanGorevServisi.getInstance().durumKontrol();
+
+            expect(durum).toEqual({
+                kayitli: true,
+                status: BackgroundFetch.BackgroundFetchStatus.Available,
+            });
+        });
+
+        it('gorev kayitli degilken kayitli:false dondurmeli', async () => {
+            (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+            (BackgroundFetch.getStatusAsync as jest.Mock).mockResolvedValue(
+                BackgroundFetch.BackgroundFetchStatus.Denied
+            );
+
+            const durum = await ArkaplanGorevServisi.getInstance().durumKontrol();
+
+            expect(durum.kayitli).toBe(false);
+            expect(durum.status).toBe(BackgroundFetch.BackgroundFetchStatus.Denied);
+        });
+    });
+
+    describe('durumAciklamasi', () => {
+        it('Restricted icin kisitli aciklamasi vermeli', () => {
+            expect(
+                ArkaplanGorevServisi.durumAciklamasi(
+                    BackgroundFetch.BackgroundFetchStatus.Restricted
+                )
+            ).toBe('Kısıtlı - Sistem tarafından engelleniyor');
+        });
+
+        it('Denied icin reddedildi aciklamasi vermeli', () => {
+            expect(
+                ArkaplanGorevServisi.durumAciklamasi(
+                    BackgroundFetch.BackgroundFetchStatus.Denied
+                )
+            ).toBe('Reddedildi - Kullanıcı izin vermedi');
+        });
+
+        it('Available icin kullanilabilir aciklamasi vermeli', () => {
+            expect(
+                ArkaplanGorevServisi.durumAciklamasi(
+                    BackgroundFetch.BackgroundFetchStatus.Available
+                )
+            ).toBe('Kullanılabilir');
+        });
+
+        it('bilinmeyen/null status icin "Bilinmiyor" donmeli', () => {
+            expect(
+                ArkaplanGorevServisi.durumAciklamasi(
+                    null as unknown as BackgroundFetch.BackgroundFetchStatus
+                )
+            ).toBe('Bilinmiyor');
+        });
+    });
+});
+
+// =====================================================================
+// BOLUM B: BILDIRIM_YENILEME_GOREVI gorev govdesi (ADIM 2)
+// =====================================================================
+describe('BILDIRIM_YENILEME_GOREVI gorev govdesi', () => {
+    it('muhafiz ayarlari yoksa NoData donmeli ve planlama yapmamali', async () => {
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.NoData);
+        expect(mockYapilandirVePlanla).not.toHaveBeenCalled();
+    });
+
+    it('muhafiz devre disiysa (aktif:false) NoData donmeli ve planlama yapmamali', async () => {
+        mockDepo.set(MUHAFIZ_AYARLARI_ANAHTAR, JSON.stringify({ aktif: false }));
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.NoData);
+        expect(mockYapilandirVePlanla).not.toHaveBeenCalled();
+    });
+
+    it('muhafiz aktif + konum ayarlarinda koordinat varsa o koordinatla planlamali ve NewData donmeli', async () => {
+        mockDepo.set(
+            MUHAFIZ_AYARLARI_ANAHTAR,
+            JSON.stringify({
+                aktif: true,
+                esikler: { seviye1: 45, seviye2: 25, seviye3: 10, seviye4: 3 },
+                sikliklar: { seviye1: 15, seviye2: 10, seviye3: 5, seviye4: 1 },
+            })
+        );
+        mockDepo.set(
+            KONUM_DEPOLAMA_ANAHTARI,
+            JSON.stringify({ koordinatlar: { lat: 39.92, lng: 32.85 } }) // Ankara
+        );
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.NewData);
+        expect(mockYapilandirVePlanla).toHaveBeenCalledTimes(1);
+        const gecenAyar = mockYapilandirVePlanla.mock.calls[0][0] as unknown as {
+            aktif: boolean;
+            koordinatlar: { lat: number; lng: number };
+            esikler: Record<string, number>;
+        };
+        // Konum slice'indaki koordinat kullanilmali (muhafiz koordinati degil)
+        expect(gecenAyar.koordinatlar).toEqual({ lat: 39.92, lng: 32.85 });
+        expect(gecenAyar.aktif).toBe(true);
+        // Esik + siklik haritalama dogru tasinmali
+        expect(gecenAyar.esikler.seviye1).toBe(45);
+        expect(gecenAyar.esikler.seviye1Siklik).toBe(15);
+        expect(gecenAyar.esikler.seviye4).toBe(3);
+        expect(gecenAyar.esikler.seviye4Siklik).toBe(1);
+    });
+
+    it('konum ayarlari yoksa ama muhafiz ayarinda koordinat varsa (geriye uyumluluk) onu kullanmali', async () => {
+        mockDepo.set(
+            MUHAFIZ_AYARLARI_ANAHTAR,
+            JSON.stringify({
+                aktif: true,
+                koordinatlar: { lat: 38.42, lng: 27.14 }, // Izmir - eski format
+            })
+        );
+        // KONUM_DEPOLAMA_ANAHTARI bilerek yazilmadi
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.NewData);
+        const gecenAyar = mockYapilandirVePlanla.mock.calls[0][0] as unknown as {
+            koordinatlar: { lat: number; lng: number };
+        };
+        expect(gecenAyar.koordinatlar).toEqual({ lat: 38.42, lng: 27.14 });
+    });
+
+    it('hicbir yerde koordinat yoksa varsayilan Istanbul koordinatini kullanmali', async () => {
+        mockDepo.set(MUHAFIZ_AYARLARI_ANAHTAR, JSON.stringify({ aktif: true }));
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.NewData);
+        const gecenAyar = mockYapilandirVePlanla.mock.calls[0][0] as unknown as {
+            koordinatlar: { lat: number; lng: number };
+        };
+        expect(gecenAyar.koordinatlar).toEqual({ lat: 41.0082, lng: 28.9784 });
+    });
+
+    it('esikler/sikliklar eksikse varsayilan esik ve siklik degerlerine dusmeli', async () => {
+        // aktif:true ama esikler ve sikliklar HIC yok -> tum fallback dallari calisir
+        mockDepo.set(MUHAFIZ_AYARLARI_ANAHTAR, JSON.stringify({ aktif: true }));
+        const gorev = gorevGeriCagrisiniAl();
+
+        await gorev();
+
+        const gecenAyar = mockYapilandirVePlanla.mock.calls[0][0] as unknown as {
+            esikler: Record<string, number>;
+        };
+        // Uretim varsayilanlari (UygulamaSabitleri degil, gorev icindeki sabitler):
+        // esik fallback: 45/25/10/3 ; siklik fallback: 15/10/5/1
+        expect(gecenAyar.esikler).toEqual({
+            seviye1: 45,
+            seviye1Siklik: 15,
+            seviye2: 25,
+            seviye2Siklik: 10,
+            seviye3: 10,
+            seviye3Siklik: 5,
+            seviye4: 3,
+            seviye4Siklik: 1,
+        });
+    });
+
+    it('planlama sirasinda hata olursa Failed donmeli (firlatmamali)', async () => {
+        mockDepo.set(MUHAFIZ_AYARLARI_ANAHTAR, JSON.stringify({ aktif: true }));
+        mockYapilandirVePlanla.mockRejectedValueOnce(new Error('planlama patladi'));
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.Failed);
+    });
+
+    it('bozuk JSON (parse hatasi) durumunda Failed donmeli', async () => {
+        mockDepo.set(MUHAFIZ_AYARLARI_ANAHTAR, '{ bozuk json');
+        const gorev = gorevGeriCagrisiniAl();
+
+        const sonuc = await gorev();
+
+        expect(sonuc).toBe(BackgroundFetch.BackgroundFetchResult.Failed);
+        expect(mockYapilandirVePlanla).not.toHaveBeenCalled();
+    });
+});

--- a/src/domain/services/__tests__/KazaHesaplayiciServisi.test.ts
+++ b/src/domain/services/__tests__/KazaHesaplayiciServisi.test.ts
@@ -1,0 +1,394 @@
+/**
+ * KazaHesaplayiciServisi Testleri
+ * Saf hesap servisinin davranisi: sihirbaz borc tahmini, vakitlere paylastirma,
+ * motivasyon onerileri, tempo istatistik tahmini, tarih formatlama ve mekruh vakit kontrolu.
+ *
+ * adhan mock'lanir; mekruh kontrolu icin "su an" jest.useFakeTimers + setSystemTime ile
+ * sabit bir gune konumlandirilir, boylece sabit tarih sorunu yasanmaz.
+ */
+
+import {
+  hesaplaTahminiBorcMiktari,
+  borcuVakitlerePaylaştır,
+  motivasyonOnerileriHesapla,
+  kazaIstatistikHesapla,
+  tahminiTarihiFormatla,
+  mekruhVakitKontrolEt,
+} from '../KazaHesaplayiciServisi';
+import { KAZA_NAMAZ_LISTESI } from '../../../core/types/KazaTipleri';
+import { KAZA_SABITLERI } from '../../../core/constants/UygulamaSabitleri';
+import { tarihiISOFormatinaCevir } from '../../../core/utils/TarihYardimcisi';
+
+// ─── adhan mock'u ───────────────────────────────────────────────────────────────
+// Deterministik vakitler: sunrise 06:30, dhuhr 13:00, maghrib 19:00 (her gun icin).
+// Koordinat NaN ise (gecersiz) PrayerTimes firlatir -> catch dalini test edebiliriz.
+jest.mock('adhan', () => ({
+  Coordinates: jest.fn().mockImplementation((lat: number, lng: number) => {
+    if (Number.isNaN(lat) || Number.isNaN(lng)) {
+      throw new Error('Gecersiz koordinat');
+    }
+    return { lat, lng };
+  }),
+  CalculationMethod: { Turkey: jest.fn(() => ({})) },
+  PrayerTimes: jest.fn().mockImplementation((_coords: unknown, date: Date) => {
+    const g = (saat: number, dakika = 0) =>
+      new Date(date.getFullYear(), date.getMonth(), date.getDate(), saat, dakika);
+    return {
+      fajr: g(5, 0),
+      sunrise: g(6, 30),
+      dhuhr: g(13, 0),
+      asr: g(16, 0),
+      maghrib: g(19, 0),
+      isha: g(20, 30),
+    };
+  }),
+}));
+
+const ISTANBUL = { lat: 41.0, lng: 29.0 };
+
+// ════════════════════════════════════════════════════════════════════════════════
+// SIHIRBAZ HESABI — hesaplaTahminiBorcMiktari
+// ════════════════════════════════════════════════════════════════════════════════
+describe('hesaplaTahminiBorcMiktari', () => {
+  // "Su an"i sabitlemek davranisi deterministik yapar.
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // 2030-06-15: testin yazildigi gunden bagimsiz, deterministik referans an.
+    jest.setSystemTime(new Date(2030, 5, 15, 12, 0, 0));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('ergenlik tarihi henuz gelmediyse 0 borc dondurur', () => {
+    // 2025 dogumlu + 14 yas ergenlik = 2039 -> 2030'da henuz gelmedi
+    const borc = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2025-01-01',
+      ergenlikYasi: 14,
+      kildigiTahminiYuzdesi: 0,
+    });
+    expect(borc).toBe(0);
+  });
+
+  it('ergenlikten bugune gecen gun x 6 vakit toplam borcu verir (hic kilinmamis)', () => {
+    // Ergenlik = 2010-06-15 (2000 dogum + 10 yas), bugun 2030-06-15 -> tam 20 yil.
+    const borc = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: 0,
+    });
+    // 20 yilda artik yillar (2012,2016,2020,2024,2028) = 5 -> 20*365 + 5 = 7305 gun
+    const beklenenGun = 7305;
+    expect(borc).toBe(beklenenGun * KAZA_NAMAZ_LISTESI.length);
+  });
+
+  it('kildigi yuzdesini borctan duser (yari kilinmis ~yari borc)', () => {
+    const tam = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: 0,
+    });
+    const yari = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: 50,
+    });
+    expect(yari).toBe(Math.round(tam * 0.5));
+  });
+
+  it('%100 kilindiysa borc 0 olur', () => {
+    const borc = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: 100,
+    });
+    expect(borc).toBe(0);
+  });
+
+  it('yuzde 100 ustu degerler 100 ile sinirlanir (negatif borc uretmez)', () => {
+    const borc = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: 250,
+    });
+    expect(borc).toBe(0);
+  });
+
+  it('negatif yuzde 0 ile sinirlanir (tam borca esit)', () => {
+    const tam = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: 0,
+    });
+    const negatif = hesaplaTahminiBorcMiktari({
+      dogumTarihi: '2000-06-15',
+      ergenlikYasi: 10,
+      kildigiTahminiYuzdesi: -40,
+    });
+    expect(negatif).toBe(tam);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════
+// borcuVakitlerePaylaştır
+// ════════════════════════════════════════════════════════════════════════════════
+describe('borcuVakitlerePaylaştır', () => {
+  it('tam bolunen borcu 6 vakite esit dagitir', () => {
+    const dagilim = borcuVakitlerePaylaştır(60);
+    KAZA_NAMAZ_LISTESI.forEach((ad) => {
+      expect(dagilim[ad]).toBe(10);
+    });
+    const toplam = Object.values(dagilim).reduce((a, b) => a + b, 0);
+    expect(toplam).toBe(60);
+  });
+
+  it('kalanli borcu ilk vakitlere +1 ekleyerek dagitir (toplam korunur)', () => {
+    // 64 / 6 = 10 kalan 4 -> ilk 4 vakit 11, son 2 vakit 10
+    const dagilim = borcuVakitlerePaylaştır(64);
+    const degerler = KAZA_NAMAZ_LISTESI.map((ad) => dagilim[ad]);
+    expect(degerler).toEqual([11, 11, 11, 11, 10, 10]);
+    const toplam = degerler.reduce((a, b) => a + b, 0);
+    expect(toplam).toBe(64);
+  });
+
+  it('sifir borcta tum vakitler 0 olur', () => {
+    const dagilim = borcuVakitlerePaylaştır(0);
+    KAZA_NAMAZ_LISTESI.forEach((ad) => {
+      expect(dagilim[ad]).toBe(0);
+    });
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════
+// motivasyonOnerileriHesapla
+// ════════════════════════════════════════════════════════════════════════════════
+describe('motivasyonOnerileriHesapla', () => {
+  it('toplam kalan <= 0 ise bos dizi dondurur', () => {
+    expect(motivasyonOnerileriHesapla(0)).toEqual([]);
+    expect(motivasyonOnerileriHesapla(-5)).toEqual([]);
+  });
+
+  it('her senaryo icin bir oneri uretir', () => {
+    const oneriler = motivasyonOnerileriHesapla(1000);
+    expect(oneriler).toHaveLength(KAZA_SABITLERI.MOTIVASYON_SENARYOLARI.length);
+    expect(oneriler.map((o) => o.kazaAdediPerVakit)).toEqual([
+      ...KAZA_SABITLERI.MOTIVASYON_SENARYOLARI,
+    ]);
+  });
+
+  it('gunluk kaza = vakit basina x 6 ve gun sayisi yukari yuvarlanir', () => {
+    // toplamKalan 100, senaryo 1/vakit -> gunluk 6 -> ceil(100/6) = 17 gun
+    const oneri = motivasyonOnerileriHesapla(100).find((o) => o.kazaAdediPerVakit === 1)!;
+    expect(oneri.toplamGunlukKaza).toBe(6);
+    expect(oneri.tamamlanmaGunSayisi).toBe(17);
+  });
+
+  it('gun bicimi (<=30 gun): "X gunde biter" der', () => {
+    // senaryo 10/vakit, kalan 600 -> gunluk 60 -> 10 gun -> gun ifadesi
+    const oneri = motivasyonOnerileriHesapla(600).find((o) => o.kazaAdediPerVakit === 10)!;
+    expect(oneri.tamamlanmaGunSayisi).toBe(10);
+    expect(oneri.aciklama).toContain('10 günde biter');
+  });
+
+  it('ay bicimi (>30 gun, <=12 ay): "~N ayda biter" der', () => {
+    // senaryo 1/vakit, kalan 600 -> gunluk 6 -> 100 gun -> ~3.3 ay -> ay ifadesi
+    const oneri = motivasyonOnerileriHesapla(600).find((o) => o.kazaAdediPerVakit === 1)!;
+    expect(oneri.tamamlanmaGunSayisi).toBe(100);
+    expect(oneri.aciklama).toContain('ayda biter');
+    expect(oneri.aciklama).not.toContain('günde biter');
+    expect(oneri.aciklama).not.toContain('yılda biter');
+  });
+
+  it('yil bicimi (>12 ay): "~N yilda biter" der', () => {
+    // senaryo 1/vakit, kalan 100000 -> gunluk 6 -> 16667 gun -> ~555 ay -> yil ifadesi
+    const oneri = motivasyonOnerileriHesapla(100000).find((o) => o.kazaAdediPerVakit === 1)!;
+    expect(oneri.aciklama).toContain('yılda biter');
+    expect(oneri.aciklama).not.toContain('ayda biter');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════
+// kazaIstatistikHesapla
+// ════════════════════════════════════════════════════════════════════════════════
+describe('kazaIstatistikHesapla', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2030, 5, 15, 12, 0, 0));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Son N gunun ISO tarih anahtarlarini bugune gore uretir (sabit tarih yazmadan).
+  const sonGunler = (gunSayisi: number): string[] => {
+    const bugun = new Date();
+    const liste: string[] = [];
+    for (let i = 0; i < gunSayisi; i++) {
+      const t = new Date(bugun);
+      t.setDate(bugun.getDate() - i);
+      liste.push(tarihiISOFormatinaCevir(t));
+    }
+    return liste;
+  };
+
+  it('toplam kalan <= 0 ise sifir ortalama ve null tahmin dondurur', () => {
+    const sonuc = kazaIstatistikHesapla(0, { [sonGunler(1)[0]]: 5 });
+    expect(sonuc.haftaOrtalamasi).toBe(0);
+    expect(sonuc.tahminiTamamlanmaTarihi).toBeNull();
+    expect(sonuc.tahminiTamamlanmaGunSayisi).toBeNull();
+    // toplamKalan 0 olsa bile motivasyon onerileri (bos) dahil edilir
+    expect(sonuc.motivasyonOnerileri).toEqual([]);
+  });
+
+  it('tempo gecmisi bos ise (son 7 gunde kayit yok) tahmin null doner', () => {
+    // Anahtarlar var ama 7 gun penceresi disinda -> gunSayisi 0
+    const eskiTarih = '2000-01-01';
+    const sonuc = kazaIstatistikHesapla(100, { [eskiTarih]: 10 });
+    expect(sonuc.haftaOrtalamasi).toBe(0);
+    expect(sonuc.tahminiTamamlanmaTarihi).toBeNull();
+    expect(sonuc.tahminiTamamlanmaGunSayisi).toBeNull();
+    // toplamKalan > 0 oldugu icin motivasyon onerileri dolu gelir
+    expect(sonuc.motivasyonOnerileri.length).toBeGreaterThan(0);
+  });
+
+  it('son 7 gun ortalamasi 0 ise (hep 0 kaza) tahmin null doner', () => {
+    const gecmis: Record<string, number> = {};
+    sonGunler(KAZA_SABITLERI.TEMPO_HESAP_GUNLERI).forEach((t) => {
+      gecmis[t] = 0;
+    });
+    const sonuc = kazaIstatistikHesapla(100, gecmis);
+    expect(sonuc.haftaOrtalamasi).toBe(0);
+    expect(sonuc.tahminiTamamlanmaTarihi).toBeNull();
+    expect(sonuc.tahminiTamamlanmaGunSayisi).toBeNull();
+  });
+
+  it('pozitif tempo ile haftalik ortalama ve tahmini tarih hesaplar', () => {
+    // Son 7 gunun hepsinde 10 kaza -> ortalama 10. Kalan 100 -> ceil(100/10)=10 gun.
+    const gecmis: Record<string, number> = {};
+    sonGunler(KAZA_SABITLERI.TEMPO_HESAP_GUNLERI).forEach((t) => {
+      gecmis[t] = 10;
+    });
+    const sonuc = kazaIstatistikHesapla(100, gecmis);
+    expect(sonuc.haftaOrtalamasi).toBe(10);
+    expect(sonuc.tahminiTamamlanmaGunSayisi).toBe(10);
+
+    // Tahmini tarih = bugun + 10 gun
+    const beklenen = new Date(2030, 5, 15);
+    beklenen.setDate(beklenen.getDate() + 10);
+    expect(sonuc.tahminiTamamlanmaTarihi).toBe(tarihiISOFormatinaCevir(beklenen));
+  });
+
+  it('kismi gunlu tempoda yalniz mevcut gunlerin ortalamasini alir', () => {
+    // Sadece 2 gunde kayit (bugun 6, dun 4) -> ortalama 5. Kalan 50 -> ceil(50/5)=10 gun.
+    const gunler = sonGunler(KAZA_SABITLERI.TEMPO_HESAP_GUNLERI);
+    const gecmis: Record<string, number> = {
+      [gunler[0]]: 6,
+      [gunler[1]]: 4,
+    };
+    const sonuc = kazaIstatistikHesapla(50, gecmis);
+    expect(sonuc.haftaOrtalamasi).toBe(5);
+    expect(sonuc.tahminiTamamlanmaGunSayisi).toBe(10);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════
+// tahminiTarihiFormatla
+// ════════════════════════════════════════════════════════════════════════════════
+describe('tahminiTarihiFormatla', () => {
+  it('ISO tarihi "gun Ay yil" formatinda dondurur', () => {
+    expect(tahminiTarihiFormatla('2026-07-14')).toBe('14 Temmuz 2026');
+  });
+
+  it('yilin ilk gununu dogru formatlar (Ocak)', () => {
+    expect(tahminiTarihiFormatla('2026-01-01')).toBe('1 Ocak 2026');
+  });
+
+  it('yilin son gununu dogru formatlar (Aralik)', () => {
+    expect(tahminiTarihiFormatla('2026-12-31')).toBe('31 Aralık 2026');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════════
+// mekruhVakitKontrolEt
+// ════════════════════════════════════════════════════════════════════════════════
+describe('mekruhVakitKontrolEt', () => {
+  // Mock vakitler: sunrise 06:30, dhuhr 13:00, maghrib 19:00; tolerans 20 dk, istiwa 5 dk.
+  const gun = new Date(2030, 5, 15);
+  const anaAyarla = (saat: number, dakika: number) => {
+    jest.setSystemTime(new Date(2030, 5, 15, saat, dakika, 0));
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('suruk (gunes dogus) penceresinde mekruh dondurur', () => {
+    // sunrise 06:30 .. +20dk -> 06:50 arasi mekruh. 06:40 sec.
+    anaAyarla(6, 40);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng);
+    expect(sonuc.mekruhMu).toBe(true);
+    expect(sonuc.aciklama).toContain('şuruk');
+    // bitis = sunrise + 20dk
+    expect(sonuc.bitis).toEqual(new Date(gun.getFullYear(), gun.getMonth(), gun.getDate(), 6, 50));
+  });
+
+  it('suruk penceresinin tam sinirinda (sunrise ani) mekruh sayilir', () => {
+    anaAyarla(6, 30);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng);
+    expect(sonuc.mekruhMu).toBe(true);
+    expect(sonuc.aciklama).toContain('şuruk');
+  });
+
+  it('istiwa (ogle oncesi 5dk) penceresinde mekruh dondurur', () => {
+    // dhuhr 13:00, istiwa 12:55..13:00. 12:57 sec.
+    anaAyarla(12, 57);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng);
+    expect(sonuc.mekruhMu).toBe(true);
+    expect(sonuc.aciklama).toContain('istiwa');
+    expect(sonuc.bitis).toEqual(new Date(gun.getFullYear(), gun.getMonth(), gun.getDate(), 13, 0));
+  });
+
+  it('gurub (gunes batis oncesi 20dk) penceresinde mekruh dondurur', () => {
+    // maghrib 19:00, gurub 18:40..19:00. 18:50 sec.
+    anaAyarla(18, 50);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng);
+    expect(sonuc.mekruhMu).toBe(true);
+    expect(sonuc.aciklama).toContain('gurub');
+    expect(sonuc.bitis).toEqual(new Date(gun.getFullYear(), gun.getMonth(), gun.getDate(), 19, 0));
+  });
+
+  it('mekruh disi normal vakitte (ogleden sonra) mekruh degil dondurur', () => {
+    anaAyarla(15, 0);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng);
+    expect(sonuc).toEqual({ mekruhMu: false, aciklama: null, bitis: null });
+  });
+
+  it('suruk penceresi bittikten 1dk sonra (06:51) mekruh degil', () => {
+    anaAyarla(6, 51);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng);
+    expect(sonuc.mekruhMu).toBe(false);
+  });
+
+  it('farz namaz tipinde aciklama "namaz" ifadesini kullanir (kaza namazi degil)', () => {
+    anaAyarla(6, 40);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng, 'farz');
+    expect(sonuc.mekruhMu).toBe(true);
+    expect(sonuc.aciklama).toContain('namaz kılınması');
+    expect(sonuc.aciklama).not.toContain('kaza namazı');
+  });
+
+  it('kaza namaz tipinde (varsayilan) aciklama "kaza namazi" ifadesini kullanir', () => {
+    anaAyarla(6, 40);
+    const sonuc = mekruhVakitKontrolEt(ISTANBUL.lat, ISTANBUL.lng, 'kaza');
+    expect(sonuc.aciklama).toContain('kaza namazı kılınması');
+  });
+
+  it('gecersiz koordinatta (NaN) hata yutulur, mekruh degil dondurur (catch dali)', () => {
+    anaAyarla(6, 40); // mekruh penceresinde bile olsa, koordinat hatasi guvenli sonuc verir
+    const sonuc = mekruhVakitKontrolEt(NaN, NaN);
+    expect(sonuc).toEqual({ mekruhMu: false, aciklama: null, bitis: null });
+  });
+});

--- a/src/domain/services/__tests__/KonumTakipServisiAndroid.test.ts
+++ b/src/domain/services/__tests__/KonumTakipServisiAndroid.test.ts
@@ -1,0 +1,479 @@
+/**
+ * KonumTakipServisi — Android / hata-yolu / bozuk-veri davranis testleri
+ *
+ * Ana test dosyasi (KonumTakipServisi.test.ts) react-native'i MOCKLAMAZ; preset
+ * altinda Platform.OS = 'ios' oldugu icin Android-ozgu dallar (arka plan foreground
+ * service kisitlamasi, onPlanaGelinceDene retry mantigi, yenidenBaslat'in erken
+ * cikisi) ORADA hic calismaz. Bu dosya Platform.OS='android' ve KONTROL EDILEBILIR
+ * bir AppState ile o dallari + sessiz hata yakalama (catch) ve bozuk-JSON kurtarma
+ * yollarini DAVRANISSAL olarak dogrular.
+ *
+ * Izolasyon: react-native mock'u modul-yuklenisinde okundugu icin bu senaryolar
+ * AYRI bir test dosyasinda olmali (ana dosya 'ios' varsayar; ikisi ayni modulu
+ * farkli Platform ile paylasamaz).
+ */
+
+// ---- Kontrol edilebilir AppState ----
+// currentState bir GETTER ile okunur: namespace import altinda duz property kaybolur,
+// getter ise mock* tutucudan canli okur (kanitlandi). Dinleyiciler mock* dizide tutulur
+// ki testler "on plana gelis"i elle tetikleyebilsin.
+const mockAppStateDurum = { deger: 'active' as string };
+const mockAppStateDinleyiciler: Array<(s: string) => void> = [];
+
+jest.mock('react-native', () => ({
+    Platform: { OS: 'android' },
+    AppState: {
+        get currentState() { return mockAppStateDurum.deger; },
+        addEventListener: jest.fn((_olay: string, cb: (s: string) => void) => {
+            mockAppStateDinleyiciler.push(cb);
+            return {
+                remove: jest.fn(() => {
+                    const i = mockAppStateDinleyiciler.indexOf(cb);
+                    if (i >= 0) mockAppStateDinleyiciler.splice(i, 1);
+                }),
+            };
+        }),
+    },
+}));
+
+// In-memory AsyncStorage (mock* oneki: jest.mock fabrikasi erisebilsin)
+const mockStore = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(async (k: string) => (mockStore.has(k) ? mockStore.get(k)! : null)),
+        setItem: jest.fn(async (k: string, v: string) => { mockStore.set(k, v); }),
+        removeItem: jest.fn(async (k: string) => { mockStore.delete(k); }),
+    },
+}));
+
+jest.mock('expo-task-manager', () => ({
+    defineTask: jest.fn(),
+    isTaskRegisteredAsync: jest.fn(),
+}));
+
+jest.mock('../ArkaplanMuhafizServisi', () => ({
+    ArkaplanMuhafizServisi: {
+        getInstance: jest.fn(() => ({ yapilandirVePlanla: jest.fn() })),
+    },
+}));
+
+// Logger'i sustur (yan etki testi kirletmesin)
+jest.mock('../../../core/utils/Logger', () => ({
+    Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { KonumTakipServisi, KONUM_TAKIP_GOREVI } from '../KonumTakipServisi';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Location from 'expo-location';
+import * as TaskManager from 'expo-task-manager';
+
+const TAKIP_AYAR_ANAHTARI = '@namaz_akisi/konum_takip_ayarlari';
+const KONUM_ANAHTARI = '@namaz_akisi/konum_ayarlari';
+
+// Arka plan gorevi modul yuklenirken defineTask(...) ile kaydedilir. beforeEach'teki
+// jest.clearAllMocks() mock.calls'u siler, bu yuzden geri-cagirimi MODUL KAPSAMINDA,
+// herhangi bir beforeEach'ten ONCE yakaliyoruz.
+const ilkDefineTaskCagrisi = (TaskManager.defineTask as jest.Mock).mock.calls[0];
+const arkaPlanGorevi: (b: { data?: { locations?: Location.LocationObject[] }; error?: unknown }) => Promise<void> =
+    ilkDefineTaskCagrisi[1];
+
+/** Yeni izole singleton al (statik 'instance' alanini test icin sifirla) */
+function yeniServis(): KonumTakipServisi {
+    (KonumTakipServisi as unknown as { instance?: KonumTakipServisi }).instance = undefined;
+    return KonumTakipServisi.getInstance();
+}
+
+/** Tum izinleri ver + gorev kayitli degil + start basarili: "mutlu yol" mock'lari */
+function mutluYolKur(): void {
+    (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted', canAskAgain: true });
+    (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+    (Location.startLocationUpdatesAsync as jest.Mock).mockResolvedValue(undefined);
+    (Location.stopLocationUpdatesAsync as jest.Mock).mockResolvedValue(undefined);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockStore.clear();
+    mockAppStateDurum.deger = 'active';
+    mockAppStateDinleyiciler.length = 0;
+});
+
+describe('baslat — Android arka plan erteleme (Platform.OS=android)', () => {
+    it('uygulama arka plandayken baslatmamali, false donmeli ve izin SORMAMALI', async () => {
+        mockAppStateDurum.deger = 'background';
+        const servis = yeniServis();
+
+        const sonuc = await servis.baslat();
+
+        expect(sonuc).toBe(false);
+        // Erken cikis: izin akisi hic baslamamali, konum guncellemesi planlanmamali
+        expect(Location.getForegroundPermissionsAsync).not.toHaveBeenCalled();
+        expect(Location.startLocationUpdatesAsync).not.toHaveBeenCalled();
+        // On plana gelince tekrar denemek icin bir AppState dinleyicisi kaydedilmeli
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+    });
+
+    it('arka planda kayitli dinleyici ON PLANA gelince baslat-i tetikleyip basariyla baslatmali', async () => {
+        mockAppStateDurum.deger = 'background';
+        mutluYolKur();
+        const servis = yeniServis();
+
+        // 1) Arka planda: ertelendi, dinleyici kuruldu
+        expect(await servis.baslat()).toBe(false);
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+
+        // 2) Uygulama on plana geldi: dinleyici baslat'i yeniden cagirmali
+        mockAppStateDurum.deger = 'active';
+        await mockAppStateDinleyiciler[0]('active');
+        // mikro-gorev kuyrugunu bosalt (listener icindeki await baslat)
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Bu sefer on planda -> gercekten baslatilmali
+        expect(Location.startLocationUpdatesAsync).toHaveBeenCalledTimes(1);
+        // Basarili baslatma ayarlari yazmali
+        expect(JSON.parse(mockStore.get(TAKIP_AYAR_ANAHTARI)!).aktif).toBe(true);
+    });
+
+    it('arka planda ust uste cagri TEK dinleyici kaydetmeli (memory leak korumasi)', async () => {
+        mockAppStateDurum.deger = 'background';
+        const servis = yeniServis();
+
+        await servis.baslat();
+        await servis.baslat();
+        await servis.baslat();
+
+        // Birden cok erteleme isteginde yalnizca tek subscription tutulmali
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+    });
+
+    it('dinleyici "active" DISI bir durumla tetiklenirse hicbir sey yapmamali (no-op)', async () => {
+        mockAppStateDurum.deger = 'background';
+        const servis = yeniServis();
+        await servis.baslat();
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+
+        // Uygulama 'inactive'e gecti (active DEGIL) -> baslatma denenmemeli, dinleyici kalmali
+        await mockAppStateDinleyiciler[0]('inactive');
+        await Promise.resolve();
+
+        expect(Location.startLocationUpdatesAsync).not.toHaveBeenCalled();
+        expect(mockAppStateDinleyiciler.length).toBe(1); // hala bekliyor (remove edilmedi)
+    });
+});
+
+describe('baslat — foreground service hatasi (Android catch dali)', () => {
+    it('start "foreground service" hatasi atarsa false donmeli ve on plana gelince yeniden denemeli', async () => {
+        mutluYolKur();
+        (Location.startLocationUpdatesAsync as jest.Mock).mockRejectedValue(
+            new Error('Not allowed to start foreground service'),
+        );
+        const servis = yeniServis();
+
+        const sonuc = await servis.baslat();
+
+        expect(sonuc).toBe(false);
+        // Catch dali on-plana-gelince retry icin dinleyici kurmali
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+    });
+
+    it('genel (foreground-disi) hata atarsa false donmeli ve retry dinleyicisi KURMAMALI', async () => {
+        mutluYolKur();
+        (Location.startLocationUpdatesAsync as jest.Mock).mockRejectedValue(new Error('beklenmeyen hata'));
+        const servis = yeniServis();
+
+        const sonuc = await servis.baslat();
+
+        expect(sonuc).toBe(false);
+        // foreground service'e ozgu olmayan hata -> retry dinleyicisi kurulmamali
+        expect(mockAppStateDinleyiciler.length).toBe(0);
+    });
+});
+
+describe('onPlanaGelinceDene — maksimum deneme siniri (3)', () => {
+    it('foreground service hatasi 3 kez tekrarlasa da en fazla 3 kez yeniden denemeli', async () => {
+        mutluYolKur();
+        (Location.startLocationUpdatesAsync as jest.Mock).mockRejectedValue(
+            new Error('Unable to start foreground service'),
+        );
+        const servis = yeniServis();
+
+        // Ilk start: hata -> 1. deneme dinleyicisi kuruldu
+        await servis.baslat();
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+
+        // 3 tur: her on-plana-gelis yeni bir baslat -> yine hata -> yeni dinleyici (sayac artar)
+        for (let tur = 0; tur < 3; tur++) {
+            const dinleyici = mockAppStateDinleyiciler[0];
+            mockAppStateDurum.deger = 'active';
+            await dinleyici('active');
+            await Promise.resolve();
+            await Promise.resolve();
+        }
+
+        // baslatmaDenemeSayisi MAX_BASLATMA_DENEME(3)'e ulasinca yeni dinleyici KURULMAMALI
+        // -> sonunda bekleyen dinleyici kalmaz (hepsi tuketildi, yenisi eklenmedi)
+        expect(mockAppStateDinleyiciler.length).toBe(0);
+        // start her turda denendi ama hep patladi (sonsuz dongu YOK: sinir devrede)
+        expect((Location.startLocationUpdatesAsync as jest.Mock).mock.calls.length).toBeLessThanOrEqual(4);
+    });
+});
+
+describe('baslat — kayitli gorevi durdururken hata (stopError catch)', () => {
+    it('mevcut gorev durdurulamasa bile cokmeden yeniden baslatmali', async () => {
+        mutluYolKur();
+        (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true); // zaten kayitli
+        (Location.stopLocationUpdatesAsync as jest.Mock).mockRejectedValue(new Error('durdurulamadi'));
+        const servis = yeniServis();
+
+        const sonuc = await servis.baslat();
+
+        // stopError yutulmali -> akis devam edip yeni takip baslatilmali
+        expect(sonuc).toBe(true);
+        expect(Location.startLocationUpdatesAsync).toHaveBeenCalledWith(
+            KONUM_TAKIP_GOREVI,
+            expect.objectContaining({ distanceInterval: 5000 }),
+        );
+    });
+});
+
+describe('durdur — hata yutma (catch dali)', () => {
+    it('isTaskRegisteredAsync hata atarsa firlatmamali (sessizce yutmali)', async () => {
+        (TaskManager.isTaskRegisteredAsync as jest.Mock).mockRejectedValue(new Error('TM hatasi'));
+        const servis = yeniServis();
+
+        await expect(servis.durdur()).resolves.toBeUndefined();
+    });
+});
+
+describe('yenidenBaslat — Android arka plan erken cikis', () => {
+    it('uygulama arka plandayken yeniden baslatmamali, false donmeli ve ayarlari OKUMAMALI', async () => {
+        mockAppStateDurum.deger = 'background';
+        const servis = yeniServis();
+
+        const sonuc = await servis.yenidenBaslat();
+
+        expect(sonuc).toBe(false);
+        // Erken cikis: ayarlar bile okunmamali (arka plan kontrolu en basta)
+        expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+        // On plana gelince denemek icin dinleyici kurulmali
+        expect(mockAppStateDinleyiciler.length).toBe(1);
+    });
+
+    it('on plan izin kontrolu HATA atarsa cokmemeli, baslat yoluna devam etmeli', async () => {
+        // aktif=true, arka plan izni var. yenidenBaslat icindeki on-plan izin kontrolu
+        // ILK cagride patlar (try/catch yutar), sonra baslat'in KENDI kontrolunde granted
+        // doner -> akis cokmeden basariyla baslamali.
+        mockStore.set(TAKIP_AYAR_ANAHTARI, JSON.stringify({
+            aktif: true, sonKoordinatlar: null, sonGuncellemeTarihi: null,
+        }));
+        (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+        (Location.getForegroundPermissionsAsync as jest.Mock)
+            .mockRejectedValueOnce(new Error('izin kontrol hatasi')) // yenidenBaslat'in kontrolu
+            .mockResolvedValue({ status: 'granted' });                // baslat'in kontrolu
+        (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+        (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+        (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+        (Location.startLocationUpdatesAsync as jest.Mock).mockResolvedValue(undefined);
+        const servis = yeniServis();
+
+        const sonuc = await servis.yenidenBaslat();
+
+        // On plan izin kontrolu try/catch ile yutuldu; baslat'a dusup basariyla baslatti
+        expect(sonuc).toBe(true);
+        expect(Location.startLocationUpdatesAsync).toHaveBeenCalled();
+    });
+
+    it('ayarlar okunurken beklenmedik hata olusursa false donmeli (dis catch)', async () => {
+        // ayarlariGetir bozuk JSON'da CATCH'e dusup varsayilan {aktif:false} doner ->
+        // yenidenBaslat "aktif degil" yoluyla guvenli false doner (cokme yok).
+        mockStore.set(TAKIP_AYAR_ANAHTARI, '{bozuk json');
+        const servis = yeniServis();
+
+        const sonuc = await servis.yenidenBaslat();
+
+        expect(sonuc).toBe(false);
+        expect(Location.startLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+
+    it('izin iptal yolunda disk yazma patlarsa cokmeden false donmeli (dis catch)', async () => {
+        // aktif=true ama arka plan izni iptal -> "devre disi birak" disk yazmasi reject ediyor.
+        // Outer try/catch hatayi yutmali; servis cokmeden false donmeli.
+        mockStore.set(TAKIP_AYAR_ANAHTARI, JSON.stringify({
+            aktif: true, sonKoordinatlar: null, sonGuncellemeTarihi: null,
+        }));
+        (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+        (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk dolu'));
+        const servis = yeniServis();
+
+        const sonuc = await servis.yenidenBaslat();
+
+        expect(sonuc).toBe(false);
+        expect(Location.startLocationUpdatesAsync).not.toHaveBeenCalled();
+    });
+});
+
+describe('ayarlariGetir — bozuk JSON dayanikliligi', () => {
+    it('kayitli ayar bozuk JSON ise varsayilan (pasif) donmeli, FIRLATMAMALI', async () => {
+        mockStore.set(TAKIP_AYAR_ANAHTARI, '{"aktif":tr');
+        const servis = yeniServis();
+
+        const sonuc = await servis.ayarlariGetir();
+
+        expect(sonuc).toEqual({ aktif: false, sonKoordinatlar: null, sonGuncellemeTarihi: null });
+    });
+});
+
+describe('sonKonumBilgisiniGetir — bozuk JSON dayanikliligi', () => {
+    it('konum ayarlari bozuk JSON ise null donmeli, FIRLATMAMALI', async () => {
+        mockStore.set(KONUM_ANAHTARI, 'not-json-{');
+        const servis = yeniServis();
+
+        const sonuc = await servis.sonKonumBilgisiniGetir();
+
+        expect(sonuc).toBeNull();
+    });
+});
+
+describe('aktifProfilGetir (durumBilgisiGetir uzerinden) — bozuk JSON varsayilan profile duser', () => {
+    it('konum_ayarlari JSON bozuksa varsayilan dengeli profil mesafesi (5km) donmeli', async () => {
+        mockStore.set(KONUM_ANAHTARI, '{"takipHassasiyeti":');
+        (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+        (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+        const servis = yeniServis();
+
+        const durum = await servis.durumBilgisiGetir();
+
+        // Profil okuma catch'e dustu -> VARSAYILAN_TAKIP_HASSASIYETI ('dengeli') -> 5000m
+        expect(durum.minimumMesafe).toBe(5000);
+        expect(durum.takipAktif).toBe(false);
+        expect(durum.arkaPlanIzniVar).toBe(false);
+    });
+
+    it('TANINMAYAN hassasiyet degeri varsayilan dengeli profile (5km) DUSMELI', async () => {
+        // Gecerli JSON ama bilinmeyen hassasiyet anahtari -> TAKIP_PROFILLERI[x] undefined
+        // -> uretim VARSAYILAN profile dusmeli (5000m), patlamamali.
+        mockStore.set(KONUM_ANAHTARI, JSON.stringify({ takipHassasiyeti: 'bilinmeyen_mod' }));
+        (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+        (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+        const servis = yeniServis();
+
+        const durum = await servis.durumBilgisiGetir();
+
+        expect(durum.minimumMesafe).toBe(5000);
+    });
+});
+
+describe('arka plan gorevi — bildirim yeniden planlama hatasi yutulmali', () => {
+    it('muhafiz yapilandirVePlanla HATA atsa bile koordinat guncellemesi kalici olmali', async () => {
+        // Muhafiz aktif ama yapilandirVePlanla reject ediyor -> ic try/catch yutmali,
+        // ana islem (koordinat yazma) zaten ONCEDEN diske yazildigi icin korunmali.
+        const { ArkaplanMuhafizServisi } = require('../ArkaplanMuhafizServisi');
+        (ArkaplanMuhafizServisi.getInstance as jest.Mock).mockReturnValue({
+            yapilandirVePlanla: jest.fn().mockRejectedValue(new Error('planlama coktu')),
+        });
+
+        mockStore.set(KONUM_ANAHTARI, JSON.stringify({
+            konumModu: 'oto',
+            takipHassasiyeti: 'dengeli',
+            koordinatlar: { lat: 41.0369, lng: 28.9850 }, // Istanbul
+        }));
+        mockStore.set('muhafiz_ayarlari', JSON.stringify({
+            aktif: true,
+            esikler: { seviye1: 45, seviye2: 25, seviye3: 10, seviye4: 3 },
+        }));
+        (Location.reverseGeocodeAsync as jest.Mock).mockResolvedValue([{ district: 'Cankaya', city: 'Ankara' }]);
+
+        const ankara = {
+            coords: { latitude: 39.9208, longitude: 32.8541, altitude: null, accuracy: null, altitudeAccuracy: null, heading: null, speed: null },
+            timestamp: 0,
+        } as Location.LocationObject;
+
+        // Planlama hatasina ragmen gorev REJECT etmemeli (modul-kapsaminda yakalanan govde)
+        await expect(arkaPlanGorevi({ data: { locations: [ankara] } })).resolves.toBeUndefined();
+
+        // Koordinat diske yeni (Ankara) deger olarak yazilmis olmali (planlama hatasi bunu bozmamali)
+        const yazilan = JSON.parse(mockStore.get(KONUM_ANAHTARI)!);
+        expect(yazilan.koordinatlar.lat).toBeCloseTo(39.9208);
+        expect(yazilan.koordinatlar.lng).toBeCloseTo(32.8541);
+    });
+
+    it('muhafiz aktif ama esikler/sikliklar YOKSA varsayilan esik+sikliklarla yeniden planlamali', async () => {
+        const yapilandirVePlanlaMock = jest.fn().mockResolvedValue(undefined);
+        const { ArkaplanMuhafizServisi } = require('../ArkaplanMuhafizServisi');
+        (ArkaplanMuhafizServisi.getInstance as jest.Mock).mockReturnValue({
+            yapilandirVePlanla: yapilandirVePlanlaMock,
+        });
+
+        mockStore.set(KONUM_ANAHTARI, JSON.stringify({
+            konumModu: 'oto',
+            takipHassasiyeti: 'dengeli',
+            koordinatlar: { lat: 41.0369, lng: 28.9850 }, // Istanbul
+        }));
+        // Muhafiz aktif AMA esikler ve sikliklar tanimsiz -> uretim varsayilanlara dusmeli
+        mockStore.set('muhafiz_ayarlari', JSON.stringify({ aktif: true }));
+        (Location.reverseGeocodeAsync as jest.Mock).mockResolvedValue([{ district: 'Cankaya', city: 'Ankara' }]);
+
+        const ankara = {
+            coords: { latitude: 39.9208, longitude: 32.8541, altitude: null, accuracy: null, altitudeAccuracy: null, heading: null, speed: null },
+            timestamp: 0,
+        } as Location.LocationObject;
+
+        await arkaPlanGorevi({ data: { locations: [ankara] } });
+
+        expect(yapilandirVePlanlaMock).toHaveBeenCalledTimes(1);
+        const iletilen = yapilandirVePlanlaMock.mock.calls[0][0];
+        // Varsayilan esik degerleri (45/25/10/3) ve siklik degerleri (15/10/5/1) uygulanmali
+        expect(iletilen.esikler.seviye1).toBe(45);
+        expect(iletilen.esikler.seviye1Siklik).toBe(15);
+        expect(iletilen.esikler.seviye2).toBe(25);
+        expect(iletilen.esikler.seviye3).toBe(10);
+        expect(iletilen.esikler.seviye4).toBe(3);
+        expect(iletilen.esikler.seviye4Siklik).toBe(1);
+        // Yeni koordinatlar iletilmeli
+        expect(iletilen.koordinatlar.lat).toBeCloseTo(39.9208);
+    });
+
+    it('geocode district/city YOKSA subregion/region alanlarina DUSMELI (alan fallback)', async () => {
+        mockStore.set(KONUM_ANAHTARI, JSON.stringify({
+            konumModu: 'oto',
+            takipHassasiyeti: 'dengeli',
+            koordinatlar: { lat: 41.0369, lng: 28.9850 }, // Istanbul
+        }));
+        // district ve city YOK -> uretim subregion/region'a dusmeli
+        (Location.reverseGeocodeAsync as jest.Mock).mockResolvedValue([
+            { district: null, subregion: 'TasraIlce', city: null, region: 'TasraIl' },
+        ]);
+
+        const ankara = {
+            coords: { latitude: 39.9208, longitude: 32.8541, altitude: null, accuracy: null, altitudeAccuracy: null, heading: null, speed: null },
+            timestamp: 0,
+        } as Location.LocationObject;
+
+        await arkaPlanGorevi({ data: { locations: [ankara] } });
+
+        const yazilan = JSON.parse(mockStore.get(KONUM_ANAHTARI)!);
+        expect(yazilan.gpsAdres.ilce).toBe('TasraIlce'); // subregion fallback
+        expect(yazilan.gpsAdres.il).toBe('TasraIl');     // region fallback
+    });
+
+    it('konum ayarlari BOZUK JSON ise gorev cokmeden sessizce cikmali (dis catch)', async () => {
+        // getItem null degil ama JSON.parse patliyor -> ic kontrollerden onceki parse
+        // disardaki try/catch'e dusmeli; gorev reject ETMEMELI ve hicbir yazma yapmamali.
+        mockStore.set(KONUM_ANAHTARI, '{"konumModu":"oto", BOZUK');
+
+        const istanbul = {
+            coords: { latitude: 41.0082, longitude: 28.9784, altitude: null, accuracy: null, altitudeAccuracy: null, heading: null, speed: null },
+            timestamp: 0,
+        } as Location.LocationObject;
+
+        await expect(arkaPlanGorevi({ data: { locations: [istanbul] } })).resolves.toBeUndefined();
+        // Parse patladigi icin hicbir guncelleme/yazma olmamali (bozuk veri korunur)
+        expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+        expect(Location.reverseGeocodeAsync).not.toHaveBeenCalled();
+    });
+});

--- a/src/domain/services/__tests__/NamazVaktiHesaplayiciServisi.test.ts
+++ b/src/domain/services/__tests__/NamazVaktiHesaplayiciServisi.test.ts
@@ -262,8 +262,9 @@ describe('NamazVaktiHesaplayiciServisi', () => {
             const bugun = new Date();
             expect(bilgi.saat).toEqual(vakitTreti(bugun, 16, 0));
             expect(bilgi.sonrakiVakitGiris).toBe(vakitTreti(bugun, 16, 0).toISOString());
-            // kalanSureMs = nextTime - now; ileri bir saat olduğundan
-            expect(typeof bilgi.kalanSureMs).toBe('number');
+            // kalanSureMs = nextTime - now; gerçek duvar saati kullanıldığından işaret belirsiz,
+            // bu yüzden değer/işaret değil yalnız sonlu-sayı tipi doğrulanır.
+            expect(Number.isFinite(bilgi.kalanSureMs)).toBe(true);
         });
 
         it('yatsı sonrası (next=none) yarının imsak vaktine geçer', () => {

--- a/src/domain/services/__tests__/NamazVaktiHesaplayiciServisi.test.ts
+++ b/src/domain/services/__tests__/NamazVaktiHesaplayiciServisi.test.ts
@@ -1,0 +1,292 @@
+/**
+ * NamazVaktiHesaplayiciServisi Testleri
+ * Davranışsal testler: yapılandırma (oto/manuel/plaka), günlük vakitler,
+ * şu anki vakit bilgisi (yatsı sonrası yarına geçiş dahil) ve PrayerTimes önbellek davranışı.
+ *
+ * adhan tamamen mock'lanır (gerçek trig hesabı yok) → deterministik, hızlı, tarihe bağımsız.
+ */
+
+import * as Location from 'expo-location';
+import { NamazVaktiHesaplayiciServisi } from '../NamazVaktiHesaplayiciServisi';
+
+// ─── Mock'lar ──────────────────────────────────────────────────────────────────
+
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+
+jest.mock('../../../core/utils/Logger', () => ({
+    Logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('expo-location', () => ({
+    requestForegroundPermissionsAsync: jest.fn(),
+    getCurrentPositionAsync: jest.fn(),
+}));
+
+// adhan: her gün için deterministik vakitler + currentPrayer/nextPrayer/timeForPrayer döndür.
+// PrayerTimes ctor jest.fn → "kaç kez instantiate edildi?" (önbellek) testleri için sayılır.
+const vakitTreti = (date: Date, saat: number, dakika = 0) =>
+    new Date(date.getFullYear(), date.getMonth(), date.getDate(), saat, dakika);
+
+// Mock davranışını test gövdesinden ayarlamak için dışarıda tutulan kancalar.
+const mockKancalar = {
+    // currentPrayer'in döneceği adhan-anahtarı (ör. 'dhuhr'); 'none' = vakit yok
+    current: 'dhuhr' as string,
+    // nextPrayer'in döneceği adhan-anahtarı; 'none' = bugün için kalan vakit yok
+    next: 'asr' as string,
+};
+
+jest.mock('adhan', () => {
+    const Coordinates = jest.fn().mockImplementation((lat: number, lng: number) => ({ lat, lng }));
+    const PrayerTimes = jest.fn().mockImplementation((_coords: any, date: Date) => {
+        const vakitler: Record<string, Date> = {
+            fajr: vakitTreti(date, 5, 0),
+            sunrise: vakitTreti(date, 6, 30),
+            dhuhr: vakitTreti(date, 13, 0),
+            asr: vakitTreti(date, 16, 0),
+            maghrib: vakitTreti(date, 19, 0),
+            isha: vakitTreti(date, 20, 30),
+        };
+        return {
+            ...vakitler,
+            currentPrayer: jest.fn(() => mockKancalar.current),
+            nextPrayer: jest.fn(() => mockKancalar.next),
+            timeForPrayer: jest.fn((p: string) => (p === 'none' ? null : vakitler[p] ?? null)),
+        };
+    });
+    return {
+        Coordinates,
+        PrayerTimes,
+        CalculationMethod: { Turkey: jest.fn(() => ({})) },
+        Madhab: { Hanafi: 'hanafi', Shafi: 'shafi' },
+        SunnahTimes: jest.fn(),
+    };
+});
+
+// adhan mock'una eriş (PrayerTimes çağrı sayımı için)
+const adhan = require('adhan');
+const mockLocation = Location as jest.Mocked<typeof Location>;
+
+// ─── Yardımcılar ────────────────────────────────────────────────────────────────
+
+const servis = NamazVaktiHesaplayiciServisi.getInstance();
+
+/** Singleton durumunu testler arası sıfırlar (config + önbellek). */
+function servisiSifirla() {
+    (servis as any).config = null;
+    (servis as any).yapilandirildi = false;
+    (servis as any).ptCache.clear();
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    servisiSifirla();
+    mockKancalar.current = 'dhuhr';
+    mockKancalar.next = 'asr';
+});
+
+// ─── Testler ─────────────────────────────────────────────────────────────────────
+
+describe('NamazVaktiHesaplayiciServisi', () => {
+    it('getInstance her zaman aynı örneği döndürür (singleton)', () => {
+        expect(NamazVaktiHesaplayiciServisi.getInstance()).toBe(servis);
+    });
+
+    describe('yapilandir / getKonfig', () => {
+        it('yapılandırmadan önce getKonfig null döner', () => {
+            expect(servis.getKonfig()).toBeNull();
+        });
+
+        it('yapılandırma config nesnesini saklar', () => {
+            servis.yapilandir({ latitude: 41, longitude: 29 });
+            expect(servis.getKonfig()).toEqual({ latitude: 41, longitude: 29 });
+        });
+
+        it('yeniden yapılandırma PrayerTimes önbelleğini temizler', () => {
+            servis.yapilandir({ latitude: 41, longitude: 29 });
+            const tarih = new Date(2026, 0, 15);
+            servis.getGunlukVakitler(tarih); // önbelleğe 1 giriş
+            expect(adhan.PrayerTimes).toHaveBeenCalledTimes(1);
+
+            // Aynı gün tekrar → önbellekten gelir, yeni ctor yok
+            servis.getGunlukVakitler(tarih);
+            expect(adhan.PrayerTimes).toHaveBeenCalledTimes(1);
+
+            // Yeniden yapılandır → önbellek temizlenir → aynı gün artık yeniden hesaplanır
+            servis.yapilandir({ latitude: 40, longitude: 32 });
+            servis.getGunlukVakitler(tarih);
+            expect(adhan.PrayerTimes).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('getGunlukVakitler', () => {
+        it('config yoksa null döner', () => {
+            expect(servis.getGunlukVakitler(new Date(2026, 0, 15))).toBeNull();
+        });
+
+        it('altı vakti adhan alanlarından doğru eşler', () => {
+            servis.yapilandir({ latitude: 41, longitude: 29 });
+            const tarih = new Date(2026, 0, 15);
+            const v = servis.getGunlukVakitler(tarih)!;
+
+            expect(v.imsak).toEqual(vakitTreti(tarih, 5, 0));
+            expect(v.gunes).toEqual(vakitTreti(tarih, 6, 30));
+            expect(v.ogle).toEqual(vakitTreti(tarih, 13, 0));
+            expect(v.ikindi).toEqual(vakitTreti(tarih, 16, 0));
+            expect(v.aksam).toEqual(vakitTreti(tarih, 19, 0));
+            expect(v.yatsi).toEqual(vakitTreti(tarih, 20, 30));
+        });
+
+        it('Coordinates yapılandırılan enlem/boylam ile oluşturulur', () => {
+            servis.yapilandir({ latitude: 38.75, longitude: 30.55 });
+            servis.getGunlukVakitler(new Date(2026, 0, 15));
+            expect(adhan.Coordinates).toHaveBeenCalledWith(38.75, 30.55);
+        });
+    });
+
+    describe('prayerTimesAl önbellek davranışı', () => {
+        beforeEach(() => servis.yapilandir({ latitude: 41, longitude: 29 }));
+
+        it('aynı gün için ikinci çağrıda yeni PrayerTimes oluşturmaz', () => {
+            const tarih = new Date(2026, 0, 15);
+            servis.getGunlukVakitler(tarih);
+            servis.getGunlukVakitler(tarih);
+            expect(adhan.PrayerTimes).toHaveBeenCalledTimes(1);
+        });
+
+        it('farklı günler için ayrı PrayerTimes oluşturur', () => {
+            servis.getGunlukVakitler(new Date(2026, 0, 15));
+            servis.getGunlukVakitler(new Date(2026, 0, 16));
+            expect(adhan.PrayerTimes).toHaveBeenCalledTimes(2);
+        });
+
+        it('önbellek sınırsız büyümez: eşik aşılınca temizlenir', () => {
+            // Temizlik kontrolü yeni giriş eklenmeden ÖNCE `size > 4` ise tetiklenir.
+            // 1..5 eklenince size 5'e ulaşır (5. eklemeden önce size=4, > değil → clear yok).
+            for (let g = 1; g <= 5; g++) servis.getGunlukVakitler(new Date(2026, 0, g));
+            expect((servis as any).ptCache.size).toBe(5);
+
+            // 6. gün eklenmeden önce size=5 > 4 → clear → yalnız yeni gün kalır.
+            servis.getGunlukVakitler(new Date(2026, 0, 6));
+            expect((servis as any).ptCache.size).toBe(1);
+
+            // Temizlik sonrası ilk gün artık önbellekte değil → yeniden hesaplanır.
+            const oncekiSayim = (adhan.PrayerTimes as jest.Mock).mock.calls.length;
+            servis.getGunlukVakitler(new Date(2026, 0, 1));
+            expect((adhan.PrayerTimes as jest.Mock).mock.calls.length).toBe(oncekiSayim + 1);
+        });
+    });
+
+    describe('guncelleKonumManuel', () => {
+        it('koordinat objesi ile yapılandırır ve true döner', () => {
+            const sonuc = servis.guncelleKonumManuel({ lat: 36.89, lng: 30.71 });
+            expect(sonuc).toBe(true);
+            expect(servis.getKonfig()).toMatchObject({ latitude: 36.89, longitude: 30.71 });
+        });
+
+        it('geçerli plaka kodu ile ili bulup yapılandırır (06 → Ankara)', () => {
+            const sonuc = servis.guncelleKonumManuel('06');
+            expect(sonuc).toBe(true);
+            const cfg = servis.getKonfig()!;
+            expect(cfg.latitude).toBeCloseTo(39.9334, 3);
+            expect(cfg.longitude).toBeCloseTo(32.8597, 3);
+        });
+
+        it('geçersiz plaka kodunda false döner ve config değişmez', () => {
+            servis.yapilandir({ latitude: 41, longitude: 29 });
+            const sonuc = servis.guncelleKonumManuel('999');
+            expect(sonuc).toBe(false);
+            expect(servis.getKonfig()).toEqual({ latitude: 41, longitude: 29 });
+        });
+
+        it('var olan method/madhab tercihlerini korur', () => {
+            servis.yapilandir({ latitude: 41, longitude: 29, method: 'Turkey', madhab: 'Shafi' });
+            servis.guncelleKonumManuel({ lat: 1, lng: 2 });
+            expect(servis.getKonfig()).toMatchObject({ method: 'Turkey', madhab: 'Shafi' });
+        });
+
+        it('method/madhab yoksa varsayılan Turkey/Hanafi atanır', () => {
+            servis.guncelleKonumManuel({ lat: 1, lng: 2 });
+            expect(servis.getKonfig()).toMatchObject({ method: 'Turkey', madhab: 'Hanafi' });
+        });
+    });
+
+    describe('guncelleKonumOto', () => {
+        it('izin verildiğinde konumu alır ve yapılandırır', async () => {
+            (mockLocation.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+            (mockLocation.getCurrentPositionAsync as jest.Mock).mockResolvedValue({
+                coords: { latitude: 40.5, longitude: 32.5 },
+            });
+
+            const sonuc = await servis.guncelleKonumOto();
+
+            expect(sonuc).toEqual({ lat: 40.5, lng: 32.5 });
+            expect(servis.getKonfig()).toMatchObject({ latitude: 40.5, longitude: 32.5, method: 'Turkey', madhab: 'Hanafi' });
+        });
+
+        it('izin reddedilince null döner ve config oluşmaz', async () => {
+            (mockLocation.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+
+            const sonuc = await servis.guncelleKonumOto();
+
+            expect(sonuc).toBeNull();
+            expect(mockLocation.getCurrentPositionAsync).not.toHaveBeenCalled();
+            expect(servis.getKonfig()).toBeNull();
+        });
+
+        it('konum alımı hata fırlatırsa null döner (yutulur)', async () => {
+            (mockLocation.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'granted' });
+            (mockLocation.getCurrentPositionAsync as jest.Mock).mockRejectedValue(new Error('GPS yok'));
+
+            await expect(servis.guncelleKonumOto()).resolves.toBeNull();
+        });
+    });
+
+    describe('getSuankiVakitBilgisi', () => {
+        beforeEach(() => servis.yapilandir({ latitude: 41, longitude: 29 }));
+
+        it('config yoksa null döner', () => {
+            servisiSifirla();
+            expect(servis.getSuankiVakitBilgisi()).toBeNull();
+        });
+
+        it('içinde bulunulan vakti Türkçeleştirir ve sonraki vakte kalan süreyi pozitif verir', () => {
+            // current = öğle (dhuhr=13:00), next = ikindi (asr=16:00)
+            mockKancalar.current = 'dhuhr';
+            mockKancalar.next = 'asr';
+
+            const bilgi = servis.getSuankiVakitBilgisi()!;
+            expect(bilgi).not.toBeNull();
+            expect(bilgi.vakit).toBe('ogle');
+            expect(bilgi.sonrakiVakitAdi).toBe('ikindi');
+            // saat = sonraki vaktin (ikindi) saati; bugünün 16:00'sı
+            const bugun = new Date();
+            expect(bilgi.saat).toEqual(vakitTreti(bugun, 16, 0));
+            expect(bilgi.sonrakiVakitGiris).toBe(vakitTreti(bugun, 16, 0).toISOString());
+            // kalanSureMs = nextTime - now; ileri bir saat olduğundan
+            expect(typeof bilgi.kalanSureMs).toBe('number');
+        });
+
+        it('yatsı sonrası (next=none) yarının imsak vaktine geçer', () => {
+            mockKancalar.current = 'isha';
+            mockKancalar.next = 'none'; // bugün için kalan vakit yok
+
+            const bilgi = servis.getSuankiVakitBilgisi()!;
+            expect(bilgi).not.toBeNull();
+            // içinde bulunulan vakit yatsı
+            expect(bilgi.vakit).toBe('yatsi');
+            // sonraki vakit yarının imsak'ı
+            expect(bilgi.sonrakiVakitAdi).toBe('imsak');
+
+            const yarin = new Date();
+            yarin.setDate(yarin.getDate() + 1);
+            expect(bilgi.saat).toEqual(vakitTreti(yarin, 5, 0));
+        });
+
+        it('bilinmeyen current değeri yatsı olarak fallback eder', () => {
+            mockKancalar.current = 'none';
+            mockKancalar.next = 'fajr';
+            const bilgi = servis.getSuankiVakitBilgisi()!;
+            expect(bilgi.vakit).toBe('yatsi');
+        });
+    });
+});

--- a/src/domain/services/__tests__/TurkiyeKonumServisi.test.ts
+++ b/src/domain/services/__tests__/TurkiyeKonumServisi.test.ts
@@ -1,0 +1,425 @@
+/**
+ * TurkiyeKonumServisi — davranışsal testler
+ *
+ * Singleton servis: il/ilçe verisini bellek cache → AsyncStorage cache → API → offline
+ * sırasıyla çözer. Burada cache isabeti, bayat cache, API başarı/başarısızlık dalları,
+ * offline fallback, koordinat eşleme edge'leri ve cache temizleme yan etkileri test edilir.
+ *
+ * Not: servis SINGLETON ve bellek-içi cache (illerCache/ilcelerCache) tutar →
+ * her testten önce cacheTemizle() ile sıfırlanmalı, aksi halde testler sızar.
+ */
+
+import {
+    TurkiyeKonumServisi,
+    TURKIYE_ILLERI_OFFLINE,
+} from '../TurkiyeKonumServisi';
+
+// In-memory AsyncStorage mock (mock* öneki: jest.mock fabrikası closure'a erişebilsin)
+const mockStore = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: async (k: string) => (mockStore.has(k) ? mockStore.get(k)! : null),
+        setItem: async (k: string, v: string) => {
+            mockStore.set(k, v);
+        },
+        removeItem: async (k: string) => {
+            mockStore.delete(k);
+        },
+        getAllKeys: async () => Array.from(mockStore.keys()),
+        multiRemove: async (keys: string[]) => {
+            keys.forEach((k) => mockStore.delete(k));
+        },
+    },
+}));
+
+// Logger'ı sustur (gürültü + olası yan etki testi kirletmesin)
+jest.mock('../../../core/utils/Logger', () => ({
+    Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const CACHE_ANAHTARI_ILLER = '@turkiye_iller';
+const CACHE_ANAHTARI_ILCELER = '@turkiye_ilceler_';
+
+// fetch mock yardımcıları
+function fetchYanitOlustur(ok: boolean, json: unknown): Response {
+    return {
+        ok,
+        json: async () => json,
+    } as unknown as Response;
+}
+
+beforeEach(async () => {
+    mockStore.clear();
+    // Singleton bellek cache'ini sıfırla (cacheTemizle bellek + diski temizler)
+    await TurkiyeKonumServisi.cacheTemizle();
+    mockStore.clear();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as { fetch?: unknown }).fetch;
+});
+
+describe('TurkiyeKonumServisi.illeriGetir', () => {
+    test('API başarısız ve cache yokken offline 81 ili döner', async () => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('ağ hatası'));
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        expect(iller).toBe(TURKIYE_ILLERI_OFFLINE);
+        expect(iller.length).toBe(81);
+        expect(iller[0].ad).toBe('Adana');
+    });
+
+    test('API yanıtı ok değilse offline veriye düşer', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(false, {}));
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        expect(iller).toBe(TURKIYE_ILLERI_OFFLINE);
+    });
+
+    test('API başarılıysa yanıtı eşler, plakaKoduyu 2 haneye tamamlar ve cache yazar', async () => {
+        const apiYanit = {
+            data: [
+                {
+                    id: 6,
+                    name: 'Ankara',
+                    areaCode: 6,
+                    coordinates: { latitude: 39.93, longitude: 32.85 },
+                },
+            ],
+        };
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(true, apiYanit));
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        expect(iller).toHaveLength(1);
+        expect(iller[0]).toEqual({
+            id: 6,
+            ad: 'Ankara',
+            plakaKodu: '06', // padStart(2,'0')
+            lat: 39.93,
+            lng: 32.85,
+        });
+        // Cache'e timestamp + data biçiminde yazılmış olmalı
+        const yazilan = JSON.parse(mockStore.get(CACHE_ANAHTARI_ILLER)!);
+        expect(yazilan.data).toHaveLength(1);
+        expect(typeof yazilan.timestamp).toBe('number');
+    });
+
+    test('coordinates yoksa lat/lng 0 olur (|| 0 dalı)', async () => {
+        const apiYanit = [{ id: 99, name: 'Testil', areaCode: 99 }]; // coordinates yok, bare array
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(true, apiYanit));
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        expect(iller[0].lat).toBe(0);
+        expect(iller[0].lng).toBe(0);
+        expect(iller[0].plakaKodu).toBe('99');
+    });
+
+    test('bellek cache sıcaksa ikinci çağrı API/fetch yapmaz', async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(true, { data: [] }));
+        global.fetch = fetchMock;
+
+        await TurkiyeKonumServisi.illeriGetir(); // ilk çağrı: fetch 1 kez
+        await TurkiyeKonumServisi.illeriGetir(); // ikinci: bellek cache → fetch yok
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('taze AsyncStorage cache varsa API çağrılmadan cache verisi döner', async () => {
+        const cacheVeri = [
+            { id: 1, ad: 'CacheIl', plakaKodu: '01', lat: 1, lng: 2 },
+        ];
+        mockStore.set(
+            CACHE_ANAHTARI_ILLER,
+            JSON.stringify({ timestamp: Date.now(), data: cacheVeri })
+        );
+        const fetchMock = jest.fn();
+        global.fetch = fetchMock;
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        expect(iller).toEqual(cacheVeri);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('bayat AsyncStorage cache yok sayılır, API denenir', async () => {
+        const bayatVeri = [
+            { id: 1, ad: 'BayatIl', plakaKodu: '01', lat: 1, lng: 2 },
+        ];
+        mockStore.set(
+            CACHE_ANAHTARI_ILLER,
+            JSON.stringify({
+                // 25 saat önce → CACHE_SURESI (24s) aşıldı
+                timestamp: Date.now() - 25 * 60 * 60 * 1000,
+                data: bayatVeri,
+            })
+        );
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                fetchYanitOlustur(true, {
+                    data: [
+                        {
+                            id: 2,
+                            name: 'TazeIl',
+                            areaCode: 2,
+                            coordinates: { latitude: 5, longitude: 6 },
+                        },
+                    ],
+                })
+            );
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        expect(iller).toHaveLength(1);
+        expect(iller[0].ad).toBe('TazeIl');
+    });
+
+    test('bozuk AsyncStorage cache (geçersiz JSON) çökmeden API/offline yoluna devam eder', async () => {
+        mockStore.set(CACHE_ANAHTARI_ILLER, '{bozuk-json');
+        global.fetch = jest.fn().mockRejectedValue(new Error('ağ yok'));
+
+        const iller = await TurkiyeKonumServisi.illeriGetir();
+
+        // Cache parse patladı → catch → API patladı → offline
+        expect(iller).toBe(TURKIYE_ILLERI_OFFLINE);
+    });
+});
+
+describe('TurkiyeKonumServisi.ilGetirById / ilGetirByPlaka', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('offline'));
+    });
+
+    test('ilGetirById var olan ID için ili döner', async () => {
+        const il = await TurkiyeKonumServisi.ilGetirById(34);
+        expect(il?.ad).toBe('İstanbul');
+    });
+
+    test('ilGetirById olmayan ID için null döner', async () => {
+        const il = await TurkiyeKonumServisi.ilGetirById(9999);
+        expect(il).toBeNull();
+    });
+
+    test('ilGetirByPlaka var olan plaka için ili döner', async () => {
+        const il = await TurkiyeKonumServisi.ilGetirByPlaka('06');
+        expect(il?.ad).toBe('Ankara');
+    });
+
+    test('ilGetirByPlaka olmayan plaka için null döner', async () => {
+        const il = await TurkiyeKonumServisi.ilGetirByPlaka('00');
+        expect(il).toBeNull();
+    });
+});
+
+describe('TurkiyeKonumServisi.ilceleriGetir', () => {
+    test('API başarılıysa ilçeleri eşler ve id yoksa index+1 kullanır', async () => {
+        const apiYanit = {
+            data: {
+                coordinates: { latitude: 10, longitude: 20 },
+                districts: [
+                    {
+                        id: 100,
+                        name: 'Merkez',
+                        coordinates: { latitude: 11, longitude: 21 },
+                    },
+                    // id yok → index+1 = 2; coordinates yok → il koordinatına düşer
+                    { name: 'KoordsuzIlce' },
+                ],
+            },
+        };
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(true, apiYanit));
+
+        const ilceler = await TurkiyeKonumServisi.ilceleriGetir(6);
+
+        expect(ilceler).toHaveLength(2);
+        expect(ilceler[0]).toEqual({
+            id: 100,
+            ilId: 6,
+            ad: 'Merkez',
+            lat: 11,
+            lng: 21,
+        });
+        // id yoksa index+1, koordinatlar il koordinatına fallback
+        expect(ilceler[1]).toEqual({
+            id: 2,
+            ilId: 6,
+            ad: 'KoordsuzIlce',
+            lat: 10,
+            lng: 20,
+        });
+    });
+
+    test('districts hiç yoksa boş dizi döner (|| [] dalı)', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(true, { data: {} }));
+
+        const ilceler = await TurkiyeKonumServisi.ilceleriGetir(7);
+        expect(ilceler).toEqual([]);
+    });
+
+    test('API ok değilse boş dizi döner', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(fetchYanitOlustur(false, {}));
+
+        const ilceler = await TurkiyeKonumServisi.ilceleriGetir(8);
+        expect(ilceler).toEqual([]);
+    });
+
+    test('fetch fırlatırsa boş dizi döner', async () => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('ağ yok'));
+
+        const ilceler = await TurkiyeKonumServisi.ilceleriGetir(9);
+        expect(ilceler).toEqual([]);
+    });
+
+    test('bellek cache sıcaksa ikinci çağrı fetch yapmaz', async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(
+                fetchYanitOlustur(true, {
+                    data: { districts: [{ id: 1, name: 'A' }] },
+                })
+            );
+        global.fetch = fetchMock;
+
+        await TurkiyeKonumServisi.ilceleriGetir(10);
+        await TurkiyeKonumServisi.ilceleriGetir(10);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('taze AsyncStorage ilçe cache varsa fetch yapmadan döner', async () => {
+        const ilId = 11;
+        const cacheVeri = [{ id: 1, ilId, ad: 'CacheIlce', lat: 0, lng: 0 }];
+        mockStore.set(
+            `${CACHE_ANAHTARI_ILCELER}${ilId}`,
+            JSON.stringify({ timestamp: Date.now(), data: cacheVeri })
+        );
+        const fetchMock = jest.fn();
+        global.fetch = fetchMock;
+
+        const ilceler = await TurkiyeKonumServisi.ilceleriGetir(ilId);
+
+        expect(ilceler).toEqual(cacheVeri);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('bayat AsyncStorage ilçe cache yok sayılır, API denenir', async () => {
+        const ilId = 12;
+        mockStore.set(
+            `${CACHE_ANAHTARI_ILCELER}${ilId}`,
+            JSON.stringify({
+                timestamp: Date.now() - 25 * 60 * 60 * 1000,
+                data: [{ id: 1, ilId, ad: 'Bayat', lat: 0, lng: 0 }],
+            })
+        );
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                fetchYanitOlustur(true, {
+                    data: { districts: [{ id: 5, name: 'Taze' }] },
+                })
+            );
+
+        const ilceler = await TurkiyeKonumServisi.ilceleriGetir(ilId);
+        expect(ilceler).toHaveLength(1);
+        expect(ilceler[0].ad).toBe('Taze');
+    });
+});
+
+describe('TurkiyeKonumServisi.enYakinIliBul', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('offline'));
+    });
+
+    test('İstanbul koordinatına en yakın il İstanbul döner', async () => {
+        // İstanbul: 41.0082, 28.9784
+        const il = await TurkiyeKonumServisi.enYakinIliBul(41.0082, 28.9784);
+        expect(il?.ad).toBe('İstanbul');
+    });
+
+    test('Ankara koordinatına en yakın il Ankara döner', async () => {
+        // Ankara: 39.9334, 32.8597
+        const il = await TurkiyeKonumServisi.enYakinIliBul(39.93, 32.86);
+        expect(il?.ad).toBe('Ankara');
+    });
+});
+
+describe('TurkiyeKonumServisi.cacheTemizle', () => {
+    test('yalnız türkiye cache anahtarlarını siler, ilgisiz anahtara dokunmaz', async () => {
+        mockStore.set(
+            CACHE_ANAHTARI_ILLER,
+            JSON.stringify({ timestamp: Date.now(), data: [] })
+        );
+        mockStore.set(
+            `${CACHE_ANAHTARI_ILCELER}6`,
+            JSON.stringify({ timestamp: Date.now(), data: [] })
+        );
+        mockStore.set('@baska_anahtar', 'korunmali');
+
+        await TurkiyeKonumServisi.cacheTemizle();
+
+        expect(mockStore.has(CACHE_ANAHTARI_ILLER)).toBe(false);
+        expect(mockStore.has(`${CACHE_ANAHTARI_ILCELER}6`)).toBe(false);
+        expect(mockStore.get('@baska_anahtar')).toBe('korunmali');
+    });
+
+    test('cacheTemizle sonrası bellek cache de sıfırlanır (illeriGetir yeniden fetch eder)', async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(
+                fetchYanitOlustur(true, {
+                    data: [
+                        {
+                            id: 1,
+                            name: 'A',
+                            areaCode: 1,
+                            coordinates: { latitude: 0, longitude: 0 },
+                        },
+                    ],
+                })
+            );
+        global.fetch = fetchMock;
+
+        await TurkiyeKonumServisi.illeriGetir(); // bellek cache dolar (fetch 1)
+        await TurkiyeKonumServisi.cacheTemizle(); // bellek + disk temizlenir
+        mockStore.clear();
+        await TurkiyeKonumServisi.illeriGetir(); // tekrar fetch (fetch 2)
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test('getAllKeys fırlatsa bile fırlatmadan tamamlanır (catch dalı)', async () => {
+        const asyncStorage = jest.requireMock(
+            '@react-native-async-storage/async-storage'
+        ).default;
+        const orijinal = asyncStorage.getAllKeys;
+        asyncStorage.getAllKeys = jest
+            .fn()
+            .mockRejectedValue(new Error('storage hatası'));
+
+        await expect(
+            TurkiyeKonumServisi.cacheTemizle()
+        ).resolves.toBeUndefined();
+
+        asyncStorage.getAllKeys = orijinal;
+    });
+});

--- a/src/domain/services/__tests__/VakitSayacBildirimServisi.test.ts
+++ b/src/domain/services/__tests__/VakitSayacBildirimServisi.test.ts
@@ -384,4 +384,175 @@ describe('VakitSayacBildirimServisi', () => {
     const ogleId = `${BILDIRIM_SABITLERI.ONEKLEME.SAYAC}2026-02-19_ogle`;
     expect(createIds).toContain(ogleId);
   });
+
+  it('kanal idempotency: ikinci yapilandirmada kanal TEKRAR olusturulmamali', async () => {
+    saatiDondur(new OriginalDate('2026-02-19T10:00:00'));
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+    const ayarlar = {
+      aktif: true,
+      koordinatlar: { lat: 41, lng: 29 },
+      baslangicEsikDk: 30,
+    };
+
+    await servis.yapilandirVePlanla(ayarlar);
+    expect(notifee.createChannel).toHaveBeenCalledTimes(1);
+
+    // Ikinci kez yapilandir: kanal zaten olusturuldu bayragi set => tekrar acilmamali
+    await servis.yapilandirVePlanla(ayarlar);
+    expect(notifee.createChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it('kanal olusturma hatasi: createChannel reddetse bile akis cokmemeli (catch yutulur)', async () => {
+    saatiDondur(new OriginalDate('2026-02-19T10:00:00'));
+    (notifee.createChannel as jest.Mock).mockRejectedValueOnce(new Error('kanal patladi'));
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+
+    // Kanal acilamasa da yapilandirma reddetmemeli; planlama yine de denenmeli
+    await expect(
+      servis.yapilandirVePlanla({
+        aktif: true,
+        koordinatlar: { lat: 41, lng: 29 },
+        baslangicEsikDk: 30,
+      })
+    ).resolves.toBeUndefined();
+
+    // Kanal hatasi yutuldu, vakit planlamasi yine de yapildi
+    const createIds = (notifee.createTriggerNotification as jest.Mock).mock.calls
+      .map((c: any[]) => c[0].id as string);
+    expect(createIds).toContain(`${BILDIRIM_SABITLERI.ONEKLEME.SAYAC}2026-02-19_ogle`);
+  });
+
+  it('hemen baslayan sayac hatasi: startCountdown firlatsa bile temizleme trigger\'i yine kurulmali', async () => {
+    // 14:45: ogle cikisi 15:00, esik 30dk => HEMEN native countdown baslar (firlatacak)
+    saatiDondur(new OriginalDate('2026-02-19T14:45:00'));
+    mockStartCountdown.mockImplementationOnce(() => {
+      throw new Error('native sayac patladi');
+    });
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+
+    await expect(
+      servis.yapilandirVePlanla({
+        aktif: true,
+        koordinatlar: { lat: 41, lng: 29 },
+        baslangicEsikDk: 30,
+      })
+    ).resolves.toBeUndefined();
+
+    // Native sayac firlatti ama akis devam etti: ogle icin temizleme (_bitis) trigger'i kuruldu
+    const ogleBitis = (notifee.createTriggerNotification as jest.Mock).mock.calls
+      .find((c: any[]) => c[0].id === `${BILDIRIM_SABITLERI.ONEKLEME.SAYAC}2026-02-19_ogle_bitis`);
+    expect(ogleBitis).toBeDefined();
+  });
+
+  it('trigger planlama hatasi: createTriggerNotification reddetse bile diger vakitler planlanmaya devam etmeli', async () => {
+    // 10:00: ogle/ikindi/aksam/yatsi gelecekte; ilk trigger cagrisi reddedilsin
+    saatiDondur(new OriginalDate('2026-02-19T10:00:00'));
+    (notifee.createTriggerNotification as jest.Mock).mockRejectedValueOnce(new Error('trigger patladi'));
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+
+    await expect(
+      servis.yapilandirVePlanla({
+        aktif: true,
+        koordinatlar: { lat: 41, lng: 29 },
+        baslangicEsikDk: 30,
+      })
+    ).resolves.toBeUndefined();
+
+    // Ilk trigger reddedildi (catch yutuldu) ama sonraki vakitler icin cagri devam etti
+    expect((notifee.createTriggerNotification as jest.Mock).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('asamaGecisiniIsle: _vakitgirdi sonekli ID temel bildirimi iptal etmeli', async () => {
+    const servis = VakitSayacBildirimServisi.getInstance();
+    const temelId = `${BILDIRIM_SABITLERI.ONEKLEME.SAYAC}2026-02-19_ogle`;
+
+    await servis.asamaGecisiniIsle(`${temelId}_vakitgirdi`);
+
+    expect(notifee.cancelNotification).toHaveBeenCalledWith(temelId);
+  });
+
+  it('asamaGecisiniIsle: _bitis sonekli ID hem temel hem _vakitgirdi bildirimini iptal etmeli', async () => {
+    const servis = VakitSayacBildirimServisi.getInstance();
+    const temelId = `${BILDIRIM_SABITLERI.ONEKLEME.SAYAC}2026-02-19_ogle`;
+
+    await servis.asamaGecisiniIsle(`${temelId}_bitis`);
+
+    const iptalEdilenler = (notifee.cancelNotification as jest.Mock).mock.calls.map((c: any[]) => c[0]);
+    expect(iptalEdilenler).toContain(temelId);
+    expect(iptalEdilenler).toContain(`${temelId}_vakitgirdi`);
+  });
+
+  it('asamaGecisiniIsle: eslesmeyen sonekte hicbir iptal yapilmamali', async () => {
+    const servis = VakitSayacBildirimServisi.getInstance();
+
+    await servis.asamaGecisiniIsle(`${BILDIRIM_SABITLERI.ONEKLEME.SAYAC}2026-02-19_ogle`);
+
+    expect(notifee.cancelNotification).not.toHaveBeenCalled();
+  });
+
+  it('temizleme trigger hatasi: _bitis trigger\'i reddetse bile sonraki vakitler planlanmaya devam etmeli', async () => {
+    // 14:45: ogle HEMEN baslar (startCountdown), ardindan ilk createTriggerNotification cagrisi
+    // ogle'nin _bitis temizleme trigger'idir; bunu reddet => catch (343) calisir, akis devam eder.
+    saatiDondur(new OriginalDate('2026-02-19T14:45:00'));
+    (notifee.createTriggerNotification as jest.Mock).mockRejectedValueOnce(new Error('bitis trigger patladi'));
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+
+    await expect(
+      servis.yapilandirVePlanla({
+        aktif: true,
+        koordinatlar: { lat: 41, lng: 29 },
+        baslangicEsikDk: 30,
+      })
+    ).resolves.toBeUndefined();
+
+    // Ilk _bitis reddedildi (catch yutuldu) ama sonraki vakitlerin (ikindi/aksam/yatsi) planlamasi surdu
+    expect((notifee.createTriggerNotification as jest.Mock).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('temizleme: gosterilen sayac bildirimleri iptal edilmeli, sayac olmayanlar dokunulmamali', async () => {
+    const onek = BILDIRIM_SABITLERI.ONEKLEME.SAYAC;
+    const sayacBildirimId = `${onek}2026-02-19_ogle`;
+    (notifee.getDisplayedNotifications as jest.Mock).mockResolvedValue([
+      { id: sayacBildirimId },
+      { id: 'baska_bildirim_123' }, // sayac onekli degil -> dokunulmamali
+      { id: undefined }, // id'siz -> guvenli atlanmali
+    ]);
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+    await servis.tumSayacBildirimleriniTemizle();
+
+    // Sayac onekli bildirim icin native countdown durdurulup notifee iptali yapilmali
+    expect(mockStopCountdown).toHaveBeenCalledWith(sayacBildirimId);
+    expect(notifee.cancelNotification).toHaveBeenCalledWith(sayacBildirimId);
+    // Sayac olmayan bildirim icin iptal yapilmamali
+    expect(notifee.cancelNotification).not.toHaveBeenCalledWith('baska_bildirim_123');
+  });
+
+  it('temizleme: sayac onekli trigger ID\'leri iptal edilmeli, digerleri korunmali', async () => {
+    const onek = BILDIRIM_SABITLERI.ONEKLEME.SAYAC;
+    const sayacTriggerId = `${onek}2026-02-19_yatsi`;
+    (notifee.getTriggerNotificationIds as jest.Mock).mockResolvedValue([
+      sayacTriggerId,
+      'muhafiz_2026-02-19_ogle', // baska servisin trigger'i -> korunmali
+    ]);
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+    await servis.tumSayacBildirimleriniTemizle();
+
+    expect(notifee.cancelTriggerNotification).toHaveBeenCalledWith(sayacTriggerId);
+    expect(notifee.cancelTriggerNotification).not.toHaveBeenCalledWith('muhafiz_2026-02-19_ogle');
+  });
+
+  it('temizleme hatasi: getDisplayedNotifications reddetse bile metot reddetmemeli (catch yutulur)', async () => {
+    (notifee.getDisplayedNotifications as jest.Mock).mockRejectedValueOnce(new Error('liste alinamadi'));
+
+    const servis = VakitSayacBildirimServisi.getInstance();
+
+    await expect(servis.tumSayacBildirimleriniTemizle()).resolves.toBeUndefined();
+  });
 });

--- a/src/domain/services/__tests__/VakitSayacBildirimServisi.test.ts
+++ b/src/domain/services/__tests__/VakitSayacBildirimServisi.test.ts
@@ -496,7 +496,7 @@ describe('VakitSayacBildirimServisi', () => {
 
   it('temizleme trigger hatasi: _bitis trigger\'i reddetse bile sonraki vakitler planlanmaya devam etmeli', async () => {
     // 14:45: ogle HEMEN baslar (startCountdown), ardindan ilk createTriggerNotification cagrisi
-    // ogle'nin _bitis temizleme trigger'idir; bunu reddet => catch (343) calisir, akis devam eder.
+    // ogle'nin _bitis temizleme trigger'idir; bunu reddet => _bitis trigger'inin catch'i yutar, akis devam eder.
     saatiDondur(new OriginalDate('2026-02-19T14:45:00'));
     (notifee.createTriggerNotification as jest.Mock).mockRejectedValueOnce(new Error('bitis trigger patladi'));
 

--- a/src/presentation/hooks/__tests__/useYeniOzellikler.test.tsx
+++ b/src/presentation/hooks/__tests__/useYeniOzellikler.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * useYeniOzellikler Hook Testleri
+ *
+ * Hook'un GERÇEK türetme mantığını davranışsal olarak doğrular:
+ *   - okunmamis: gorulenIdler filtresi (sürüm/görüldü ayıklama)
+ *   - kart: kartGoster + kapatilanKartIdler ile tek (ilk) tanıtım kartı seçimi
+ *   - sayfaOkunmamisMi / sayfayiGorulduIsaretle: hedefSayfa eşlemesi
+ *   - dispatch sonrası türevlerin (okunmamisVarMi, kart) güncellenmesi
+ *
+ * Katalog (YENI_OZELLIKLER) sabit ama ileride değişebilir; testin kararlı
+ * kalması için katalog mocklanır → filtreleme dalları kontrollü veriyle test edilir.
+ */
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import ozelliklerReducer from '../../store/ozelliklerSlice';
+import { useYeniOzellikler } from '../useYeniOzellikler';
+
+// AsyncStorage: thunk'lar (gorulduIsaretle / kartiKapat) içeride kullanır
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    setItem: jest.fn(() => Promise.resolve()),
+    getItem: jest.fn(() => Promise.resolve(null)),
+    removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+// Katalog mocklanır: kontrollü, sabit bir senaryoyla filtreleme dalları test edilir.
+//   - A: kartGoster=true, hedefSayfa='SayfaA'  (en güncel — kart adayı)
+//   - B: kartGoster=true, hedefSayfa='SayfaB'  (ikinci kart adayı)
+//   - C: kartGoster=false, hedefSayfa yok      (kart adayı DEĞİL)
+jest.mock('../../../core/constants/YeniOzellikler', () => ({
+    YENI_OZELLIKLER: [
+        {
+            id: 'a',
+            surum: '0.3.0',
+            tarih: '2026-03-01',
+            baslik: 'A',
+            aciklama: 'A açıklama',
+            ikon: 'star',
+            hedefSayfa: 'SayfaA',
+            kartGoster: true,
+        },
+        {
+            id: 'b',
+            surum: '0.2.0',
+            tarih: '2026-02-01',
+            baslik: 'B',
+            aciklama: 'B açıklama',
+            ikon: 'star',
+            hedefSayfa: 'SayfaB',
+            kartGoster: true,
+        },
+        {
+            id: 'c',
+            surum: '0.1.0',
+            tarih: '2026-01-01',
+            baslik: 'C',
+            aciklama: 'C açıklama',
+            ikon: 'star',
+            kartGoster: false,
+        },
+    ],
+}));
+
+function storeOlustur(onYukleme?: { gorulenIdler?: string[]; kapatilanKartIdler?: string[] }) {
+    const store = configureStore({
+        reducer: { ozellikler: ozelliklerReducer },
+        middleware: (g) => g({ serializableCheck: false }),
+    });
+    // Slice'ın yalnızca extraReducers'ı olduğu için başlangıç durumunu
+    // thunk fulfilled action'ı taklit ederek enjekte ederiz.
+    if (onYukleme) {
+        store.dispatch({
+            type: 'ozellikler/yukle/fulfilled',
+            payload: {
+                gorulenIdler: onYukleme.gorulenIdler ?? [],
+                kapatilanKartIdler: onYukleme.kapatilanKartIdler ?? [],
+            },
+        });
+    }
+    return store;
+}
+
+function sar(store: ReturnType<typeof storeOlustur>) {
+    return ({ children }: { children: React.ReactNode }) => (
+        <Provider store={store}>{children}</Provider>
+    );
+}
+
+describe('useYeniOzellikler', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('hiçbir özellik görülmemişse tümü okunmamış sayılır', () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.okunmamis.map((o) => o.id)).toEqual(['a', 'b', 'c']);
+        expect(result.current.okunmamisVarMi).toBe(true);
+    });
+
+    it('görülen idler okunmamış listesinden çıkarılır', () => {
+        const store = storeOlustur({ gorulenIdler: ['a', 'c'] });
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.okunmamis.map((o) => o.id)).toEqual(['b']);
+        expect(result.current.okunmamisVarMi).toBe(true);
+    });
+
+    it('tüm özellikler görülünce okunmamisVarMi false olur', () => {
+        const store = storeOlustur({ gorulenIdler: ['a', 'b', 'c'] });
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.okunmamis).toEqual([]);
+        expect(result.current.okunmamisVarMi).toBe(false);
+        expect(result.current.kart).toBeNull();
+    });
+
+    it('kart, kartGoster=true olan ilk (en güncel) okunmamış özelliği seçer', () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        // a kartGoster=true ve en üstte → kart=a (c kartGoster=false, aday değil)
+        expect(result.current.kart?.id).toBe('a');
+    });
+
+    it('kart, kapatılan veya görülen kartı atlayıp bir sonraki adaya geçer', () => {
+        // a görülmüş VE kartı kapatılmış → sıradaki kartGoster adayı b
+        const store = storeOlustur({ gorulenIdler: [], kapatilanKartIdler: ['a'] });
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.kart?.id).toBe('b');
+    });
+
+    it('kartGoster=false olan özellik kart olarak seçilmez', () => {
+        // a ve b görülmüş; geriye yalnız c (kartGoster=false) kalır → kart null
+        const store = storeOlustur({ gorulenIdler: ['a', 'b'] });
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.okunmamis.map((o) => o.id)).toEqual(['c']);
+        expect(result.current.kart).toBeNull();
+    });
+
+    it('sayfaOkunmamisMi yalnızca eşleşen hedefSayfa için true döner', () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.sayfaOkunmamisMi('SayfaA')).toBe(true);
+        expect(result.current.sayfaOkunmamisMi('SayfaB')).toBe(true);
+        expect(result.current.sayfaOkunmamisMi('OlmayanSayfa')).toBe(false);
+    });
+
+    it('isaretle dispatch sonrası okunmamış listesi ve türevleri günceller', async () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.kart?.id).toBe('a');
+
+        await act(async () => {
+            result.current.isaretle('a');
+        });
+
+        await waitFor(() => {
+            expect(result.current.okunmamis.map((o) => o.id)).toEqual(['b', 'c']);
+        });
+        // 'a' okununca kart bir sonraki adaya (b) kayar
+        expect(result.current.kart?.id).toBe('b');
+    });
+
+    it('sayfayiGorulduIsaretle yalnızca o sayfaya ait okunmamışları görülmüş yapar', async () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        await act(async () => {
+            result.current.sayfayiGorulduIsaretle('SayfaA');
+        });
+
+        await waitFor(() => {
+            expect(result.current.sayfaOkunmamisMi('SayfaA')).toBe(false);
+        });
+        // Yalnızca SayfaA işaretlendi; b (SayfaB) hâlâ okunmamış
+        expect(result.current.sayfaOkunmamisMi('SayfaB')).toBe(true);
+        expect(result.current.okunmamis.map((o) => o.id)).toEqual(['b', 'c']);
+    });
+
+    it('eşleşmeyen sayfa için sayfayiGorulduIsaretle hiçbir şeyi değiştirmez', async () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        const oncekiSayisi = result.current.okunmamis.length;
+
+        await act(async () => {
+            result.current.sayfayiGorulduIsaretle('OlmayanSayfa');
+        });
+
+        expect(result.current.okunmamis.length).toBe(oncekiSayisi);
+    });
+
+    it('kartiKapat kartı gizler ama özelliği okunmamış bırakır', async () => {
+        const store = storeOlustur();
+        const { result } = renderHook(() => useYeniOzellikler(), { wrapper: sar(store) });
+
+        expect(result.current.kart?.id).toBe('a');
+
+        await act(async () => {
+            result.current.kartiKapat('a');
+        });
+
+        await waitFor(() => {
+            expect(result.current.kart?.id).toBe('b');
+        });
+        // Kart kapandı ama 'a' hâlâ okunmamış (rozet kalır)
+        expect(result.current.okunmamis.map((o) => o.id)).toContain('a');
+    });
+});

--- a/src/presentation/store/__tests__/kazaSlice.test.ts
+++ b/src/presentation/store/__tests__/kazaSlice.test.ts
@@ -1,0 +1,378 @@
+/**
+ * kazaSlice — DAVRANIŞSAL testler
+ *
+ * Thunk'lar gerçek LocalKazaServisi + KazaHesaplayiciServisi'ni (AsyncStorage
+ * in-memory mock'lu) kullanır; gerçek store üzerinde dispatch edilip hem Redux
+ * state'i hem diske yazılan blob doğrulanır. Tarihe bağlı alanlar SABİT yazılmaz
+ * (tarihiISOFormatinaCevir ile bugünden türetilir).
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import kazaReducer, {
+  kazaVerileriniYukle,
+  borcEkle,
+  kazaTamamla,
+  sihirbazIleBaslat,
+  gunlukHedefiGuncelle,
+  gizlemeToggle,
+  hataTemizle,
+} from '../kazaSlice';
+import { DEPOLAMA_ANAHTARLARI } from '../../../core/constants/UygulamaSabitleri';
+import { tarihiISOFormatinaCevir } from '../../../core/utils/TarihYardimcisi';
+import type { KazaDurumu } from '../../../core/types/KazaTipleri';
+
+// In-memory AsyncStorage mock (mock* öneki: jest.mock fabrikası closure'a erişebilsin)
+const mockStore = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: async (k: string) => (mockStore.has(k) ? mockStore.get(k)! : null),
+    setItem: async (k: string, v: string) => {
+      mockStore.set(k, v);
+    },
+    removeItem: async (k: string) => {
+      mockStore.delete(k);
+    },
+  },
+}));
+
+// Logger sustur
+jest.mock('../../../core/utils/Logger', () => ({
+  Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const DURUM_KEY = DEPOLAMA_ANAHTARLARI.KAZA_DURUMU;
+const TEMPO_KEY = DEPOLAMA_ANAHTARLARI.KAZA_TEMPO_GECMIS;
+
+const bugun = () => tarihiISOFormatinaCevir(new Date());
+
+/** Diskten KazaDurumu blob'unu okur (yoksa null). */
+const diskDurumOku = (): KazaDurumu | null => {
+  const v = mockStore.get(DURUM_KEY);
+  return v ? (JSON.parse(v) as KazaDurumu) : null;
+};
+
+const yeniStore = () => configureStore({ reducer: { kaza: kazaReducer } });
+
+const kalan = (d: KazaDurumu, ad: string) =>
+  d.namazlar.find((n) => n.namazAdi === ad)!.kalanBorc;
+const tamamlanan = (d: KazaDurumu, ad: string) =>
+  d.namazlar.find((n) => n.namazAdi === ad)!.tamamlanan;
+
+beforeEach(() => {
+  mockStore.clear();
+});
+
+// ==================== hataTemizle reducer ====================
+
+describe('hataTemizle', () => {
+  it('hata alanını null yapar, diğer state korunur', () => {
+    const baslangic = kazaReducer(undefined, { type: '@@INIT' });
+    const hataliState = { ...baslangic, hata: 'bir şey patladı', yukleniyor: true };
+    const sonuc = kazaReducer(hataliState, hataTemizle());
+    expect(sonuc.hata).toBeNull();
+    expect(sonuc.yukleniyor).toBe(true); // dokunulmadı
+  });
+});
+
+// ==================== kazaVerileriniYukle ====================
+
+describe('kazaVerileriniYukle', () => {
+  it('pending → yukleniyor true & hata temizlenir', () => {
+    const s = kazaReducer(
+      { kazaDurumu: null, istatistik: null, tempoGecmis: {}, yukleniyor: false, hata: 'eski' },
+      { type: kazaVerileriniYukle.pending.type }
+    );
+    expect(s.yukleniyor).toBe(true);
+    expect(s.hata).toBeNull();
+  });
+
+  it('boş diskte fulfilled: boş durum yüklenir, istatistik üretilir', async () => {
+    const store = yeniStore();
+    await store.dispatch(kazaVerileriniYukle());
+    const st = store.getState().kaza;
+    expect(st.yukleniyor).toBe(false);
+    expect(st.kazaDurumu).not.toBeNull();
+    expect(st.kazaDurumu!.namazlar.length).toBeGreaterThan(0);
+    expect(st.istatistik).not.toBeNull();
+    // toplamKalan 0 iken tahmin yok, motivasyon önerisi boş
+    expect(st.istatistik!.tahminiTamamlanmaTarihi).toBeNull();
+    expect(st.istatistik!.motivasyonOnerileri).toEqual([]);
+  });
+
+  it('diskteki tempo geçmişi state.tempoGecmis olarak yüklenir', async () => {
+    const tempo = { '2026-01-01': 5, '2026-01-02': 3 };
+    mockStore.set(TEMPO_KEY, JSON.stringify(tempo));
+    const store = yeniStore();
+    await store.dispatch(kazaVerileriniYukle());
+    expect(store.getState().kaza.tempoGecmis).toEqual(tempo);
+  });
+
+  it('gunlukHedefTarihi dünden ise günlük sayaç sıfırlanır', async () => {
+    const durum: KazaDurumu = {
+      namazlar: [{ namazAdi: 'Sabah', toplamBorc: 5, kalanBorc: 5, tamamlanan: 0 }],
+      toplamKalan: 5,
+      toplamTamamlanan: 0,
+      gunlukHedef: 3,
+      gunlukTamamlanan: 7, // dünkü ilerleme
+      gunlukHedefTarihi: '2000-01-01', // geçmiş tarih → sıfırlanmalı
+      toplamGizleMi: false,
+      guncellemeTarihi: '2000-01-01',
+    };
+    mockStore.set(DURUM_KEY, JSON.stringify(durum));
+    const store = yeniStore();
+    await store.dispatch(kazaVerileriniYukle());
+    const st = store.getState().kaza.kazaDurumu!;
+    expect(st.gunlukTamamlanan).toBe(0);
+    expect(st.gunlukHedefTarihi).toBe(bugun());
+  });
+
+  it('gunlukHedefTarihi bugün ise günlük sayaç KORUNUR', async () => {
+    const durum: KazaDurumu = {
+      namazlar: [{ namazAdi: 'Sabah', toplamBorc: 5, kalanBorc: 5, tamamlanan: 0 }],
+      toplamKalan: 5,
+      toplamTamamlanan: 0,
+      gunlukHedef: 3,
+      gunlukTamamlanan: 4,
+      gunlukHedefTarihi: bugun(),
+      toplamGizleMi: false,
+      guncellemeTarihi: bugun(),
+    };
+    mockStore.set(DURUM_KEY, JSON.stringify(durum));
+    const store = yeniStore();
+    await store.dispatch(kazaVerileriniYukle());
+    expect(store.getState().kaza.kazaDurumu!.gunlukTamamlanan).toBe(4);
+  });
+
+  it('rejected: kaza servisi başarısız olursa hata state\'e yazılır', async () => {
+    // localKazaDurumunuGetir bozuk veride bile başarılı döner; reddi tetiklemek için
+    // servisi doğrudan mock'layıp {basarili:false} döndürmek gerekir. Burada thunk'ın
+    // rejected reducer'ını izole test ediyoruz (gerçek reddedilmiş action ile).
+    const s = kazaReducer(
+      { kazaDurumu: null, istatistik: null, tempoGecmis: {}, yukleniyor: true, hata: null },
+      {
+        type: kazaVerileriniYukle.rejected.type,
+        error: { message: 'Kaza verileri yüklenemedi' },
+      }
+    );
+    expect(s.yukleniyor).toBe(false);
+    expect(s.hata).toBe('Kaza verileri yüklenemedi');
+  });
+
+  it('rejected: error.message yoksa varsayılan mesaj kullanılır', () => {
+    const s = kazaReducer(
+      { kazaDurumu: null, istatistik: null, tempoGecmis: {}, yukleniyor: true, hata: null },
+      { type: kazaVerileriniYukle.rejected.type, error: {} }
+    );
+    expect(s.hata).toBe('Kaza verileri yüklenemedi');
+  });
+});
+
+// ==================== borcEkle ====================
+
+describe('borcEkle', () => {
+  it('boş state\'ten Sabah\'a borç ekler, toplamlar güncellenir, diske yazılır', async () => {
+    const store = yeniStore();
+    await store.dispatch(borcEkle({ namazAdi: 'Sabah', sayi: 10 }));
+    const st = store.getState().kaza.kazaDurumu!;
+    expect(kalan(st, 'Sabah')).toBe(10);
+    expect(st.namazlar.find((n) => n.namazAdi === 'Sabah')!.toplamBorc).toBe(10);
+    expect(st.toplamKalan).toBe(10);
+    // diğer namazlar etkilenmedi
+    expect(kalan(st, 'Öğle')).toBe(0);
+    // diske yazıldı
+    expect(kalan(diskDurumOku()!, 'Sabah')).toBe(10);
+  });
+
+  it('mevcut borca ekler (kümülatif), istatistik tahmini üretir', async () => {
+    const store = yeniStore();
+    await store.dispatch(borcEkle({ namazAdi: 'Öğle', sayi: 5 }));
+    await store.dispatch(borcEkle({ namazAdi: 'Öğle', sayi: 3 }));
+    const st = store.getState().kaza;
+    expect(kalan(st.kazaDurumu!, 'Öğle')).toBe(8);
+    expect(st.kazaDurumu!.toplamKalan).toBe(8);
+    // toplamKalan > 0 → motivasyon önerileri var
+    expect(st.istatistik!.motivasyonOnerileri.length).toBeGreaterThan(0);
+  });
+
+  it('guncellemeTarihi ISO damgası yazılır', async () => {
+    const store = yeniStore();
+    await store.dispatch(borcEkle({ namazAdi: 'Vitir', sayi: 1 }));
+    const ts = store.getState().kaza.kazaDurumu!.guncellemeTarihi;
+    expect(Number.isNaN(Date.parse(ts))).toBe(false);
+  });
+});
+
+// ==================== kazaTamamla ====================
+
+describe('kazaTamamla', () => {
+  const borcluStoreHazirla = async () => {
+    const store = yeniStore();
+    await store.dispatch(borcEkle({ namazAdi: 'Sabah', sayi: 10 }));
+    await store.dispatch(borcEkle({ namazAdi: 'Öğle', sayi: 4 }));
+    return store;
+  };
+
+  it('belirli namazdan tamamlama: kalan düşer, tamamlanan artar, günlük sayaç artar', async () => {
+    const store = await borcluStoreHazirla();
+    await store.dispatch(kazaTamamla({ namazAdi: 'Sabah', sayi: 3 }));
+    const st = store.getState().kaza;
+    const d = st.kazaDurumu!;
+    expect(kalan(d, 'Sabah')).toBe(7);
+    expect(tamamlanan(d, 'Sabah')).toBe(3);
+    expect(d.gunlukTamamlanan).toBe(3);
+    // Öğle dokunulmadı
+    expect(kalan(d, 'Öğle')).toBe(4);
+    // tempo geçmişine bugünün toplamı yazıldı
+    expect(st.tempoGecmis[bugun()]).toBe(3);
+  });
+
+  it('kalandan fazla istense bile 0\'ın altına inmez (clamp); fazlalık tamamlanana sayılmaz', async () => {
+    const store = await borcluStoreHazirla();
+    await store.dispatch(kazaTamamla({ namazAdi: 'Öğle', sayi: 100 }));
+    const d = store.getState().kaza.kazaDurumu!;
+    expect(kalan(d, 'Öğle')).toBe(0);
+    expect(tamamlanan(d, 'Öğle')).toBe(4); // 100 değil, gerçek kalan kadar
+    // günlük tamamlanan gerçekleşen miktar (4) olmalı, 100 değil
+    expect(d.gunlukTamamlanan).toBe(4);
+  });
+
+  it('genel tamamlama (namazAdi=null): en yüksek kalandan düşer, orijinal sıra korunur', async () => {
+    const store = await borcluStoreHazirla(); // Sabah=10, Öğle=4
+    await store.dispatch(kazaTamamla({ namazAdi: null, sayi: 3 }));
+    const d = store.getState().kaza.kazaDurumu!;
+    // en yüksek kalan Sabah(10) → 3 ondan düşer
+    expect(kalan(d, 'Sabah')).toBe(7);
+    expect(kalan(d, 'Öğle')).toBe(4);
+    // sıra korundu: ilk eleman hala Sabah
+    expect(d.namazlar[0].namazAdi).toBe('Sabah');
+    expect(d.gunlukTamamlanan).toBe(3);
+  });
+
+  it('genel tamamlama bir vakti aşınca sonraki en yüksek vakte taşar', async () => {
+    const store = await borcluStoreHazirla(); // Sabah=10, Öğle=4
+    // 13 düş: Sabah(10) biter, kalan 3 Öğle'den düşer
+    await store.dispatch(kazaTamamla({ namazAdi: null, sayi: 13 }));
+    const d = store.getState().kaza.kazaDurumu!;
+    expect(kalan(d, 'Sabah')).toBe(0);
+    expect(kalan(d, 'Öğle')).toBe(1);
+    expect(d.toplamKalan).toBe(1);
+    expect(d.gunlukTamamlanan).toBe(13);
+  });
+
+  it('borç yokken genel tamamlama günlük sayacı bozmaz (gerçek tamamlanan 0)', async () => {
+    const store = yeniStore();
+    await store.dispatch(kazaTamamla({ namazAdi: null, sayi: 5 }));
+    const d = store.getState().kaza.kazaDurumu!;
+    expect(d.toplamKalan).toBe(0);
+    expect(d.gunlukTamamlanan).toBe(0);
+  });
+
+  it('art arda tamamlamalar günlük sayacı kümülatif biriktirir', async () => {
+    const store = await borcluStoreHazirla();
+    await store.dispatch(kazaTamamla({ namazAdi: 'Sabah', sayi: 2 }));
+    await store.dispatch(kazaTamamla({ namazAdi: 'Sabah', sayi: 3 }));
+    const d = store.getState().kaza.kazaDurumu!;
+    expect(d.gunlukTamamlanan).toBe(5);
+    expect(store.getState().kaza.tempoGecmis[bugun()]).toBe(5);
+  });
+});
+
+// ==================== sihirbazIleBaslat ====================
+
+describe('sihirbazIleBaslat', () => {
+  it('toplam borcu 6 vakte dağıtır, toplamKalan dağıtılan toplamına eşittir', async () => {
+    const store = yeniStore();
+    // Bugün doğmuş biri için (ergenlik gelecekte) borç 0 olur; geçmiş doğum tarihi ver
+    await store.dispatch(
+      sihirbazIleBaslat({ dogumTarihi: '1990-01-01', ergenlikYasi: 14, kildigiTahminiYuzdesi: 0 })
+    );
+    const d = store.getState().kaza.kazaDurumu!;
+    const dagilimToplami = d.namazlar.reduce((s, n) => s + n.kalanBorc, 0);
+    expect(d.toplamKalan).toBe(dagilimToplami);
+    expect(d.toplamKalan).toBeGreaterThan(0);
+    // toplamBorc = kalan + tamamlanan invariantı (tamamlanan 0)
+    d.namazlar.forEach((n) => expect(n.toplamBorc).toBe(n.kalanBorc + n.tamamlanan));
+    // diske yazıldı
+    expect(diskDurumOku()!.toplamKalan).toBe(d.toplamKalan);
+  });
+
+  it('ergenlik geleceyse (sıfır borç) tüm kalanlar 0 olur', async () => {
+    const store = yeniStore();
+    await store.dispatch(
+      sihirbazIleBaslat({ dogumTarihi: '2025-01-01', ergenlikYasi: 14, kildigiTahminiYuzdesi: 0 })
+    );
+    const d = store.getState().kaza.kazaDurumu!;
+    expect(d.toplamKalan).toBe(0);
+    d.namazlar.forEach((n) => expect(n.kalanBorc).toBe(0));
+  });
+
+  it('mevcut tamamlanan değeri sihirbaz sonrası toplamBorc invariantında korunur', async () => {
+    const store = yeniStore();
+    // önce bir tamamlama yap (Sabah'a borç ekle + 2 tamamla)
+    await store.dispatch(borcEkle({ namazAdi: 'Sabah', sayi: 5 }));
+    await store.dispatch(kazaTamamla({ namazAdi: 'Sabah', sayi: 2 }));
+    const tamamlananOnce = tamamlanan(store.getState().kaza.kazaDurumu!, 'Sabah');
+    expect(tamamlananOnce).toBe(2);
+    // sihirbazı çalıştır
+    await store.dispatch(
+      sihirbazIleBaslat({ dogumTarihi: '1990-01-01', ergenlikYasi: 14, kildigiTahminiYuzdesi: 0 })
+    );
+    const sabah = store.getState().kaza.kazaDurumu!.namazlar.find((n) => n.namazAdi === 'Sabah')!;
+    expect(sabah.tamamlanan).toBe(2); // korundu
+    expect(sabah.toplamBorc).toBe(sabah.kalanBorc + 2); // invariant
+  });
+});
+
+// ==================== gunlukHedefiGuncelle ====================
+
+describe('gunlukHedefiGuncelle', () => {
+  it('hedefi günceller ve diske yazar', async () => {
+    const store = yeniStore();
+    await store.dispatch(gunlukHedefiGuncelle({ hedef: 8 }));
+    expect(store.getState().kaza.kazaDurumu!.gunlukHedef).toBe(8);
+    expect(diskDurumOku()!.gunlukHedef).toBe(8);
+  });
+
+  it('negatif hedef 0\'a kenetlenir (Math.max)', async () => {
+    const store = yeniStore();
+    await store.dispatch(gunlukHedefiGuncelle({ hedef: -5 }));
+    expect(store.getState().kaza.kazaDurumu!.gunlukHedef).toBe(0);
+  });
+});
+
+// ==================== gizlemeToggle ====================
+
+describe('gizlemeToggle', () => {
+  it('toplamGizleMi değerini tersine çevirir (false→true)', async () => {
+    const store = yeniStore();
+    await store.dispatch(gizlemeToggle());
+    expect(store.getState().kaza.kazaDurumu!.toplamGizleMi).toBe(true);
+    expect(diskDurumOku()!.toplamGizleMi).toBe(true);
+  });
+
+  it('iki kez toggle başa döner (true→false)', async () => {
+    const store = yeniStore();
+    await store.dispatch(gizlemeToggle());
+    await store.dispatch(gizlemeToggle());
+    expect(store.getState().kaza.kazaDurumu!.toplamGizleMi).toBe(false);
+  });
+});
+
+// ==================== entegrasyon: yükle → ekle → tamamla → kalıcılık ====================
+
+describe('entegrasyon: yaşam döngüsü kalıcılığı', () => {
+  it('borç ekleyip tamamlanan ilerleme yeniden yüklendiğinde korunur', async () => {
+    const store1 = yeniStore();
+    await store1.dispatch(borcEkle({ namazAdi: 'İkindi', sayi: 6 }));
+    await store1.dispatch(kazaTamamla({ namazAdi: 'İkindi', sayi: 2 }));
+
+    // yeni store ile diskten yükle
+    const store2 = yeniStore();
+    await store2.dispatch(kazaVerileriniYukle());
+    const d = store2.getState().kaza.kazaDurumu!;
+    expect(kalan(d, 'İkindi')).toBe(4);
+    expect(tamamlanan(d, 'İkindi')).toBe(2);
+    expect(d.toplamKalan).toBe(4);
+  });
+});

--- a/src/presentation/store/__tests__/muhafizSlice.test.ts
+++ b/src/presentation/store/__tests__/muhafizSlice.test.ts
@@ -1,0 +1,226 @@
+/**
+ * muhafizSlice — davranışsal testler
+ *
+ * Kapsanan davranışlar:
+ *  - initialState (varsayılan kapalı muhafız, 'normal' preset)
+ *  - muhafizAyarlariniGuncelle: payload'u merge eder + AsyncStorage'a tam JSON yazar
+ *  - muhafizStateSifirla: initialState'e döner + depolama anahtarını siler
+ *  - muhafizAyarlariniYukle.fulfilled: diskten okuyup eksik alanları ?? ile doldurur
+ *  - muhafizAyarlariniYukle: veri yokken null -> state değişmez
+ *  - muhafizAyarlariniYukle: bozuk JSON -> catch -> null -> state değişmez (asla fırlatmaz)
+ */
+
+import reducer, {
+    muhafizAyarlariniGuncelle,
+    muhafizStateSifirla,
+    muhafizAyarlariniYukle,
+    HATIRLATMA_PRESETLERI,
+    MuhafizAyarlari,
+} from '../muhafizSlice';
+import { DEPOLAMA_ANAHTARLARI } from '../../../core/constants/UygulamaSabitleri';
+import { configureStore } from '@reduxjs/toolkit';
+
+// In-memory AsyncStorage mock (mock* öneki: jest.mock fabrikası closure dışına erişebilsin).
+// Global jest.setup mock'unu kasıtlı override ediyoruz ki yazılan ham JSON'u assert edebilelim
+// ve bozuk-veri (parse hatası) dalını gerçek diskten besleyebilelim.
+const mockStore = new Map<string, string>();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: async (k: string) => (mockStore.has(k) ? mockStore.get(k)! : null),
+        setItem: async (k: string, v: string) => {
+            mockStore.set(k, v);
+        },
+        removeItem: async (k: string) => {
+            mockStore.delete(k);
+        },
+    },
+}));
+
+// Logger'ı sustur (catch dalı Logger.error çağırıyor; test çıktısını kirletmesin).
+jest.mock('../../../core/utils/Logger', () => ({
+    Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const ANAHTAR = DEPOLAMA_ANAHTARLARI.MUHAFIZ_AYARLARI;
+
+const yeniStore = () => configureStore({ reducer: { muhafiz: reducer } });
+
+describe('muhafizSlice', () => {
+    beforeEach(() => {
+        mockStore.clear();
+        jest.clearAllMocks();
+    });
+
+    describe('initialState', () => {
+        it('muhafız kapalı, yogunluk normal ve esik/sikliklar normal preset olmalı', () => {
+            const state = yeniStore().getState().muhafiz as MuhafizAyarlari;
+            expect(state.aktif).toBe(false);
+            expect(state.yogunluk).toBe('normal');
+            expect(state.gelismisMod).toBe(false);
+            expect(state.esikler).toEqual(HATIRLATMA_PRESETLERI.normal.esikler);
+            expect(state.sikliklar).toEqual(HATIRLATMA_PRESETLERI.normal.sikliklar);
+        });
+    });
+
+    describe('muhafizAyarlariniGuncelle', () => {
+        it('kısmi payload state ile merge edilir; dokunulmayan alanlar korunur', () => {
+            const store = yeniStore();
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true, yogunluk: 'yogun' }));
+
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state.aktif).toBe(true);
+            expect(state.yogunluk).toBe('yogun');
+            // Payload'da olmayan alanlar değişmemeli
+            expect(state.gelismisMod).toBe(false);
+            expect(state.esikler).toEqual(HATIRLATMA_PRESETLERI.normal.esikler);
+        });
+
+        it('güncellenen TAM state AsyncStorage anahtarına JSON olarak yazılır', async () => {
+            const store = yeniStore();
+            store.dispatch(
+                muhafizAyarlariniGuncelle({
+                    aktif: true,
+                    gelismisMod: true,
+                    esikler: { seviye1: 99, seviye2: 50, seviye3: 25, seviye4: 10 },
+                })
+            );
+
+            // setItem async olduğu için mikrotask kuyruğunun boşalmasını bekle
+            await Promise.resolve();
+
+            const yazilan = mockStore.get(ANAHTAR);
+            expect(yazilan).toBeDefined();
+            const cozulen = JSON.parse(yazilan!);
+            // Disk, reducer'ın döndürdüğü tam state'i yansıtmalı (kısmi değil)
+            expect(cozulen.aktif).toBe(true);
+            expect(cozulen.gelismisMod).toBe(true);
+            expect(cozulen.yogunluk).toBe('normal'); // dokunulmayan alan da yazılmalı
+            expect(cozulen.esikler).toEqual({ seviye1: 99, seviye2: 50, seviye3: 25, seviye4: 10 });
+            expect(cozulen.sikliklar).toEqual(HATIRLATMA_PRESETLERI.normal.sikliklar);
+        });
+
+        it('ardışık güncellemeler birikerek uygulanır (son state önceki değişikliği korur)', () => {
+            const store = yeniStore();
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true }));
+            store.dispatch(muhafizAyarlariniGuncelle({ gelismisMod: true }));
+
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state.aktif).toBe(true); // ilk güncelleme kaybolmamalı
+            expect(state.gelismisMod).toBe(true);
+        });
+    });
+
+    describe('muhafizStateSifirla', () => {
+        it('state initialState değerlerine döner', () => {
+            const store = yeniStore();
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true, yogunluk: 'yogun', gelismisMod: true }));
+
+            store.dispatch(muhafizStateSifirla());
+
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state.aktif).toBe(false);
+            expect(state.yogunluk).toBe('normal');
+            expect(state.gelismisMod).toBe(false);
+            expect(state.esikler).toEqual(HATIRLATMA_PRESETLERI.normal.esikler);
+        });
+
+        it('depolama anahtarı silinir (kalıcı ayar temizlenir)', async () => {
+            const store = yeniStore();
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true }));
+            await Promise.resolve();
+            expect(mockStore.has(ANAHTAR)).toBe(true);
+
+            store.dispatch(muhafizStateSifirla());
+            await Promise.resolve();
+
+            expect(mockStore.has(ANAHTAR)).toBe(false);
+        });
+    });
+
+    describe('muhafizAyarlariniYukle (thunk)', () => {
+        it('fulfilled: diskteki tam ayarlar state e merge edilir', async () => {
+            const kayitli: MuhafizAyarlari = {
+                aktif: true,
+                yogunluk: 'hafif',
+                gelismisMod: true,
+                esikler: { seviye1: 11, seviye2: 9, seviye3: 4, seviye4: 1 },
+                sikliklar: { seviye1: 12, seviye2: 6, seviye3: 3, seviye4: 1 },
+            };
+            mockStore.set(ANAHTAR, JSON.stringify(kayitli));
+
+            const store = yeniStore();
+            const sonuc = await store.dispatch(muhafizAyarlariniYukle());
+
+            expect(sonuc.type).toBe('muhafiz/yukle/fulfilled');
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state).toEqual(kayitli);
+        });
+
+        it('fulfilled: eksik alanlar ?? ile initialState varsayılanından doldurulur', async () => {
+            // Diskte yalnızca 'gelismisMod' var; diğer TÜM alanlar (aktif dahil) varsayılana
+            // düşmeli — her bir alanın ?? sol-tarafı null/undefined dalını kapsar.
+            mockStore.set(ANAHTAR, JSON.stringify({ gelismisMod: true }));
+
+            const store = yeniStore();
+            await store.dispatch(muhafizAyarlariniYukle());
+
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state.gelismisMod).toBe(true); // diskten gelen
+            expect(state.aktif).toBe(false); // varsayılan (aktif eksik -> ?? sağ taraf)
+            expect(state.yogunluk).toBe('normal'); // varsayılan
+            expect(state.esikler).toEqual(HATIRLATMA_PRESETLERI.normal.esikler); // varsayılan
+            expect(state.sikliklar).toEqual(HATIRLATMA_PRESETLERI.normal.sikliklar); // varsayılan
+        });
+
+        it('fulfilled: aktif=false diskte olsa bile ?? ile EZİLMEZ (yanlış-pozitif null guard)', async () => {
+            // ?? operatörü yalnız null/undefined'da varsayılana düşer; false korunmalı.
+            // Store'u açıp aktif=true yapalım, sonra diskteki false'u yükleyip ezildiğini doğrulayalım.
+            const store = yeniStore();
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true }));
+            await Promise.resolve();
+            // guncelle aynı anahtara yazdı; fixture'ı SONRA koy ki thunk false okusun.
+            mockStore.set(ANAHTAR, JSON.stringify({ aktif: false, yogunluk: 'yogun' }));
+
+            await store.dispatch(muhafizAyarlariniYukle());
+
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state.aktif).toBe(false); // disk değeri false, ?? ile true'ya kaçmamalı
+            expect(state.yogunluk).toBe('yogun');
+        });
+
+        it('veri yoksa null döner ve fulfilled state i DEĞİŞTİRMEZ', async () => {
+            const store = yeniStore();
+            // Önce bilinen bir değişiklik yap, yükleme bunu bozmamalı
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true, yogunluk: 'hafif' }));
+            await Promise.resolve();
+            // guncelle anahtara yazdı; "veri yok" senaryosu için anahtarı temizle.
+            mockStore.delete(ANAHTAR);
+
+            const sonuc = await store.dispatch(muhafizAyarlariniYukle());
+
+            expect(sonuc.type).toBe('muhafiz/yukle/fulfilled');
+            expect(sonuc.payload).toBeNull();
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            // Yükleme null döndü → fulfilled reducer no-op → mevcut state korunur
+            expect(state.aktif).toBe(true);
+            expect(state.yogunluk).toBe('hafif');
+        });
+
+        it('bozuk JSON varsa fırlatmaz; catch null döndürür ve state korunur', async () => {
+            const store = yeniStore();
+            store.dispatch(muhafizAyarlariniGuncelle({ aktif: true }));
+            await Promise.resolve();
+            // guncelle geçerli JSON yazdı; bozuk veriyi SONRA koy ki parse hatası dalı tetiklensin.
+            mockStore.set(ANAHTAR, '{bozuk-json::');
+
+            const sonuc = await store.dispatch(muhafizAyarlariniYukle());
+
+            // Thunk reject DEĞİL fulfilled(null) olmalı (try/catch içinde yutulur)
+            expect(sonuc.type).toBe('muhafiz/yukle/fulfilled');
+            expect(sonuc.payload).toBeNull();
+            const state = store.getState().muhafiz as MuhafizAyarlari;
+            expect(state.aktif).toBe(true); // bozuk veri mevcut state'i bozmamalı
+        });
+    });
+});

--- a/src/presentation/store/__tests__/namazSlice.test.ts
+++ b/src/presentation/store/__tests__/namazSlice.test.ts
@@ -1,0 +1,399 @@
+/**
+ * namazSlice davranis testleri
+ *
+ * Kapsam: async thunk basari/red yollari, reducer dallari (eslesme/eslesmeme
+ * guard'lari) ve istatistik hesaplama (haftalik/aylik) — bos veri ve karisik
+ * tamamlanma dahil edge case'ler. Slice'in TEK bagimliligi LocalNamazServisi
+ * mocklanir; TarihYardimcisi (saf tarih yardimcilari) gercek calisir, bu yuzden
+ * istatistik thunk'lari deterministik kalir.
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import namazReducer, {
+  namazlariYukle,
+  namazDurumunuDegistir,
+  tumNamazlariTamamla,
+  tumNamazlariSifirla,
+  haftalikIstatistikleriYukle,
+  aylikIstatistikleriYukle,
+  tarihiDegistir,
+  hataTemizle,
+} from '../namazSlice';
+import { NamazAdi, NAMAZ_ISIMLERI } from '../../../core/constants/UygulamaSabitleri';
+import { GunlukNamazlar } from '../../../core/types';
+import { bugunuAl } from '../../../core/utils/TarihYardimcisi';
+
+// ==================== MOCKLAR ====================
+
+const mockLocalNamazlariGetir = jest.fn();
+const mockLocalNamazDurumunuGuncelle = jest.fn();
+const mockLocalTumNamazlariGuncelle = jest.fn();
+const mockLocalTarihAraligindakiNamazlariGetir = jest.fn();
+
+jest.mock('../../../data/local/LocalNamazServisi', () => ({
+  localNamazlariGetir: (...args: any[]) => mockLocalNamazlariGetir(...args),
+  localNamazDurumunuGuncelle: (...args: any[]) => mockLocalNamazDurumunuGuncelle(...args),
+  localTumNamazlariGuncelle: (...args: any[]) => mockLocalTumNamazlariGuncelle(...args),
+  localTarihAraligindakiNamazlariGetir: (...args: any[]) =>
+    mockLocalTarihAraligindakiNamazlariGetir(...args),
+}));
+
+// ==================== YARDIMCILAR ====================
+
+function storeOlustur() {
+  return configureStore({
+    reducer: { namaz: namazReducer },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }),
+  });
+}
+
+// 5 farz namazli bir gun olustur; varsayilan: hepsi tamamlanmamis
+const gunOlustur = (
+  tarih: string,
+  tamamlananlar: Partial<Record<NamazAdi, boolean>> = {}
+): GunlukNamazlar => ({
+  tarih,
+  namazlar: NAMAZ_ISIMLERI.map((namazAdi) => ({
+    namazAdi,
+    tamamlandi: tamamlananlar[namazAdi] ?? false,
+    tarih,
+  })),
+});
+
+// ==================== TESTLER ====================
+
+describe('namazSlice', () => {
+  let store: ReturnType<typeof storeOlustur>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = storeOlustur();
+  });
+
+  describe('senkron reducer aksiyonlari', () => {
+    test('tarihiDegistir mevcutTarih state alanini gunceller', () => {
+      store.dispatch(tarihiDegistir('2026-03-15'));
+      expect(store.getState().namaz.mevcutTarih).toBe('2026-03-15');
+    });
+
+    test('hataTemizle hata alanini null yapar', async () => {
+      // Once bir hata uret
+      mockLocalNamazlariGetir.mockResolvedValueOnce({ basarili: false, hata: 'patladi' });
+      await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+      expect(store.getState().namaz.hata).toBe('patladi');
+
+      store.dispatch(hataTemizle());
+      expect(store.getState().namaz.hata).toBeNull();
+    });
+  });
+
+  describe('namazlariYukle', () => {
+    test('basarili: gunlukNamazlar ve mevcutTarih payload ile guncellenir, yukleniyor kapanir', async () => {
+      const veri = gunOlustur('2026-03-15', { [NamazAdi.Sabah]: true });
+      mockLocalNamazlariGetir.mockResolvedValueOnce({ basarili: true, veri });
+
+      const sonuc = await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+
+      expect(sonuc.type).toContain('fulfilled');
+      const s = store.getState().namaz;
+      expect(s.yukleniyor).toBe(false);
+      expect(s.gunlukNamazlar).toEqual(veri);
+      expect(s.mevcutTarih).toBe('2026-03-15');
+      expect(s.hata).toBeNull();
+      expect(mockLocalNamazlariGetir).toHaveBeenCalledWith('2026-03-15');
+    });
+
+    test('basarisiz (basarili=false): servis hatasi state.hata olur, gunlukNamazlar null kalir', async () => {
+      mockLocalNamazlariGetir.mockResolvedValueOnce({ basarili: false, hata: 'disk hatasi' });
+
+      const sonuc = await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+
+      expect(sonuc.type).toContain('rejected');
+      const s = store.getState().namaz;
+      expect(s.yukleniyor).toBe(false);
+      expect(s.hata).toBe('disk hatasi');
+      expect(s.gunlukNamazlar).toBeNull();
+    });
+
+    test('basarisiz (veri yok): varsayilan hata mesaji kullanilir', async () => {
+      // basarili:true ama veri undefined -> thunk fallback mesajla firlatir
+      mockLocalNamazlariGetir.mockResolvedValueOnce({ basarili: true, veri: undefined });
+
+      const sonuc = await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+
+      expect(sonuc.type).toContain('rejected');
+      expect(store.getState().namaz.hata).toBe('Namazlar yuklenemedi');
+    });
+
+    test('pending: yukleniyor true olur ve onceki hata temizlenir', async () => {
+      // Onceki hatayi kur
+      mockLocalNamazlariGetir.mockResolvedValueOnce({ basarili: false, hata: 'eski' });
+      await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+      expect(store.getState().namaz.hata).toBe('eski');
+
+      // Cozulmeyen promise ile pending pencereyi yakala
+      let coz: (v: any) => void;
+      mockLocalNamazlariGetir.mockReturnValueOnce(new Promise((r) => { coz = r; }));
+      const bekleyen = store.dispatch(namazlariYukle({ tarih: '2026-03-16' }));
+
+      // Pending uygulandi: yukleniyor true, hata temizlendi
+      expect(store.getState().namaz.yukleniyor).toBe(true);
+      expect(store.getState().namaz.hata).toBeNull();
+
+      coz!({ basarili: true, veri: gunOlustur('2026-03-16') });
+      await bekleyen;
+      expect(store.getState().namaz.yukleniyor).toBe(false);
+    });
+  });
+
+  describe('namazDurumunuDegistir', () => {
+    test('eslesen tarihte ilgili namazin tamamlandi alanini gunceller', async () => {
+      // Once bir gun yukle
+      mockLocalNamazlariGetir.mockResolvedValueOnce({
+        basarili: true,
+        veri: gunOlustur('2026-03-15'),
+      });
+      await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+
+      mockLocalNamazDurumunuGuncelle.mockResolvedValueOnce({ basarili: true });
+      const sonuc = await store.dispatch(
+        namazDurumunuDegistir({ tarih: '2026-03-15', namazAdi: NamazAdi.Ogle, tamamlandi: true })
+      );
+
+      expect(sonuc.type).toContain('fulfilled');
+      const s = store.getState().namaz;
+      expect(s.guncelleniyor).toBe(false);
+      const ogle = s.gunlukNamazlar!.namazlar.find((n) => n.namazAdi === NamazAdi.Ogle);
+      expect(ogle!.tamamlandi).toBe(true);
+      // Diger namazlar etkilenmedi
+      const sabah = s.gunlukNamazlar!.namazlar.find((n) => n.namazAdi === NamazAdi.Sabah);
+      expect(sabah!.tamamlandi).toBe(false);
+      expect(mockLocalNamazDurumunuGuncelle).toHaveBeenCalledWith('2026-03-15', NamazAdi.Ogle, true);
+    });
+
+    test('payload tarihi yuklu gunden FARKLIYSA state degismez (guard dali)', async () => {
+      mockLocalNamazlariGetir.mockResolvedValueOnce({
+        basarili: true,
+        veri: gunOlustur('2026-03-15'),
+      });
+      await store.dispatch(namazlariYukle({ tarih: '2026-03-15' }));
+
+      mockLocalNamazDurumunuGuncelle.mockResolvedValueOnce({ basarili: true });
+      // Baska bir gun icin guncelle
+      await store.dispatch(
+        namazDurumunuDegistir({ tarih: '2026-03-99', namazAdi: NamazAdi.Ogle, tamamlandi: true })
+      );
+
+      // Yuklu gun (2026-03-15) hic dokunulmamali — tum namazlar hala false
+      const s = store.getState().namaz;
+      expect(s.gunlukNamazlar!.namazlar.every((n) => !n.tamamlandi)).toBe(true);
+    });
+
+    test('gunlukNamazlar null iken fulfilled cokmeden gecer (guard dali)', async () => {
+      mockLocalNamazDurumunuGuncelle.mockResolvedValueOnce({ basarili: true });
+      const sonuc = await store.dispatch(
+        namazDurumunuDegistir({ tarih: '2026-03-15', namazAdi: NamazAdi.Ogle, tamamlandi: true })
+      );
+      expect(sonuc.type).toContain('fulfilled');
+      expect(store.getState().namaz.gunlukNamazlar).toBeNull();
+    });
+
+    test('servis throw ederse rejected olur ve hata state alanina yazilir', async () => {
+      mockLocalNamazDurumunuGuncelle.mockRejectedValueOnce(new Error('yazma basarisiz'));
+      const sonuc = await store.dispatch(
+        namazDurumunuDegistir({ tarih: '2026-03-15', namazAdi: NamazAdi.Ogle, tamamlandi: true })
+      );
+      expect(sonuc.type).toContain('rejected');
+      const s = store.getState().namaz;
+      expect(s.guncelleniyor).toBe(false);
+      expect(s.hata).toBe('yazma basarisiz');
+    });
+  });
+
+  describe('tumNamazlariTamamla / tumNamazlariSifirla', () => {
+    async function gunYukle(tarih: string, tamamlananlar: Partial<Record<NamazAdi, boolean>> = {}) {
+      mockLocalNamazlariGetir.mockResolvedValueOnce({
+        basarili: true,
+        veri: gunOlustur(tarih, tamamlananlar),
+      });
+      await store.dispatch(namazlariYukle({ tarih }));
+    }
+
+    test('tumNamazlariTamamla eslesen gunde tum namazlari tamamlar', async () => {
+      await gunYukle('2026-03-15');
+      mockLocalTumNamazlariGuncelle.mockResolvedValueOnce({ basarili: true });
+
+      await store.dispatch(tumNamazlariTamamla({ tarih: '2026-03-15' }));
+
+      const s = store.getState().namaz;
+      expect(s.gunlukNamazlar!.namazlar.every((n) => n.tamamlandi)).toBe(true);
+      expect(mockLocalTumNamazlariGuncelle).toHaveBeenCalledWith('2026-03-15', true);
+    });
+
+    test('tumNamazlariSifirla eslesen gunde tum namazlari sifirlar', async () => {
+      // Hepsi tamamlanmis baslangic
+      await gunYukle('2026-03-15', {
+        [NamazAdi.Sabah]: true,
+        [NamazAdi.Ogle]: true,
+        [NamazAdi.Ikindi]: true,
+        [NamazAdi.Aksam]: true,
+        [NamazAdi.Yatsi]: true,
+      });
+      mockLocalTumNamazlariGuncelle.mockResolvedValueOnce({ basarili: true });
+
+      await store.dispatch(tumNamazlariSifirla({ tarih: '2026-03-15' }));
+
+      const s = store.getState().namaz;
+      expect(s.gunlukNamazlar!.namazlar.every((n) => !n.tamamlandi)).toBe(true);
+      expect(mockLocalTumNamazlariGuncelle).toHaveBeenCalledWith('2026-03-15', false);
+    });
+
+    test('farkli tarih payload state degistirmez (guard dali)', async () => {
+      await gunYukle('2026-03-15', { [NamazAdi.Sabah]: true });
+      mockLocalTumNamazlariGuncelle.mockResolvedValue({ basarili: true });
+
+      await store.dispatch(tumNamazlariTamamla({ tarih: '2026-03-16' }));
+      await store.dispatch(tumNamazlariSifirla({ tarih: '2026-03-16' }));
+
+      // Yuklu gun degismedi: yalniz Sabah tamamli kaldi
+      const s = store.getState().namaz;
+      const sabah = s.gunlukNamazlar!.namazlar.find((n) => n.namazAdi === NamazAdi.Sabah);
+      const ogle = s.gunlukNamazlar!.namazlar.find((n) => n.namazAdi === NamazAdi.Ogle);
+      expect(sabah!.tamamlandi).toBe(true);
+      expect(ogle!.tamamlandi).toBe(false);
+    });
+  });
+
+  describe('haftalikIstatistikleriYukle', () => {
+    test('servis verisini eksik gunlerle tamamlayip 7 gunluk istatistik uretir', async () => {
+      const bugun = bugunuAl();
+      // Servis tek bir gun (bugun) dondursun: 2/5 tamamli
+      mockLocalTarihAraligindakiNamazlariGetir.mockResolvedValueOnce({
+        basarili: true,
+        veri: [gunOlustur(bugun, { [NamazAdi.Sabah]: true, [NamazAdi.Ogle]: true })],
+      });
+
+      const sonuc = await store.dispatch(haftalikIstatistikleriYukle());
+      expect(sonuc.type).toContain('fulfilled');
+
+      const ist = store.getState().namaz.haftalikIstatistik!;
+      // Hafta 7 gun: servis 1 gun verdi, 6'si eksik gun olarak (tum bos) eklendi
+      expect(ist.gunlukVeriler.length).toBe(7);
+      // Toplam namaz = 7 gun * 5 = 35
+      expect(ist.toplamNamaz).toBe(35);
+      // Tamamlanan = yalniz bugunun 2 namazi
+      expect(ist.tamamlananNamaz).toBe(2);
+      expect(ist.tamamlanmaYuzdesi).toBe(Math.round((2 / 35) * 100));
+      // En iyi gun = bugun (yuzde 40), digerleri 0
+      expect(ist.enIyiGun!.tarih).toBe(bugun);
+      expect(ist.enIyiGun!.tamamlanmaYuzdesi).toBe(40);
+      // Gunluk veriler tarihe gore sirali (artirak)
+      const tarihler = ist.gunlukVeriler.map((g) => g.tarih);
+      expect([...tarihler].sort()).toEqual(tarihler);
+    });
+
+    test('servis bos donerse (veri yok) tum hafta sifir istatistikle doldurulur', async () => {
+      mockLocalTarihAraligindakiNamazlariGetir.mockResolvedValueOnce({
+        basarili: true,
+        veri: [],
+      });
+
+      await store.dispatch(haftalikIstatistikleriYukle());
+
+      const ist = store.getState().namaz.haftalikIstatistik!;
+      expect(ist.gunlukVeriler.length).toBe(7);
+      expect(ist.toplamNamaz).toBe(35);
+      expect(ist.tamamlananNamaz).toBe(0);
+      expect(ist.tamamlanmaYuzdesi).toBe(0);
+      // Hicbiri tamamlanmadi -> en iyi gun yuzdesi 0
+      expect(ist.enIyiGun!.tamamlanmaYuzdesi).toBe(0);
+    });
+
+    test('servis yaniti veri alanini hic icermezse (undefined) coken yok, yukleniyor kapanir', async () => {
+      // yanit.veri undefined -> thunk icinde `|| []` ile bos diziye duser
+      mockLocalTarihAraligindakiNamazlariGetir.mockResolvedValueOnce({ basarili: true });
+
+      const sonuc = await store.dispatch(haftalikIstatistikleriYukle());
+      expect(sonuc.type).toContain('fulfilled');
+      const s = store.getState().namaz;
+      expect(s.yukleniyor).toBe(false);
+      expect(s.haftalikIstatistik!.toplamNamaz).toBe(35);
+    });
+
+    test('servis throw ederse rejected olur ve hata yazilir', async () => {
+      mockLocalTarihAraligindakiNamazlariGetir.mockRejectedValueOnce(new Error('aralik okunamadi'));
+
+      const sonuc = await store.dispatch(haftalikIstatistikleriYukle());
+      expect(sonuc.type).toContain('rejected');
+      const s = store.getState().namaz;
+      expect(s.yukleniyor).toBe(false);
+      expect(s.hata).toBe('aralik okunamadi');
+    });
+  });
+
+  describe('aylikIstatistikleriYukle', () => {
+    test('namaz bazinda yuzdeleri ve aktif gun sayisini dogru hesaplar', async () => {
+      const bugun = bugunuAl();
+      // Iki gun: birinde Sabah tamamli, digerinde Sabah+Ogle tamamli
+      const gun1 = gunOlustur(bugun, { [NamazAdi.Sabah]: true });
+      // Aydaki ikinci bir tarih uret (bugun ayinin 1'i degilse onceki gun, degilse sonraki):
+      const tarihObj = new Date(bugun);
+      const ikinciTarih = new Date(tarihObj.getFullYear(), tarihObj.getMonth(), 15)
+        .toISOString()
+        .split('T')[0];
+      const gun2 = gunOlustur(ikinciTarih, { [NamazAdi.Sabah]: true, [NamazAdi.Ogle]: true });
+
+      mockLocalTarihAraligindakiNamazlariGetir.mockResolvedValueOnce({
+        basarili: true,
+        veri: [gun1, gun2],
+      });
+
+      const sonuc = await store.dispatch(aylikIstatistikleriYukle());
+      expect(sonuc.type).toContain('fulfilled');
+
+      const ist = store.getState().namaz.aylikIstatistik!;
+      // 2 gun * 5 = 10 toplam namaz
+      expect(ist.toplamNamaz).toBe(10);
+      // Tamamlanan: gun1 Sabah(1) + gun2 Sabah,Ogle(2) = 3
+      expect(ist.tamamlananNamaz).toBe(3);
+      expect(ist.tamamlanmaYuzdesi).toBe(Math.round((3 / 10) * 100));
+      // Iki ayri gunde tamamlanan namaz var -> aktif gun = 2
+      expect(ist.aktifGunSayisi).toBe(2);
+      // Sabah iki gunde de tamamli -> 2/2 = %100
+      expect(ist.namazBazindaYuzdeler[NamazAdi.Sabah]).toBe(100);
+      // Ogle yalniz 1 gunde -> 1/2 = %50
+      expect(ist.namazBazindaYuzdeler[NamazAdi.Ogle]).toBe(50);
+      // Ikindi hic -> %0
+      expect(ist.namazBazindaYuzdeler[NamazAdi.Ikindi]).toBe(0);
+      // Ay/yil bugunun degerleriyle eslesir
+      expect(ist.ay).toBe(tarihObj.getMonth());
+      expect(ist.yil).toBe(tarihObj.getFullYear());
+    });
+
+    test('bos veride tum yuzdeler 0, aktif gun 0', async () => {
+      mockLocalTarihAraligindakiNamazlariGetir.mockResolvedValueOnce({ basarili: true, veri: [] });
+
+      await store.dispatch(aylikIstatistikleriYukle());
+
+      const ist = store.getState().namaz.aylikIstatistik!;
+      expect(ist.toplamNamaz).toBe(0);
+      expect(ist.tamamlananNamaz).toBe(0);
+      expect(ist.tamamlanmaYuzdesi).toBe(0);
+      expect(ist.aktifGunSayisi).toBe(0);
+      NAMAZ_ISIMLERI.forEach((ad) => {
+        expect(ist.namazBazindaYuzdeler[ad]).toBe(0);
+      });
+    });
+
+    test('servis throw ederse rejected olur ve hata yazilir', async () => {
+      mockLocalTarihAraligindakiNamazlariGetir.mockRejectedValueOnce(new Error('aylik patladi'));
+
+      const sonuc = await store.dispatch(aylikIstatistikleriYukle());
+      expect(sonuc.type).toContain('rejected');
+      const s = store.getState().namaz;
+      expect(s.yukleniyor).toBe(false);
+      expect(s.hata).toBe('aylik patladi');
+    });
+  });
+});

--- a/src/presentation/store/__tests__/sahurSayacSlice.test.ts
+++ b/src/presentation/store/__tests__/sahurSayacSlice.test.ts
@@ -1,0 +1,202 @@
+/**
+ * sahurSayacSlice — davranışsal testler
+ *
+ * Kapsanan davranışlar:
+ *  - yukle thunk: veri yokken / geçerli veri / aktif:false-string / bozuk JSON (catch)
+ *  - guncelle thunk: mevcut state ile birleştirme (getState merge), diske yazma,
+ *    setItem fırlatınca rejected + hata mesajı
+ *  - reducer: pending/fulfilled/rejected dalları (yukleniyor/hata/ayarlar geçişleri)
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import reducer, {
+  sahurSayacAyarlariniYukle,
+  sahurSayacAyariniGuncelle,
+} from '../sahurSayacSlice';
+import { DEPOLAMA_ANAHTARLARI } from '../../../core/constants/UygulamaSabitleri';
+
+// In-memory AsyncStorage mock (mock* öneki: jest.mock fabrikası closure dışına erişebilsin)
+const mockStore = new Map<string, string>();
+let mockSetItemHata: Error | null = null;
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async (k: string) => (mockStore.has(k) ? mockStore.get(k)! : null)),
+    setItem: jest.fn(async (k: string, v: string) => {
+      if (mockSetItemHata) throw mockSetItemHata;
+      mockStore.set(k, v);
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      mockStore.delete(k);
+    }),
+  },
+}));
+
+// Logger'ı sustur (yan etki testi kirletmesin)
+jest.mock('../../../core/utils/Logger', () => ({
+  Logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const KEY = DEPOLAMA_ANAHTARLARI.SAHUR_SAYAC_AYARLARI;
+
+// Sadece sahurSayac reducer'ı ile gerçek store — thunk'taki getState().sahurSayac çalışsın
+const yeniStore = () => configureStore({ reducer: { sahurSayac: reducer } });
+
+beforeEach(() => {
+  mockStore.clear();
+  mockSetItemHata = null;
+  jest.clearAllMocks();
+});
+
+describe('sahurSayacSlice — initial state', () => {
+  test('başlangıçta sahur sayacı kapalı ve hata yok', () => {
+    const state = yeniStore().getState().sahurSayac;
+    expect(state.ayarlar.aktif).toBe(false);
+    expect(state.yukleniyor).toBe(false);
+    expect(state.hata).toBeNull();
+  });
+});
+
+describe('sahurSayacAyarlariniYukle (thunk + reducer)', () => {
+  test('disk boşken aktif:false ile yüklenir, yukleniyor false döner', async () => {
+    const store = yeniStore();
+    await store.dispatch(sahurSayacAyarlariniYukle());
+    const state = store.getState().sahurSayac;
+    expect(state.ayarlar.aktif).toBe(false);
+    expect(state.yukleniyor).toBe(false);
+    expect(state.hata).toBeNull();
+  });
+
+  test('diskte aktif:true varsa state.aktif true olur', async () => {
+    mockStore.set(KEY, JSON.stringify({ aktif: true }));
+    const store = yeniStore();
+    await store.dispatch(sahurSayacAyarlariniYukle());
+    expect(store.getState().sahurSayac.ayarlar.aktif).toBe(true);
+  });
+
+  test('aktif kesin true değilse (örn "true" string) false normalize edilir', async () => {
+    // parsed?.aktif === true katı kontrolü: truthy ama true olmayan değer false döner
+    mockStore.set(KEY, JSON.stringify({ aktif: 'true' }));
+    const store = yeniStore();
+    await store.dispatch(sahurSayacAyarlariniYukle());
+    expect(store.getState().sahurSayac.ayarlar.aktif).toBe(false);
+  });
+
+  test('diskte aktif alanı yoksa (boş nesne) false döner', async () => {
+    mockStore.set(KEY, JSON.stringify({}));
+    const store = yeniStore();
+    await store.dispatch(sahurSayacAyarlariniYukle());
+    expect(store.getState().sahurSayac.ayarlar.aktif).toBe(false);
+  });
+
+  test('bozuk JSON catch dalına düşer, aktif:false ile başarılı (fulfilled) döner', async () => {
+    mockStore.set(KEY, '{bozuk json'); // JSON.parse fırlatır
+    const store = yeniStore();
+    const sonuc = await store.dispatch(sahurSayacAyarlariniYukle());
+    // Thunk fırlatmamalı: fulfilled olmalı, hata state'e yansımamalı
+    expect(sonuc.type).toBe(sahurSayacAyarlariniYukle.fulfilled.type);
+    const state = store.getState().sahurSayac;
+    expect(state.ayarlar.aktif).toBe(false);
+    expect(state.hata).toBeNull();
+  });
+
+  test('pending sırasında yukleniyor=true ve önceki hata temizlenir', () => {
+    // Önce rejected ile hata bırak, sonra pending ile temizlendiğini gör
+    const hataliState = reducer(undefined, {
+      type: sahurSayacAyarlariniYukle.rejected.type,
+      error: { message: 'eski hata' },
+    });
+    expect(hataliState.hata).toBe('eski hata');
+
+    const pendingState = reducer(hataliState, {
+      type: sahurSayacAyarlariniYukle.pending.type,
+    });
+    expect(pendingState.yukleniyor).toBe(true);
+    expect(pendingState.hata).toBeNull();
+  });
+
+  test('rejected mesajsız hata için varsayılan mesaj kullanılır', () => {
+    const state = reducer(undefined, {
+      type: sahurSayacAyarlariniYukle.rejected.type,
+      error: {},
+    });
+    expect(state.yukleniyor).toBe(false);
+    expect(state.hata).toBe('Ayarlar yüklenemedi');
+  });
+});
+
+describe('sahurSayacAyariniGuncelle (thunk + reducer)', () => {
+  test('kısmi ayar mevcut state ile birleşir ve diske yazılır', async () => {
+    const store = yeniStore();
+    // Başlangıç aktif:false → guncelle aktif:true
+    const sonuc = await store.dispatch(sahurSayacAyariniGuncelle({ aktif: true }));
+
+    expect(sonuc.type).toBe(sahurSayacAyariniGuncelle.fulfilled.type);
+    // State güncellendi
+    expect(store.getState().sahurSayac.ayarlar.aktif).toBe(true);
+    // Diske doğru değer yazıldı (yan etki)
+    expect(mockStore.get(KEY)).toBe(JSON.stringify({ aktif: true }));
+  });
+
+  test('aktif:false ile geri kapatma diske yansır', async () => {
+    const store = yeniStore();
+    await store.dispatch(sahurSayacAyariniGuncelle({ aktif: true }));
+    await store.dispatch(sahurSayacAyariniGuncelle({ aktif: false }));
+    expect(store.getState().sahurSayac.ayarlar.aktif).toBe(false);
+    expect(mockStore.get(KEY)).toBe(JSON.stringify({ aktif: false }));
+  });
+
+  test('boş kısmi ayar mevcut değeri korur (merge davranışı)', async () => {
+    const store = yeniStore();
+    await store.dispatch(sahurSayacAyariniGuncelle({ aktif: true }));
+    // Boş güncelleme: mevcut aktif:true korunmalı
+    await store.dispatch(sahurSayacAyariniGuncelle({}));
+    expect(store.getState().sahurSayac.ayarlar.aktif).toBe(true);
+  });
+
+  test('setItem fırlatınca thunk rejected olur, hata state e yazılır, ayarlar değişmez', async () => {
+    const store = yeniStore();
+    mockSetItemHata = new Error('disk dolu');
+
+    const sonuc = await store.dispatch(sahurSayacAyariniGuncelle({ aktif: true }));
+
+    expect(sonuc.type).toBe(sahurSayacAyariniGuncelle.rejected.type);
+    const state = store.getState().sahurSayac;
+    // Yazma başarısız → ayar eski değerinde kalmalı
+    expect(state.ayarlar.aktif).toBe(false);
+    expect(state.hata).toBe('disk dolu');
+    // Diske bir şey yazılmadı
+    expect(mockStore.has(KEY)).toBe(false);
+  });
+
+  test('rejected mesajsız hata için varsayılan mesaj kullanılır', () => {
+    const state = reducer(undefined, {
+      type: sahurSayacAyariniGuncelle.rejected.type,
+      error: {},
+    });
+    expect(state.hata).toBe('Ayar güncellenemedi');
+  });
+
+  test('fulfilled ayarlar payload ı doğrudan state e yazar', () => {
+    const state = reducer(undefined, {
+      type: sahurSayacAyariniGuncelle.fulfilled.type,
+      payload: { aktif: true },
+    });
+    expect(state.ayarlar).toEqual({ aktif: true });
+  });
+});
+
+describe('yukle ve guncelle birlikte (uçtan uca akış)', () => {
+  test('guncelle ile yazılan değer sonraki yukle ile geri okunur', async () => {
+    const store1 = yeniStore();
+    await store1.dispatch(sahurSayacAyariniGuncelle({ aktif: true }));
+
+    // Yeni bir store aynı diskten yüklesin
+    const store2 = yeniStore();
+    await store2.dispatch(sahurSayacAyarlariniYukle());
+    expect(store2.getState().sahurSayac.ayarlar.aktif).toBe(true);
+    // AsyncStorage gerçekten okundu
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith(KEY);
+  });
+});

--- a/src/presentation/store/__tests__/seriSlice.thunklarVeReducerlar.test.ts
+++ b/src/presentation/store/__tests__/seriSlice.thunklarVeReducerlar.test.ts
@@ -1,0 +1,563 @@
+/**
+ * seriSlice - thunk hata yollari, ayar/bildirim planlama, ozel gun thunk'lari,
+ * saf reducer'lar ve selector'lar icin DAVRANISSAL testler.
+ *
+ * Mevcut test dosyalari (seriSlice.test.ts / .reconcile / .butunluk) su yollari KAPSAMIYORDU:
+ * - seriVerileriniYukle.rejected (basarisiz / throw) -> hata mesaji + sonYukleme null kalir
+ * - seriAyarlariniGuncelle bildirim planlama dallari (sabit / otomatik+imsak / otomatik-imsaksiz / kapali)
+ * - seriKontrolet.rejected -> guncelleniyor=false + hata mesaji
+ * - kutlamayiKaldir / kutlamalariTemizle / hataTemizle / seriStateSifirla saf reducer'lari
+ * - ozelGunModuDurumunuGuncelle / ozelGunBaslat / ozelGunBitir / ozelGunIptal thunk'lari
+ * - seriOzetiSelector / ilkKutlamaSelector / kazanilanRozetSayisiSelector
+ */
+
+import { configureStore } from '@reduxjs/toolkit';
+import seriReducer, {
+  seriVerileriniYukle,
+  seriAyarlariniGuncelle,
+  seriKontrolet,
+  ozelGunModuDurumunuGuncelle,
+  ozelGunBaslat,
+  ozelGunBitir,
+  ozelGunIptal,
+  kutlamayiKaldir,
+  kutlamalariTemizle,
+  hataTemizle,
+  seriStateSifirla,
+  ilkKutlamaSelector,
+  kazanilanRozetSayisiSelector,
+  seriOzetiSelector,
+} from '../seriSlice';
+import { NamazAdi } from '../../../core/constants/UygulamaSabitleri';
+import { GunlukNamazlar } from '../../../core/types';
+
+// ==================== MOCKLAR ====================
+
+const mockLocalTumSeriVerileriniGetir = jest.fn();
+const mockLocalSeriAyarlariniKaydet = jest.fn();
+const mockLocalOzelGunAyarlariniKaydet = jest.fn();
+const mockLocalSeriDurumunuKaydet = jest.fn();
+const mockLocalRozetleriKaydet = jest.fn();
+const mockLocalBonusPuaniKaydet = jest.fn();
+const mockLocalBonusPuaniGetir = jest.fn(async () => ({ basarili: true, veri: 0 as number | null }));
+
+jest.mock('../../../data/local/LocalSeriServisi', () => ({
+  // Proxy ile lazy-bind: jest.mock fabrikasi const'lardan ONCE hoist edilir; dogrudan referans
+  // verirsek fabrika-eval aninda const'lar henuz undefined olur -> "is not a function".
+  localTumSeriVerileriniGetir: (...a: unknown[]) => mockLocalTumSeriVerileriniGetir(...a),
+  localSeriAyarlariniKaydet: (...a: unknown[]) => mockLocalSeriAyarlariniKaydet(...a),
+  localOzelGunAyarlariniKaydet: (...a: unknown[]) => mockLocalOzelGunAyarlariniKaydet(...a),
+  localSeriDurumunuKaydet: (...a: unknown[]) => mockLocalSeriDurumunuKaydet(...a),
+  localRozetleriKaydet: (...a: unknown[]) => mockLocalRozetleriKaydet(...a),
+  localBonusPuaniKaydet: (...a: unknown[]) => mockLocalBonusPuaniKaydet(...a),
+  localBonusPuaniGetir: () => mockLocalBonusPuaniGetir(),
+  localToparlanmaSayisiniArttir: jest.fn(async () => ({ basarili: true, veri: 0 })),
+  VARSAYILAN_OZEL_GUN_AYARLARI: {
+    ozelGunModuAktif: false,
+    aktifOzelGun: null,
+    gecmisKayitlar: [],
+  },
+}));
+
+// localVerileriSenkronizasyonIcinAl (reconcile yolu) — bu dosyada reconcile'i tetiklemiyoruz
+jest.mock('../../../data/local/LocalNamazServisi', () => ({
+  localVerileriSenkronizasyonIcinAl: jest.fn(async () => []),
+}));
+
+// BildirimServisi mock — planla/iptal cagrilarini gercek argumanlariyla yakalamak icin
+const mockBildirimPlanla = jest.fn();
+const mockBildirimIptalEt = jest.fn();
+jest.mock('../../../domain/services/BildirimServisi', () => ({
+  BildirimServisi: {
+    getInstance: jest.fn(() => ({
+      bildirimPlanla: (...a: unknown[]) => mockBildirimPlanla(...a),
+      bildirimIptalEt: (...a: unknown[]) => mockBildirimIptalEt(...a),
+    })),
+  },
+}));
+
+// KonumYoneticiServisi mock — imsak vaktini test bazinda degistirebilmek icin degisken
+let mockImsakVakti: Date | null = null;
+jest.mock('../../../domain/services/KonumYoneticiServisi', () => ({
+  KonumYoneticiServisi: {
+    getInstance: jest.fn(() => ({
+      sonrakiGunImsakVaktiGetir: jest.fn(() => mockImsakVakti),
+    })),
+  },
+}));
+
+// ==================== YARDIMCI ====================
+
+function storeOlustur() {
+  return configureStore({
+    reducer: { seri: seriReducer },
+    middleware: (gdm) => gdm({ serializableCheck: false }),
+  });
+}
+
+const tamNamazlar = (tarih: string): GunlukNamazlar => ({
+  tarih,
+  namazlar: [
+    { namazAdi: NamazAdi.Sabah, tamamlandi: true, tarih },
+    { namazAdi: NamazAdi.Ogle, tamamlandi: true, tarih },
+    { namazAdi: NamazAdi.Ikindi, tamamlandi: true, tarih },
+    { namazAdi: NamazAdi.Aksam, tamamlandi: true, tarih },
+    { namazAdi: NamazAdi.Yatsi, tamamlandi: true, tarih },
+  ],
+});
+
+const tamSeriVerileri = () => ({
+  basarili: true,
+  veri: {
+    seriDurumu: {
+      mevcutSeri: 10,
+      enUzunSeri: 15,
+      sonTamGun: '2026-02-14',
+      seriBaslangici: '2026-02-04',
+      toparlanmaDurumu: null,
+      dondurulduMu: false,
+      dondurulmaTarihi: null,
+      sonGuncelleme: new Date().toISOString(),
+    },
+    rozetler: [
+      { rozetId: 'ilk_adim', kazanildiMi: true, kazanilmaTarihi: '2026-02-10T00:00:00.000Z' },
+      { rozetId: 'aliskanlik_ustasi', kazanildiMi: false, kazanilmaTarihi: null },
+    ],
+    seviyeDurumu: {
+      mevcutSeviye: 3,
+      toplamPuan: 450,
+      mevcutSeviyePuani: 150,
+      sonrakiSeviyeKalanPuan: 150,
+      rank: 'Salik',
+      rankIkonu: '🌟',
+    },
+    ayarlar: {
+      tamGunEsigi: 5,
+      gunBitisSaati: '05:00',
+      bildirimlerAktif: true,
+      toparlanmaGunSayisi: 5,
+      gunSonuBildirimAktif: false,
+      gunSonuBildirimDk: 60,
+      gunSonuBildirimModu: 'otomatik' as const,
+      bildirimImsakOncesiDk: 30,
+      bildirimGunSecimi: 'ertesiGun' as const,
+      bildirimSaati: 4,
+      bildirimDakikasi: 0,
+    },
+    ozelGunAyarlari: { ozelGunModuAktif: false, aktifOzelGun: null, gecmisKayitlar: [] },
+    toplamKilinanNamaz: 50,
+    toparlanmaSayisi: 2,
+    mukemmelGunSayisi: 5,
+  },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockImsakVakti = null;
+  mockLocalBonusPuaniGetir.mockResolvedValue({ basarili: true, veri: 0 });
+  mockLocalSeriAyarlariniKaydet.mockResolvedValue({ basarili: true });
+  mockLocalOzelGunAyarlariniKaydet.mockResolvedValue({ basarili: true });
+  mockLocalSeriDurumunuKaydet.mockResolvedValue({ basarili: true });
+  mockLocalRozetleriKaydet.mockResolvedValue({ basarili: true });
+  mockLocalBonusPuaniKaydet.mockResolvedValue({ basarili: true });
+  mockBildirimPlanla.mockResolvedValue(undefined);
+  mockBildirimIptalEt.mockResolvedValue(undefined);
+});
+
+// ==================== seriVerileriniYukle.rejected ====================
+
+describe('seriVerileriniYukle hata yolu (rejected)', () => {
+  test('local yanit basarisiz ise hata mesaji set edilir ve sonYukleme null kalir', async () => {
+    mockLocalTumSeriVerileriniGetir.mockResolvedValue({
+      basarili: false,
+      hata: 'Disk okunamadi',
+    });
+    const store = storeOlustur();
+
+    const sonuc = await store.dispatch(seriVerileriniYukle());
+
+    expect(sonuc.type).toContain('rejected');
+    const s = store.getState().seri;
+    expect(s.yukleniyor).toBe(false);
+    expect(s.hata).toBe('Disk okunamadi');
+    // sonYukleme dolmamali -> sonraki seriKontrolet/reconcile condition guard ile bloklanir
+    expect(s.sonYukleme).toBeNull();
+    // veri yazilmadi -> baslangic durumu korunur
+    expect(s.seviyeDurumu).toBeNull();
+    expect(s.toplamKilinanNamaz).toBe(0);
+  });
+
+  test('basarili ama veri yoksa varsayilan hata mesaji kullanilir', async () => {
+    // basarili:true ama veri:null/undefined -> thunk "Seri verileri yuklenemedi" firlatir
+    mockLocalTumSeriVerileriniGetir.mockResolvedValue({ basarili: true, veri: null });
+    const store = storeOlustur();
+
+    const sonuc = await store.dispatch(seriVerileriniYukle());
+
+    expect(sonuc.type).toContain('rejected');
+    expect(store.getState().seri.hata).toBe('Seri verileri yuklenemedi');
+    expect(store.getState().seri.sonYukleme).toBeNull();
+  });
+
+  test('servis throw ederse hata yakalanir ve state tutarli kalir', async () => {
+    mockLocalTumSeriVerileriniGetir.mockRejectedValue(new Error('beklenmedik cokme'));
+    const store = storeOlustur();
+
+    const sonuc = await store.dispatch(seriVerileriniYukle());
+
+    expect(sonuc.type).toContain('rejected');
+    expect(store.getState().seri.hata).toBe('beklenmedik cokme');
+    expect(store.getState().seri.yukleniyor).toBe(false);
+  });
+
+  test('pending sirasinda yukleniyor=true ve onceki hata temizlenir', async () => {
+    const store = storeOlustur();
+    // Once bir hata olustur
+    mockLocalTumSeriVerileriniGetir.mockResolvedValueOnce({ basarili: false, hata: 'eski hata' });
+    await store.dispatch(seriVerileriniYukle());
+    expect(store.getState().seri.hata).toBe('eski hata');
+
+    // Yeni yukleme: askida tut, pending durumunu gozlemle
+    let coz: (v: ReturnType<typeof tamSeriVerileri>) => void;
+    mockLocalTumSeriVerileriniGetir.mockReturnValueOnce(
+      new Promise((resolve) => {
+        coz = resolve;
+      })
+    );
+    const beklemede = store.dispatch(seriVerileriniYukle());
+    // pending islendi: yukleniyor true, hata null'a cekildi
+    expect(store.getState().seri.yukleniyor).toBe(true);
+    expect(store.getState().seri.hata).toBeNull();
+
+    coz!(tamSeriVerileri());
+    await beklemede;
+    expect(store.getState().seri.yukleniyor).toBe(false);
+  });
+});
+
+// ==================== seriAyarlariniGuncelle + bildirim planlama ====================
+
+describe('seriAyarlariniGuncelle bildirim planlama dallari', () => {
+  test('gunSonuBildirimAktif=false ise bildirim IPTAL edilir, planlanmaz', async () => {
+    const store = storeOlustur();
+
+    const sonuc = await store.dispatch(
+      seriAyarlariniGuncelle({ ayarlar: { gunSonuBildirimAktif: false } })
+    );
+
+    expect(sonuc.type).toContain('fulfilled');
+    expect(mockBildirimIptalEt).toHaveBeenCalledWith('gun_sonu_hatirlatici');
+    expect(mockBildirimPlanla).not.toHaveBeenCalled();
+    // Ayar state'e yansidi
+    expect(store.getState().seri.ayarlar.gunSonuBildirimAktif).toBe(false);
+    // Disk'e kaydedildi (mevcut + degisiklik birlesimi)
+    expect(mockLocalSeriAyarlariniKaydet).toHaveBeenCalled();
+  });
+
+  test('SABIT mod: kullanicinin sectigi sabit saat/dakika ile planlanir', async () => {
+    const store = storeOlustur();
+
+    await store.dispatch(
+      seriAyarlariniGuncelle({
+        ayarlar: {
+          gunSonuBildirimAktif: true,
+          gunSonuBildirimModu: 'sabit',
+          bildirimSaati: 22,
+          bildirimDakikasi: 15,
+        },
+      })
+    );
+
+    expect(mockBildirimPlanla).toHaveBeenCalledTimes(1);
+    const cagriArgs = mockBildirimPlanla.mock.calls[0];
+    // (id, baslik, mesaj, saat, dakika)
+    expect(cagriArgs[0]).toBe('gun_sonu_hatirlatici');
+    expect(cagriArgs[3]).toBe(22); // saat
+    expect(cagriArgs[4]).toBe(15); // dakika
+    expect(mockBildirimIptalEt).not.toHaveBeenCalled();
+    expect(store.getState().seri.ayarlar.gunSonuBildirimModu).toBe('sabit');
+  });
+
+  test('OTOMATIK mod + imsak vakti var: imsaktan X dk once planlanir', async () => {
+    // Imsak 06:00, 30 dk once -> 05:30
+    mockImsakVakti = new Date(2026, 5, 25, 6, 0, 0);
+    const store = storeOlustur();
+
+    await store.dispatch(
+      seriAyarlariniGuncelle({
+        ayarlar: {
+          gunSonuBildirimAktif: true,
+          gunSonuBildirimModu: 'otomatik',
+          bildirimImsakOncesiDk: 30,
+        },
+      })
+    );
+
+    expect(mockBildirimPlanla).toHaveBeenCalledTimes(1);
+    const cagriArgs = mockBildirimPlanla.mock.calls[0];
+    expect(cagriArgs[3]).toBe(5); // saat = 05
+    expect(cagriArgs[4]).toBe(30); // dakika = 30 (06:00 - 30dk)
+  });
+
+  test('OTOMATIK mod + imsak vakti yok (konum yok): varsayilan 04:00 ile planlanir', async () => {
+    mockImsakVakti = null; // konum yok
+    const store = storeOlustur();
+
+    await store.dispatch(
+      seriAyarlariniGuncelle({
+        ayarlar: {
+          gunSonuBildirimAktif: true,
+          gunSonuBildirimModu: 'otomatik',
+          bildirimImsakOncesiDk: 60,
+        },
+      })
+    );
+
+    expect(mockBildirimPlanla).toHaveBeenCalledTimes(1);
+    const cagriArgs = mockBildirimPlanla.mock.calls[0];
+    expect(cagriArgs[3]).toBe(4); // varsayilan saat
+    expect(cagriArgs[4]).toBe(0); // varsayilan dakika
+  });
+
+  test('kismi ayar guncellemesi mevcut ayarlarla BIRLESTIRILIR', async () => {
+    const store = storeOlustur();
+
+    // Yalniz tamGunEsigi degistir -> diger varsayilan alanlar korunmali
+    await store.dispatch(seriAyarlariniGuncelle({ ayarlar: { tamGunEsigi: 3 } }));
+
+    const ayarlar = store.getState().seri.ayarlar;
+    expect(ayarlar.tamGunEsigi).toBe(3);
+    // Birlesim: dokunulmayan alan varsayilan degerini korur
+    expect(ayarlar.toparlanmaGunSayisi).toBe(3); // VARSAYILAN_SERI_AYARLARI.toparlanmaGunSayisi
+    expect(ayarlar.gunSonuBildirimModu).toBe('otomatik');
+    // Diske yazilan deger de birlesik olmali
+    const kaydedilen = mockLocalSeriAyarlariniKaydet.mock.calls[0][0];
+    expect(kaydedilen.tamGunEsigi).toBe(3);
+    expect(kaydedilen.bildirimSaati).toBe(4);
+  });
+});
+
+// ==================== seriKontrolet.rejected ====================
+
+describe('seriKontrolet hata yolu (rejected)', () => {
+  test('seri yuklendikten sonra kaydetme cokerse guncelleniyor=false ve hata set edilir', async () => {
+    const store = storeOlustur();
+    // Once yukle ki condition guard gecsin (sonYukleme dolar)
+    mockLocalTumSeriVerileriniGetir.mockResolvedValueOnce(tamSeriVerileri());
+    await store.dispatch(seriVerileriniYukle());
+    expect(store.getState().seri.sonYukleme).not.toBeNull();
+
+    // seriKontrolet icinde Promise.all kaydetmelerinden biri patlasin
+    mockLocalSeriDurumunuKaydet.mockRejectedValueOnce(new Error('kaydetme hatasi'));
+
+    // sonTamGun cok eski + bugun 5/5 -> seriDegisti=true (kaydetme yoluna girer)
+    const bugun = new Date().toISOString().split('T')[0];
+    const sonuc = await store.dispatch(
+      seriKontrolet({
+        bugunNamazlar: tamNamazlar(bugun),
+        dunNamazlar: null,
+      })
+    );
+
+    expect(sonuc.type).toContain('rejected');
+    const s = store.getState().seri;
+    expect(s.guncelleniyor).toBe(false);
+    expect(s.hata).toBe('kaydetme hatasi');
+  });
+});
+
+// ==================== SAF REDUCER'LAR ====================
+
+describe('saf reducer aksiyonlari (izole reducer cagrisi)', () => {
+  const k1 = { tip: 'seviye_atlandi' as const, baslik: 'A', mesaj: 'm', ikon: '⭐' };
+  const k2 = { tip: 'rozet_kazanildi' as const, baslik: 'B', mesaj: 'm', ikon: '🏅' };
+
+  const baslangic = () =>
+    seriReducer(undefined, { type: '@@INIT' });
+
+  test('kutlamayiKaldir ilk kutlamayi cikarir', () => {
+    const stateIle = {
+      ...baslangic(),
+      bekleyenKutlamalar: [k1, k2],
+    };
+    const yeni = seriReducer(stateIle, kutlamayiKaldir());
+    expect(yeni.bekleyenKutlamalar).toEqual([k2]);
+  });
+
+  test('kutlamalariTemizle kuyrugu bosaltir', () => {
+    const stateIle = { ...baslangic(), bekleyenKutlamalar: [k1, k2] };
+    const yeni = seriReducer(stateIle, kutlamalariTemizle());
+    expect(yeni.bekleyenKutlamalar).toEqual([]);
+  });
+
+  test('hataTemizle hata alanini null yapar', () => {
+    const stateIle = { ...baslangic(), hata: 'bir hata' };
+    const yeni = seriReducer(stateIle, hataTemizle());
+    expect(yeni.hata).toBeNull();
+  });
+
+  test('seriStateSifirla ayarlari KORUR, gerisini baslangica dondurur', () => {
+    const ozelAyar = { ...baslangic().ayarlar, tamGunEsigi: 4, bildirimSaati: 21 };
+    const stateIle = {
+      ...baslangic(),
+      ayarlar: ozelAyar,
+      toplamKilinanNamaz: 99,
+      bonusPuan: 500,
+      tabanPuan: 200,
+      seviyeDurumu: {
+        mevcutSeviye: 5,
+        toplamPuan: 700,
+        mevcutSeviyePuani: 0,
+        sonrakiSeviyeKalanPuan: 0,
+        rank: 'X',
+        rankIkonu: 'Y',
+      },
+      bekleyenKutlamalar: [k1],
+      hata: 'x',
+    };
+    const yeni = seriReducer(stateIle, seriStateSifirla());
+
+    // Ayarlar korunur
+    expect(yeni.ayarlar).toEqual(ozelAyar);
+    // Gerisi baslangica doner
+    expect(yeni.toplamKilinanNamaz).toBe(0);
+    expect(yeni.bonusPuan).toBe(0);
+    expect(yeni.tabanPuan).toBe(0);
+    expect(yeni.seviyeDurumu).toBeNull();
+    expect(yeni.bekleyenKutlamalar).toEqual([]);
+    expect(yeni.hata).toBeNull();
+    expect(yeni.sonYukleme).toBeNull();
+  });
+});
+
+// ==================== OZEL GUN THUNK'LARI ====================
+
+describe('ozel gun thunk\'lari', () => {
+  test('ozelGunModuDurumunuGuncelle aktif=true yapar ve diske kaydeder', async () => {
+    const store = storeOlustur();
+    const sonuc = await store.dispatch(ozelGunModuDurumunuGuncelle({ aktif: true }));
+
+    expect(sonuc.type).toContain('fulfilled');
+    expect(store.getState().seri.ozelGunAyarlari.ozelGunModuAktif).toBe(true);
+    const kaydedilen = mockLocalOzelGunAyarlariniKaydet.mock.calls[0][0];
+    expect(kaydedilen.ozelGunModuAktif).toBe(true);
+  });
+
+  test('ozelGunBaslat yeni aktif kayit olusturur (id + olusturulmaTarihi dolu)', async () => {
+    const store = storeOlustur();
+    const sonuc = await store.dispatch(
+      ozelGunBaslat({
+        baslangicTarihi: '2026-07-01',
+        bitisTarihi: '2026-07-10',
+        aciklama: 'Seyahat',
+      })
+    );
+
+    expect(sonuc.type).toContain('fulfilled');
+    const aktif = store.getState().seri.ozelGunAyarlari.aktifOzelGun!;
+    expect(aktif).not.toBeNull();
+    expect(aktif.baslangicTarihi).toBe('2026-07-01');
+    expect(aktif.bitisTarihi).toBe('2026-07-10');
+    expect(aktif.aciklama).toBe('Seyahat');
+    expect(typeof aktif.id).toBe('string');
+    expect(aktif.id.length).toBeGreaterThan(0);
+    expect(typeof aktif.olusturulmaTarihi).toBe('string');
+  });
+
+  test('ozelGunBitir aktif gunu gecmise tasir ve aktifi temizler', async () => {
+    const store = storeOlustur();
+    // Once bir ozel gun baslat
+    await store.dispatch(
+      ozelGunBaslat({ baslangicTarihi: '2026-07-01', bitisTarihi: '2026-07-05' })
+    );
+    const aktifId = store.getState().seri.ozelGunAyarlari.aktifOzelGun!.id;
+
+    const sonuc = await store.dispatch(ozelGunBitir());
+    expect(sonuc.type).toContain('fulfilled');
+
+    const oz = store.getState().seri.ozelGunAyarlari;
+    expect(oz.aktifOzelGun).toBeNull();
+    // Gecmis kayitlara EN BASA eklendi
+    expect(oz.gecmisKayitlar[0].id).toBe(aktifId);
+    expect(oz.gecmisKayitlar.length).toBe(1);
+  });
+
+  test('ozelGunBitir aktif gun yoksa mevcut ayarlari aynen dondurur (no-op)', async () => {
+    const store = storeOlustur();
+    // aktifOzelGun null (baslangic)
+    const sonuc = await store.dispatch(ozelGunBitir());
+    expect(sonuc.type).toContain('fulfilled');
+    expect(store.getState().seri.ozelGunAyarlari.aktifOzelGun).toBeNull();
+    expect(store.getState().seri.ozelGunAyarlari.gecmisKayitlar).toEqual([]);
+    // Aktif gun yoksa diske yazma yapilmaz
+    expect(mockLocalOzelGunAyarlariniKaydet).not.toHaveBeenCalled();
+  });
+
+  test('ozelGunIptal aktif gunu siler (gecmise TASIMAZ)', async () => {
+    const store = storeOlustur();
+    await store.dispatch(
+      ozelGunBaslat({ baslangicTarihi: '2026-08-01', bitisTarihi: '2026-08-03' })
+    );
+    expect(store.getState().seri.ozelGunAyarlari.aktifOzelGun).not.toBeNull();
+
+    const sonuc = await store.dispatch(ozelGunIptal());
+    expect(sonuc.type).toContain('fulfilled');
+
+    const oz = store.getState().seri.ozelGunAyarlari;
+    expect(oz.aktifOzelGun).toBeNull();
+    // Iptal -> gecmise EKLENMEZ (bitir'den farki)
+    expect(oz.gecmisKayitlar).toEqual([]);
+  });
+
+  test('ozelGunIptal aktif gun yoksa no-op (diske yazmaz)', async () => {
+    const store = storeOlustur();
+    const sonuc = await store.dispatch(ozelGunIptal());
+    expect(sonuc.type).toContain('fulfilled');
+    expect(mockLocalOzelGunAyarlariniKaydet).not.toHaveBeenCalled();
+  });
+});
+
+// ==================== SELECTOR'LAR ====================
+
+describe('selector\'lar', () => {
+  test('kazanilanRozetSayisiSelector yalniz kazanildiMi=true rozetleri sayar', async () => {
+    const store = storeOlustur();
+    mockLocalTumSeriVerileriniGetir.mockResolvedValueOnce(tamSeriVerileri());
+    await store.dispatch(seriVerileriniYukle());
+
+    // Yuklenen veride 1 kazanilmis (ilk_adim) + 1 kazanilmamis (aliskanlik_ustasi)
+    expect(kazanilanRozetSayisiSelector(store.getState())).toBe(1);
+  });
+
+  test('ilkKutlamaSelector kuyruk bosken null, doluyken ilk elemani dondurur', () => {
+    const k = { tip: 'seviye_atlandi' as const, baslik: 'A', mesaj: 'm', ikon: '⭐' };
+    const bosState = { seri: seriReducer(undefined, { type: '@@INIT' }) };
+    expect(ilkKutlamaSelector(bosState)).toBeNull();
+
+    const doluState = {
+      seri: {
+        ...bosState.seri,
+        bekleyenKutlamalar: [k, { ...k, baslik: 'B' }],
+      },
+    };
+    expect(ilkKutlamaSelector(doluState)).toEqual(k);
+  });
+
+  test('seriOzetiSelector seriDurumu null iken cokmeden bir ozet dondurur', () => {
+    const bosState = { seri: seriReducer(undefined, { type: '@@INIT' }) };
+    // seriDurumu null; selector seriOzetiniOlustur'a guvenle delege etmeli (throw etmemeli)
+    const ozet = seriOzetiSelector(bosState);
+    expect(ozet).toBeDefined();
+  });
+
+  test('seriOzetiSelector memoize: ayni girdide ayni referansi dondurur', async () => {
+    const store = storeOlustur();
+    mockLocalTumSeriVerileriniGetir.mockResolvedValueOnce(tamSeriVerileri());
+    await store.dispatch(seriVerileriniYukle());
+
+    const ilk = seriOzetiSelector(store.getState());
+    const ikinci = seriOzetiSelector(store.getState());
+    // createSelector memoize -> degismeyen girdide ayni referans
+    expect(ikinci).toBe(ilk);
+  });
+});


### PR DESCRIPTION
## Özet
Yüksek-değerli katmanlara **davranışsal** test ekleyip coverage'ı yükseltir ve **klasör-bazlı ratchet eşiği** ile kazanımı kilitler. Yalnız test + jest.config; **prod/kaynak kod değişmedi.**

## Sonuç (coverage)
| | Önce | Sonra |
|---|---|---|
| 🧠 domain (iş mantığı) | %82 / B73 | **%94 / B87** |
| 💾 data (depolama) | %55 / B37 | **%91.5 / B64** |
| Global Lines / Branch | %53 / %37 | **%64 / %45** |
| Test sayısı | 1001 | **1299 (+298)** |

15 test dosyası: data (LocalSeri/LocalKonum/LocalVakitBildirim), domain servisleri (KazaHesaplayici/TurkiyeKonum/ArkaplanGorev/KonumTakip/NamazVaktiHesaplayici/VakitSayacBildirim), store slice'ları (kaza/namaz/seri/muhafiz/sahurSayac), useYeniOzellikler hook.

## Mühendislik kararı (neden bu kadar, neden burası)
- **Kritik mantığı** (kullanıcıyı bozabilecek: vakit/puan/kaza/seri/depolama) yükseğe çektik; **UI render'ı bilerek düşük bıraktık** (pahalı/kırılgan, düşük sinyal — "coverage tiyatrosu"ndan kaçındık).
- **Klasör-bazlı eşik:** domain≥88/78, data≥78/53 (aggregate, dizin-yolu anahtarı — negatif testle aktif+aggregate doğrulandı: domain lines 99 → 94.38'de fail); geri kalan tolere edilebilir global 35/20. Kritik katmanların erozyonu artık CI'da engellenir, UI testine zorlamadan.
- Bundan sonrası **reaktif/cerrahi**: iş düştükçe (bug fix / mantık değişimi) regresyon testi eklenir — global yüzde hedefi YOK.

## Kalite
- Tüm testler **davranışsal** (çıktı/state/yan-etki üzerinde gerçek assertion; coverage-gaming yok), **flaky yok** (sabit tarih yok → TarihYardimcisi/fake timers; Immer-donmuş dizi kopyalama).
- Subagent-driven (**opus**) yazım + dosya başına adversarial review + **final opus whole-branch review: "Ready to merge YES"**, 0 Critical/0 Important.
- `npm run verify` + `npm test -- --coverage` (threshold): **83 suite / 1299 test pass**, lint 0 error.

## Kalan (bloklamaz, opsiyonel) — final review'ın 3 kozmetik Minor'ı
- `NamazVaktiHesaplayiciServisi` testinde bir `kalanSureMs` yalnız type-check (değer değil) — istenirse sıkılaştırılır.
- Test'lerde `as any` (proje konvansiyonu, TakvimServisi.test.ts deseni) ve `defineTask` callback yakalama (doğru ama yük-sırasına duyarlı) — not düşüldü.

## Not
Master'a merge auto-release tetikler (~24dk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
