### PR TITLE
Güvenlik: WebView originWhitelist aşırı yetkilendirmesi giderildi

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,14 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={[
+          'https://qiblafinder.withgoogle.com',
+          'https://*.google.com',
+          'https://*.gstatic.com',
+          'https://*.googleapis.com',
+          'https://*.googleusercontent.com',
+          'about:blank'
+        ]}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
Kıble sayfasındaki `WebPusulaView` bileşeninde `originWhitelist` yapılandırması aşırı gevşek (`['https://*', 'about:blank']`) bırakılmıştı. Bu durum, `geolocationEnabled` (konum erişimi) aktif olan WebView'un saldırgan kontrolündeki rastgele bir HTTPS sayfasına yönlendirilmesi halinde hassas konum verisinin sızdırılmasına yol açabilirdi. 

Bu değişiklikle birlikte `originWhitelist`, Qibla Finder'ın çalışması için gereken spesifik Google domain'leri ile (qiblafinder.withgoogle.com, *.google.com, *.gstatic.com vb.) sınırlandırıldı ve potansiyel yetki sızıntısı engellendi.

`npm run verify` başarıyla geçmiştir.

---
*PR created automatically by Jules for task [17742854648735640777](https://jules.google.com/task/17742854648735640777) started by @furkanisikay*