### PR TITLE
fix(security): WebView originWhitelist zafiyeti giderildi

### DIFF
--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,7 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://qiblafinder.withgoogle.com', 'https://*.google.com', 'https://*.gstatic.com', 'https://*.googleapis.com', 'https://*.googleusercontent.com', 'about:blank']}
+        originWhitelist={['https://qiblafinder.withgoogle.com', 'https://google.com', 'https://*.google.com', 'https://gstatic.com', 'https://*.gstatic.com', 'https://googleapis.com', 'https://*.googleapis.com', 'https://googleusercontent.com', 'https://*.googleusercontent.com', 'about:blank']}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (

--- a/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
+++ b/src/presentation/screens/KibleSayfasi/WebPusulaView.tsx
@@ -130,7 +130,7 @@ export const WebPusulaView = () => {
         allowFileAccess={false}
         allowFileAccessFromFileURLs={false}
         allowUniversalAccessFromFileURLs={false}
-        originWhitelist={['https://*', 'about:blank']}
+        originWhitelist={['https://qiblafinder.withgoogle.com', 'https://*.google.com', 'https://*.gstatic.com', 'https://*.googleapis.com', 'https://*.googleusercontent.com', 'about:blank']}
         onError={() => setHataOlustu(true)}
         onHttpError={() => setHataOlustu(true)}
         renderLoading={() => (


### PR DESCRIPTION
**Zafiyet:** `WebPusulaView.tsx` dosyasında `WebView` bileşeninin `originWhitelist` özelliği `['https://*', 'about:blank']` şeklinde kullanılarak çok geniş bir izin tanınmıştı. Bu esnek yapı, kötü niyetli bir yönlendirme veya iframe üzerinden uygulamanın native konum erişim izinlerinin kötüye kullanılması riskini taşımaktadır.

**Neden önemli:** OWASP standartlarına ve en az yetki prensibine (Principle of Least Privilege) göre, WebView bileşenlerinde yalnızca açıkça tanımlanmış ve güvenilir olan domainlerin yüklenmesine izin verilmelidir.

**Minimal değişiklik:** `src/presentation/screens/KibleSayfasi/WebPusulaView.tsx` dosyasında `originWhitelist` listesindeki `https://*` kuralı kaldırılarak, yalnızca güvenilir hostları (`https://qiblafinder.withgoogle.com`, `https://*.google.com`, `https://*.gstatic.com`, `https://*.googleapis.com`, `https://*.googleusercontent.com`, `about:blank`) içerecek şekilde sınırlandırıldı. Bu, mevcut Qibla bulucu işlevselliğini bozmadan WebView ortamını sıkılaştırmaktadır.

**Doğrulama:** `npm run verify` çalıştırılmış ve tüm testler/lint kuralları hatasız geçmiştir.

---
*PR created automatically by Jules for task [12346027486052412185](https://jules.google.com/task/12346027486052412185) started by @furkanisikay*