### PR TITLE
fix: Kıble sayfası WebView originWhitelist kısıtlaması

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,14 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={[
+          'https://qiblafinder.withgoogle.com',
+          'https://*.google.com',
+          'https://*.gstatic.com',
+          'https://*.googleapis.com',
+          'https://*.googleusercontent.com',
+          'about:blank',
+        ]}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
Kıble sayfası (WebPusulaView) içerisindeki WebView yapılandırmasında `originWhitelist` özelliği `['https://*']` gibi aşırı genel bir izin içeriyordu. Bu durum, kullanıcının WebView içinde rastgele, güvenilmeyen etki alanlarına yönlendirilmesi riskini taşıyordu.

Değişiklik ile birlikte bu liste, yalnızca Google Qibla Finder'ın çalışması için gerekli olan spesifik alan adlarını (`qiblafinder.withgoogle.com`, `*.google.com`, `*.gstatic.com`, `*.googleapis.com`, `*.googleusercontent.com`) ve dâhilî `about:blank` sayfasını içerecek şekilde katılaştırıldı. Herhangi bir gerileme (regression) veya hata oluşturmadığı `npm run verify` komutuyla doğrulanmıştır.

---
*PR created automatically by Jules for task [8925669684317916880](https://jules.google.com/task/8925669684317916880) started by @furkanisikay*