### PR TITLE
Güvenlik: WebPusulaView originWhitelist yapılandırması sıkılaştırıldı

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,14 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={[
+          'https://qiblafinder.withgoogle.com',
+          'https://*.google.com',
+          'https://*.gstatic.com',
+          'https://*.googleapis.com',
+          'https://*.googleusercontent.com',
+          'about:blank'
+        ]}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
Bu PR, `WebPusulaView.tsx` içindeki WebView `originWhitelist` yapılandırmasını sıkılaştırarak olası bir güvenlik açığını kapatır.

**Bulgu:** `src/presentation/screens/KibleSayfasi/WebPusulaView.tsx:133`
Mevcut durumda, `originWhitelist={['https://*', 'about:blank']}` olarak ayarlanmıştı. 

**Neden Önemli:**
Bu aşırı esnek kural (wildcard), WebView'in herhangi bir HTTPS alan adını yüklemesine izin vermektedir. `geolocationEnabled={true}` ayarı da aktif olduğundan, kötü niyetli bir sayfanın WebView içinde çalıştırılması durumunda konum verisi sızabilir veya XSS gibi vektörlere zemin hazırlayabilir (OWASP MASVS - Platform Etkileşimi / Güvenilmeyen İçerik Yürütme).

**Minimal Değişiklik:**
`originWhitelist`, sadece Qibla Finder'ın ihtiyaç duyduğu Google servislerini (ve uygulamanın izin verdiği alan adlarını) kapsayacak şekilde açıkça listelenmiştir:
```tsx
originWhitelist={[
  'https://qiblafinder.withgoogle.com',
  'https://*.google.com',
  'https://*.gstatic.com',
  'https://*.googleapis.com',
  'https://*.googleusercontent.com',
  'about:blank'
]}
```
Bu değişiklik, hedeflenen işlevselliği korurken, WebView tabanlı saldırı yüzeyini önemli ölçüde daraltır.

**Doğrulama:**
`npm run verify` komutu başarıyla çalıştırıldı; tüm test, lint ve tip kontrolleri hatasız geçmiştir.

---
*PR created automatically by Jules for task [11211115028075004126](https://jules.google.com/task/11211115028075004126) started by @furkanisikay*