### PR TITLE
fix(security): WebView originWhitelist kuralını sadece güvenilir Google domainlerine kısıtla

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,14 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={[
+          'https://*.google.com',
+          'https://*.googleapis.com',
+          'https://*.gstatic.com',
+          'https://*.googleusercontent.com',
+          'https://qiblafinder.withgoogle.com',
+          'about:blank'
+        ]}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
Bu PR, `WebPusulaView.tsx` dosyasında bulunan ve fazla yetkilendirilmiş olan `originWhitelist` yapılandırmasını daraltmaktadır.

### Bulgu
`src/presentation/screens/KibleSayfasi/WebPusulaView.tsx:133` satırında `originWhitelist={['https://*', 'about:blank']}` kullanımı mevcuttu.

### Neden Önemli?
Bu kadar geniş bir izin (OWASP: Security Misconfiguration / Insecure Data Storage - WebView Misconfig), araya giren zararlı yönlendirmeler ya da iframe saldırıları durumunda WebView'in güvensiz ve uygulamanın amacından sapmış harici adreslere gezinmesine olanak tanıyabilirdi. Saldırgan, kullanıcının güvenini suistimal edebilir veya sahte içerik sunabilirdi.

### Minimal Değişiklik
`originWhitelist` sadece gereken ve `qiblafinder.withgoogle.com` tarafından ihtiyaç duyulan ilgili Google alt alan adları ile kısıtlandırılmıştır. Bu kısıtlama, sistemin çalışmasını bozmadan dışarıya yönelik istenmeyen gezinme risklerini engeller.

### Doğrulama
Yapılan değişiklik sonrası `npm run verify` komutu başarılı bir şekilde çalıştırılmış ve tüm testlerin eksiksiz geçtiği doğrulanmıştır.

---
*PR created automatically by Jules for task [483942249248119582](https://jules.google.com/task/483942249248119582) started by @furkanisikay*