### PR TITLE
VakitKarti bileşenine erişilebilirlik (a11y) desteği eklendi

### DIFF
--- a/src/presentation/components/home/VakitKarti.tsx
+++ b/src/presentation/components/home/VakitKarti.tsx
@@ -126,6 +126,8 @@ export const VakitKarti: React.FC<VakitKartiProps> = ({
                     }}
                     onPress={onTamamla}
                     disabled={tamamlandi || kilitli}
+                    accessibilityRole="button"
+                    accessibilityLabel={tamamlandi ? "Kılındı" : (kilitli ? "Vakit Girmedi" : "Kılındı Olarak İşaretle")}
                 >
                     <FontAwesome5
                         name={tamamlandi ? "check-circle" : (kilitli ? "clock" : "pray")}


### PR DESCRIPTION
Bu PR, uygulamanın temel akışında yer alan `VakitKarti` bileşenindeki erişilebilirlik (accessibility) eksikliğini giderir. 

1. **Özet (sade dil):** Namaz vakti kartındaki ana "Kılındı Olarak İşaretle" düğmesi, ekran okuyucu (örneğin VoiceOver veya TalkBack) kullanan kullanıcılar için bir "düğme" olarak tanınmıyor ve ne işe yaradığı tam olarak seslendirilmiyordu.
2. **Bulgu:** `src/presentation/components/home/VakitKarti.tsx:135` numaralı satırda yer alan `TouchableOpacity` bileşeninde `accessibilityRole` ve `accessibilityLabel` özellikleri eksikti.
3. **Kullanıcıya etkisi:** Görme engelli veya ekran okuyucu yardımıyla uygulamayı kullanan bir kişi, bu düğmenin bir işlem yapabileceğini ve o anki işlevinin (örneğin vakit girmediği veya namazın çoktan kılındığı gibi) ne olduğunu sesli olarak duyamıyordu. Bu da temel etkileşimi büyük ölçüde aksatıyordu.
4. **Düzeltme:** Mevcut `TouchableOpacity` bileşenine `accessibilityRole="button"` eklendi. Düğmenin durumuna (kilitli veya tamamlandı) göre dinamik olarak hesaplanan ("Kılındı", "Vakit Girmedi" veya "Kılındı Olarak İşaretle") bir `accessibilityLabel` değeri verildi.
5. **Doğrulama:** `npm run verify` komutu çalıştırıldı ve kod başarıyla testlerden geçti. Yeni uyarılara yol açılmadı.

---
*PR created automatically by Jules for task [17428517495628858782](https://jules.google.com/task/17428517495628858782) started by @furkanisikay*