### PR TITLE
Güvenlik: WebPusulaView içinde WebView originWhitelist daraltıldı

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,7 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={['https://qiblafinder.withgoogle.com', 'https://*.google.com', 'https://*.gstatic.com', 'https://*.googleapis.com', 'https://*.googleusercontent.com', 'about:blank']}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
WebView yapılandırmasındaki konum yetkisinin (`geolocationEnabled={true}`) aşırı geniş bir kaynak listesi (`originWhitelist={['https://*', 'about:blank']}`) ile kullanılması, kötü niyetli bir yönlendirme durumunda kullanıcı konumunun yetkisiz sitelere sızma riskini barındırıyordu.

**Bulgu:** `src/presentation/screens/KibleSayfasi/WebPusulaView.tsx:133`
```tsx
        allowUniversalAccessFromFileURLs={false}
        originWhitelist={['https://*', 'about:blank']}
        onError={() => setHataOlustu(true)}
```

**Neden önemli:** `geolocationEnabled={true}` aktif olduğu için, eğer WebView herhangi bir sebeple saldırganın kontrolündeki bir HTTPS sitesine yönlendirilirse, bu site doğrudan uygulamanın konum erişim iznini kullanarak kullanıcının yerini öğrenebilir. Bu, OWASP MASVS standartlarına (M4: Insecure Authentication/Authorization / M7: Client Code Quality) aykırıdır.

**Minimal değişiklik:** WebView bileşeninin `originWhitelist` özelliği, Google Qibla Finder ve onun bağlı olduğu ana Google servis alan adlarıyla (ve dahili kullanım için `about:blank`) sınırlandırılarak değiştirildi.

**Doğrulama:** `npm run verify` komutu başarıyla çalıştırıldı ve tüm testler geçti.

---
*PR created automatically by Jules for task [11470754942787568787](https://jules.google.com/task/11470754942787568787) started by @furkanisikay*