### PR TITLE
fix(security): WebView originWhitelist kısıtlanarak güvenlik artırıldı

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,14 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={[
+          'https://qiblafinder.withgoogle.com',
+          'https://*.google.com',
+          'https://*.gstatic.com',
+          'https://*.googleapis.com',
+          'https://*.googleusercontent.com',
+          'about:blank',
+        ]}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
Kıble bulucu sayfasındaki `WebView` bileşeninde, gezinmeye izin verilen alan adlarını belirleyen `originWhitelist` özelliği `['https://*', 'about:blank']` şeklinde tüm alan adlarına izin verecek kadar geniş ayarlanmıştı. Bu yapılandırma, uygulamanın olası WebView manipülasyonlarına veya istenmeyen sayfalara yönlendirilmesine açık olmasına yol açıyordu.

`originWhitelist` listesi daraltılarak, sadece Qibla Finder'in çalışması için gereken temel Google alan adları ile sınırlandırıldı. Değişiklik, diğer WebView güvenlik mekanizmalarını bozmadan ve performans kaybına neden olmadan uygulandı. `npm run verify` komutu başarılı oldu.

---
*PR created automatically by Jules for task [9650275638992279797](https://jules.google.com/task/9650275638992279797) started by @furkanisikay*