### PR TITLE
perf(anasayfa): HomeHeader gereksiz yeniden çizim optimizasyonu

### DIFF
--- a/src/presentation/components/home/HomeHeader.tsx
+++ b/src/presentation/components/home/HomeHeader.tsx
@@ -26,7 +26,7 @@ interface HomeHeaderProps {
  * @param {HomeHeaderProps} props - Component props.
  * @returns {React.JSX.Element} Header with date info, qibla and streak buttons.
  */
-export const HomeHeader: React.FC<HomeHeaderProps> = ({
+export const HomeHeader: React.FC<HomeHeaderProps> = React.memo(({
     tarih,
     streakGun,
     bugunMu,
@@ -160,4 +160,5 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             </View>
         </View>
     );
-};
+});
+HomeHeader.displayName = 'HomeHeader';

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -473,6 +473,11 @@ export const AnaSayfa: React.FC = () => {
   const tumunuTamamla = () => dispatch(tumNamazlariTamamla({ tarih: mevcutTarih }));
   const tumunuSifirla = () => dispatch(tumNamazlariSifirla({ tarih: mevcutTarih }));
 
+  // HomeHeader için stabil referanslı callback'ler
+  const handleTarihTikla = useCallback(() => setTarihSeciciGorunur(true), []);
+  const handleSeriTikla = useCallback(() => setSeriModalGorunur(true), []);
+  const handleKibleTikla = useCallback(() => navigation?.navigate('KibleSayfasi'), [navigation]);
+
   // Sayfa içeriği render
   const sayfaIcerigiOlustur = (sayfaIndeksi: number) => {
     const sayfaTarihi = sayfaIndeksiniTariheCevir(sayfaIndeksi);
@@ -608,9 +613,9 @@ export const AnaSayfa: React.FC = () => {
         streakGun={seriOzeti ? seriOzeti.mevcutSeri : 0}
         bugunMu={bugunMu(mevcutTarih)}
         aktifGunMu={mevcutTarih === aktifGun}
-        onTarihTikla={() => setTarihSeciciGorunur(true)}
-        onSeriTikla={() => setSeriModalGorunur(true)}
-        onKibleTikla={() => navigation?.navigate('KibleSayfasi')}
+        onTarihTikla={handleTarihTikla}
+        onSeriTikla={handleSeriTikla}
+        onKibleTikla={handleKibleTikla}
         toparlanmaModu={seriOzeti?.toparlanmaModu}
         toparlanmaIlerleme={seriOzeti?.toparlanmaIlerleme}
       />


### PR DESCRIPTION
**AnaSayfa üzerindeki tarih/seri başlık alanının her saniye gereksiz yere yeniden çizilmesi (re-render) engellendi.**

- **Bulgu:** `src/presentation/screens/AnaSayfa.tsx:611` satırlarında `<HomeHeader onTarihTikla={() => ...} ... />` şeklinde "inline" fonksiyon geçiliyordu. Ayrıca `src/presentation/components/home/HomeHeader.tsx` bileşeni memoize (hafızaya alınmış) değildi.
- **Neden önemli:** `AnaSayfa` içindeki vakit sayacı her saniye çalıştığı için bileşen güncelleniyor. Bu nedenle `HomeHeader` da kendisine ait bir veri değişmese bile saniyede bir kez gereksiz yere (re-render) çalışıyordu, ki bu da sıcak bir yoldur.
- **Değişiklik:** `HomeHeader` bileşeni dışa aktarılırken `React.memo` ile sarmalandı. `AnaSayfa` içerisindeki `onTarihTikla`, `onSeriTikla`, `onKibleTikla` fonksiyonları ise `useCallback` ile sabit referanslara dönüştürüldü.
- **Doğrulama:** `npm run verify` (typecheck + lint + test) başarıyla geçti.

---
*PR created automatically by Jules for task [892157312095808213](https://jules.google.com/task/892157312095808213) started by @furkanisikay*