### PR TITLE
perf(AnaSayfa): PagerView dizisini modül seviyesine taşıyarak re-render maliyetini düşür

### DIFF
--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -43,6 +43,7 @@ const GECMIS_GUN_SAYISI = 90; // 3 ay geri
 const GELECEK_GUN_SAYISI = 1; // 1 gun ileri (yarin)
 const TOPLAM_SAYFA_SAYISI = GECMIS_GUN_SAYISI + 1 + GELECEK_GUN_SAYISI; // 3 ay geri + bugun + yarin
 const BASLANGIC_SAYFA_INDEKSI = GECMIS_GUN_SAYISI; // bugun
+const SAYFA_INDEKSLERI = Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i);
 
 export const AnaSayfa: React.FC = () => {
   const navigation = useNavigation<RootNavigationProp>();
@@ -678,7 +679,7 @@ export const AnaSayfa: React.FC = () => {
           oncekiTamamlananRef.current = 0;
         }}
       >
-        {Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(sayfaIndeksi => (
+        {SAYFA_INDEKSLERI.map(sayfaIndeksi => (
           <View key={sayfaIndeksi}>
             {Math.abs(sayfaIndeksi - mevcutSayfaIndeksi) <= 1 ? sayfaIcerigiOlustur(sayfaIndeksi) : <View className="flex-1" />}
           </View>


### PR DESCRIPTION
**AnaSayfa performans iyileştirmesi: Gereksiz dizi referansı oluşturma (allocation) engellendi.**

**Bulgu:** `src/presentation/screens/AnaSayfa.tsx:681`
```tsx
{Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(sayfaIndeksi => (
```
**Neden önemli:** `AnaSayfa` bileşeni sıklıkla durum (state) güncellenen ve baştan çizilen (re-render) bir ekrandır. `PagerView` içinde sayfaları oluştururken `Array.from` metodunun doğrudan JSX içerisinde kullanılması, her çizimde yeni bir dizi örneğinin (instance) bellekte oluşturulmasına (allocation) ve React'in alt bileşenler için değişmiş bir referans algılamasına yol açıyordu. `AGENTS.md` bellek notlarında da bahsedildiği üzere bu durum (gereksiz yeniden çizim / re-render) yaklaşık 0.15ms'lik fazladan yüke sebep oluyordu.
 
**Değişiklik:** `Array.from` çağrısı, bileşen gövdesinin dışına `SAYFA_INDEKSLERI` adıyla statik bir modül sabiti olarak taşındı. `TOPLAM_SAYFA_SAYISI` zaten modül seviyesinde sabit olduğu için bu işlem tamamen güvenlidir. JSX içerisinde de direkt bu sabit dizinin `.map` fonksiyonu çağrıldı.
 
**Doğrulama:** `npm run verify` komutu başarıyla çalıştırıldı (typecheck, lint, test). Değişiklik minimaldir ve uygulama işlevselliğine bir etkisi yoktur.

---
*PR created automatically by Jules for task [4401566978167312428](https://jules.google.com/task/4401566978167312428) started by @furkanisikay*