### PR TITLE
SayiGirisModali'nde Android geri tuşu davranışının düzeltilmesi

### DIFF
--- a/src/presentation/components/common/SayiGirisModali.tsx
+++ b/src/presentation/components/common/SayiGirisModali.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
 } from 'react-native';
 import { useRenkler } from '../../../core/theme';
+import { useDonanimGeriTusu } from '../../hooks/useDonanimGeriTusu';
 
 /**
  * Tek sayı girişli onay modalı (number-pad + İptal/Onay).
@@ -39,6 +40,8 @@ export const SayiGirisModali: React.FC<SayiGirisModaliProps> = ({
   onOnay,
 }) => {
   const renkler = useRenkler();
+
+  useDonanimGeriTusu(gorunur, onIptal);
 
   return (
     <Modal visible={gorunur} transparent animationType="fade" onRequestClose={onIptal}>

--- a/src/presentation/components/common/__tests__/SayiGirisModali.test.tsx
+++ b/src/presentation/components/common/__tests__/SayiGirisModali.test.tsx
@@ -13,7 +13,12 @@ jest.mock('../../../../core/theme', () => ({
   }),
 }));
 
+jest.mock('../../../hooks/useDonanimGeriTusu', () => ({
+  useDonanimGeriTusu: jest.fn(),
+}));
+
 import { SayiGirisModali } from '../SayiGirisModali';
+import { useDonanimGeriTusu } from '../../../hooks/useDonanimGeriTusu';
 
 const temelProps = {
   gorunur: true,
@@ -28,6 +33,15 @@ const temelProps = {
 };
 
 describe('SayiGirisModali', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('gorunur olduğunda useDonanimGeriTusu kancasını çağırmalıdır', () => {
+    render(<SayiGirisModali {...temelProps} />);
+    expect(useDonanimGeriTusu).toHaveBeenCalledWith(true, temelProps.onIptal);
+  });
+
   it('onay butonu onOnay çağırır', () => {
     const onOnay = jest.fn();
     const { getByLabelText } = render(<SayiGirisModali {...temelProps} onOnay={onOnay} />);


### PR DESCRIPTION
Uygulamayı kullanan biri, sayı girdiği ekranlarda Android'in fiziksel "Geri" tuşuna bastığında pencerenin kapanmaması sorununu yaşıyordu; bu sorun giderildi. 

**Bulgu:** `src/presentation/components/common/SayiGirisModali.tsx:44` (ilgili `<Modal>`)

**Kullanıcıya etkisi:** Kullanıcı sayı giriş ekranında (örneğin kaza hedefi belirlerken) Android cihazının donanımsal geri tuşuna (hardware back button) bastığında modal kapanmıyor, bu da tutarlılığı (consistency) bozuyor ve uygulamanın doğal olmayan bir his vermesine neden oluyordu. New Architecture (Yeni Mimari) sebebiyle Modal'ın `onRequestClose` prop'u Android'de güvenilir çalışmadığı için bu durum yaşanıyordu.

**Düzeltme:** Mevcut design-system standardı olan `useDonanimGeriTusu` hook'u (kancası) bileşene dahil edildi ve modalın `gorunur` (visible) durumu ile iptal işlevi bu kancaya bağlandı. Testler de bu hook'u taklit edecek (mock) şekilde güncellendi.

**Doğrulama:** `npm run verify` komutu başarıyla çalıştırıldı ve tüm testler/lint kuralları hatasız geçti.

---
*PR created automatically by Jules for task [9005859073061753092](https://jules.google.com/task/9005859073061753092) started by @furkanisikay*