### PR TITLE
Güvenlik: WebPusulaView originWhitelist yapılandırmasını daralt

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,14 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={[
+          'https://qiblafinder.withgoogle.com',
+          'https://*.google.com',
+          'https://*.gstatic.com',
+          'https://*.googleapis.com',
+          'https://*.googleusercontent.com',
+          'about:blank',
+        ]}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
**Özet (sade dil):** Kıble Bulucu (WebView) bileşeninde tüm internet adreslerine (`https://*`) izin veren açık bir ayar bulunmaktaydı; bu ayar daraltılarak sadece uygulamanın ihtiyaç duyduğu resmi Google adreslerine izin verildi, böylece sayfanın ele geçirilme veya zararlı yönlendirme riski kapatıldı.

**Bulgu:** `src/presentation/screens/KibleSayfasi/WebPusulaView.tsx` dosyasında bulunan `WebView` bileşeninin `originWhitelist` özelliği, `['https://*', 'about:blank']` olarak yapılandırılmıştı.

**Neden önemli:** Bu durum OWASP Mobile Top 10 listesindeki Güvensiz Yapılandırma (Insecure Configuration) kategorisine girer. Eğer ana sayfa bir şekilde saldırgan tarafından yönlendirilirse (açık yönlendirmeler, vs.), aşırı izinli bir liste, zararlı sitelerin uygulamanın WebView alanı içinde (konum vb. haklara potansiyel olarak sahipmiş gibi) yüklenmesine olanak tanır.

**Minimal değişiklik:** Kodu daraltarak yalnızca ilgili alan adlarını ve alt alan adlarını (örn: `https://*.google.com`, `https://qiblafinder.withgoogle.com`, `about:blank`) kapsayacak şekilde güvenli bir whitelist listesi tanımladım. Bu değişiklik sadece WebView ayarını sıkar ve işlevsel bir kırılma yaratmaz.

**Doğrulama:** `npm run verify` başarıyla geçmiştir (0 hata).

---
*PR created automatically by Jules for task [7760659330310963599](https://jules.google.com/task/7760659330310963599) started by @furkanisikay*