### PR TITLE
Sayı Giriş Modalı donanım geri tuşu sorunu giderildi

### DIFF
--- a/src/presentation/components/common/SayiGirisModali.tsx
+++ b/src/presentation/components/common/SayiGirisModali.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
 } from 'react-native';
 import { useRenkler } from '../../../core/theme';
+import { useDonanimGeriTusu } from '../../hooks/useDonanimGeriTusu';
 
 /**
  * Tek sayı girişli onay modalı (number-pad + İptal/Onay).
@@ -39,6 +40,7 @@ export const SayiGirisModali: React.FC<SayiGirisModaliProps> = ({
   onOnay,
 }) => {
   const renkler = useRenkler();
+  useDonanimGeriTusu(gorunur, onIptal);
 
   return (
     <Modal visible={gorunur} transparent animationType="fade" onRequestClose={onIptal}>

--- a/src/presentation/components/common/__tests__/SayiGirisModali.test.tsx
+++ b/src/presentation/components/common/__tests__/SayiGirisModali.test.tsx
@@ -13,7 +13,12 @@ jest.mock('../../../../core/theme', () => ({
   }),
 }));
 
+jest.mock('../../../hooks/useDonanimGeriTusu', () => ({
+  useDonanimGeriTusu: jest.fn(),
+}));
+
 import { SayiGirisModali } from '../SayiGirisModali';
+import { useDonanimGeriTusu } from '../../../hooks/useDonanimGeriTusu';
 
 const temelProps = {
   gorunur: true,
@@ -82,6 +87,11 @@ describe('SayiGirisModali', () => {
   it('gorunur=false iken Modal visible=false geçirir (modal gizli)', () => {
     const { UNSAFE_getByType } = render(<SayiGirisModali {...temelProps} gorunur={false} />);
     expect(UNSAFE_getByType(Modal).props.visible).toBe(false);
+  });
+
+  it('useDonanimGeriTusu hookunu gorunur ve onIptal ile çağırır', () => {
+    render(<SayiGirisModali {...temelProps} gorunur={true} />);
+    expect(useDonanimGeriTusu).toHaveBeenCalledWith(true, temelProps.onIptal);
   });
 
   // Gap 3: Sayı doğrulaması UPSTREAM'dedir — bu bileşen ham metni filtrelemeden iletir.


### PR DESCRIPTION
Android'de New Architecture etkinleştirildiğinde, standart React Native `<Modal>` bileşeni `onRequestClose` prop'unu donanım geri tuşuna basıldığında her zaman güvenilir bir şekilde çağırmamaktadır. Bu durum uygulamanın diğer bölümlerinde (`BildirimModali`, `KerahatOnayModal` vb.) `useDonanimGeriTusu` hook'u kullanılarak aşılmış olsa da, kaza defteri formlarında vb. kullanılan `SayiGirisModali` bileşeninde bu eksikti. 

**Bulgu:** `src/presentation/components/common/SayiGirisModali.tsx:43`
**Kullanıcıya Etkisi:** Android cihazı kullanan bir kullanıcı, sayı girişi modalı açıkken donanım geri tuşuna bastığında modal kapanmayabilir ve uygulamada takılı kalma hissi oluşturabilir.
**Düzeltme:** Mevcut `useDonanimGeriTusu` hook'u projeye dahil edilip modal görünürlüğüne bağlandı.
**Doğrulama:** `npm run verify` başarıyla geçti.

---
*PR created automatically by Jules for task [4903611385195231621](https://jules.google.com/task/4903611385195231621) started by @furkanisikay*