### PR TITLE
perf: AnaSayfa bileşeni JS iş parçacığı re-render optimizasyonu

### DIFF
--- a/src/presentation/components/home/HomeHeader.tsx
+++ b/src/presentation/components/home/HomeHeader.tsx
@@ -26,7 +26,7 @@ interface HomeHeaderProps {
  * @param {HomeHeaderProps} props - Component props.
  * @returns {React.JSX.Element} Header with date info, qibla and streak buttons.
  */
-export const HomeHeader: React.FC<HomeHeaderProps> = ({
+export const HomeHeader = React.memo<HomeHeaderProps>(({
     tarih,
     streakGun,
     bugunMu,
@@ -160,4 +160,6 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             </View>
         </View>
     );
-};
+});
+
+HomeHeader.displayName = 'HomeHeader';

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -43,6 +43,7 @@ const GECMIS_GUN_SAYISI = 90; // 3 ay geri
 const GELECEK_GUN_SAYISI = 1; // 1 gun ileri (yarin)
 const TOPLAM_SAYFA_SAYISI = GECMIS_GUN_SAYISI + 1 + GELECEK_GUN_SAYISI; // 3 ay geri + bugun + yarin
 const BASLANGIC_SAYFA_INDEKSI = GECMIS_GUN_SAYISI; // bugun
+const SAYFA_INDEKSLERI = Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i);
 
 export const AnaSayfa: React.FC = () => {
   const navigation = useNavigation<RootNavigationProp>();
@@ -473,6 +474,10 @@ export const AnaSayfa: React.FC = () => {
   const tumunuTamamla = () => dispatch(tumNamazlariTamamla({ tarih: mevcutTarih }));
   const tumunuSifirla = () => dispatch(tumNamazlariSifirla({ tarih: mevcutTarih }));
 
+  const handleTarihTikla = useCallback(() => setTarihSeciciGorunur(true), []);
+  const handleSeriTikla = useCallback(() => setSeriModalGorunur(true), []);
+  const handleKibleTikla = useCallback(() => navigation?.navigate('KibleSayfasi'), [navigation]);
+
   // Sayfa içeriği render
   const sayfaIcerigiOlustur = (sayfaIndeksi: number) => {
     const sayfaTarihi = sayfaIndeksiniTariheCevir(sayfaIndeksi);
@@ -608,9 +613,9 @@ export const AnaSayfa: React.FC = () => {
         streakGun={seriOzeti ? seriOzeti.mevcutSeri : 0}
         bugunMu={bugunMu(mevcutTarih)}
         aktifGunMu={mevcutTarih === aktifGun}
-        onTarihTikla={() => setTarihSeciciGorunur(true)}
-        onSeriTikla={() => setSeriModalGorunur(true)}
-        onKibleTikla={() => navigation?.navigate('KibleSayfasi')}
+        onTarihTikla={handleTarihTikla}
+        onSeriTikla={handleSeriTikla}
+        onKibleTikla={handleKibleTikla}
         toparlanmaModu={seriOzeti?.toparlanmaModu}
         toparlanmaIlerleme={seriOzeti?.toparlanmaIlerleme}
       />
@@ -678,7 +683,7 @@ export const AnaSayfa: React.FC = () => {
           oncekiTamamlananRef.current = 0;
         }}
       >
-        {Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(sayfaIndeksi => (
+        {SAYFA_INDEKSLERI.map(sayfaIndeksi => (
           <View key={sayfaIndeksi}>
             {Math.abs(sayfaIndeksi - mevcutSayfaIndeksi) <= 1 ? sayfaIcerigiOlustur(sayfaIndeksi) : <View className="flex-1" />}
           </View>


### PR DESCRIPTION
AnaSayfa'da her 1 saniyede bir güncellenen kalan süre sayacı nedeniyle sayfa içerisindeki diğer bileşenlerin (özellikle `HomeHeader` ve dizi atamalarının) gereksiz yere baştan oluşturulmasını engellemek için performans optimizasyonları yapıldı.

**Bulgu:** `src/presentation/screens/AnaSayfa.tsx:681` `Array.from` çağrısı, ve `src/presentation/components/home/HomeHeader.tsx`'e geçilen inline fonksiyon propları (onTarihTikla, onSeriTikla vb.) her saniye yeniden oluşturuluyordu.
**Neden önemli:** `AnaSayfa`, her 1 saniyede bir JS iş parçacığını timer sebebiyle yeniden çiziyor (re-render). Bu süreçte büyük bir dizinin baştan allocate edilmesi ve Header'ın değişmemişken tekrar çizilmesi ciddi bir "hot-path" gereksiz yük oluşturur.
**Değişiklik:** `Array.from` bileşen dışına statik bir `SAYFA_INDEKSLERI` sabiti olarak çıkarıldı. `HomeHeader` `React.memo` ile sarıldı ve inline prop'lar `useCallback` ile sabitlendi.
**Doğrulama:** `npm run verify` komutu başarıyla geçildi (typecheck, lint, ve tüm testler yeşil).

---
*PR created automatically by Jules for task [18421897932669219088](https://jules.google.com/task/18421897932669219088) started by @furkanisikay*