### PR TITLE
perf: HomeHeader gereksiz re-render onarımı

### DIFF
--- a/src/presentation/components/home/HomeHeader.tsx
+++ b/src/presentation/components/home/HomeHeader.tsx
@@ -26,7 +26,7 @@ interface HomeHeaderProps {
  * @param {HomeHeaderProps} props - Component props.
  * @returns {React.JSX.Element} Header with date info, qibla and streak buttons.
  */
-export const HomeHeader: React.FC<HomeHeaderProps> = ({
+export const HomeHeader = React.memo<HomeHeaderProps>(({
     tarih,
     streakGun,
     bugunMu,
@@ -160,4 +160,4 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             </View>
         </View>
     );
-};
+});

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -471,6 +471,11 @@ export const AnaSayfa: React.FC = () => {
 
   // Toplu islemler gunlukNamazlar'i degistirir -> useEffect (seriKontrolet -> reconcile) otomatik kosar
   const tumunuTamamla = () => dispatch(tumNamazlariTamamla({ tarih: mevcutTarih }));
+
+  const handleTarihTikla = useCallback(() => setTarihSeciciGorunur(true), []);
+  const handleSeriTikla = useCallback(() => setSeriModalGorunur(true), []);
+  const handleKibleTikla = useCallback(() => navigation?.navigate('KibleSayfasi'), [navigation]);
+
   const tumunuSifirla = () => dispatch(tumNamazlariSifirla({ tarih: mevcutTarih }));
 
   // Sayfa içeriği render
@@ -608,9 +613,9 @@ export const AnaSayfa: React.FC = () => {
         streakGun={seriOzeti ? seriOzeti.mevcutSeri : 0}
         bugunMu={bugunMu(mevcutTarih)}
         aktifGunMu={mevcutTarih === aktifGun}
-        onTarihTikla={() => setTarihSeciciGorunur(true)}
-        onSeriTikla={() => setSeriModalGorunur(true)}
-        onKibleTikla={() => navigation?.navigate('KibleSayfasi')}
+        onTarihTikla={handleTarihTikla}
+        onSeriTikla={handleSeriTikla}
+        onKibleTikla={handleKibleTikla}
         toparlanmaModu={seriOzeti?.toparlanmaModu}
         toparlanmaIlerleme={seriOzeti?.toparlanmaIlerleme}
       />


### PR DESCRIPTION
AnaSayfa'da sayaç (kalanSureStr) kaynaklı saniyede bir gerçekleşen state güncellemelerinin `HomeHeader` bileşenini gereksiz yere yeniden çizmesine (re-render) neden olduğu tespit edildi.

**Bulgu:** `src/presentation/components/home/HomeHeader.tsx:29`
`AnaSayfa`'da sayaç her saniye güncellendiğinde tüm sayfa renderlanıyordu. `HomeHeader` sadece `string`, `number`, `boolean` gibi ilkel (primitive) props aldığından, memoization için ideal bir adaydı ancak memoize edilmemişti.

**Neden önemli:** `AnaSayfa.tsx` içerisindeki `kalanSureStr` saniyede bir güncellenir ve ana ekranın re-render'ına yol açar. `HomeHeader`'a iletilen `onTarihTikla`, `onSeriTikla` ve `onKibleTikla` gibi fonksiyonlar inline olarak oluşturulduğu için referansları her render'da değişiyor ve bu da alt bileşenlerin de boş yere yeniden çizilmesine neden oluyordu. Bu işlem JS thread üzerinde gereksiz bir yük yaratır.

**Değişiklik:**
1. `HomeHeader` bileşeni gereksiz çizimleri (re-render) önlemek için `React.memo` ile sarıldı.
2. `AnaSayfa.tsx` içinde `HomeHeader`'a paslanan `onTarihTikla`, `onSeriTikla` ve `onKibleTikla` anonim fonksiyonları `useCallback` ile sarmalanarak referanslarının sabit (stable) kalması sağlandı. Böylece `React.memo`'nun çalışması garanti altına alındı.

**Doğrulama:**
Değişiklik sonrası `npm run verify` komutu çalıştırılmış ve TypeScript kontrolü, linter ile test adımları başarıyla tamamlanmıştır. Yeni bir bağımlılık veya gereksiz dosya değişikliği yapılmamıştır.

---
*PR created automatically by Jules for task [6909172261619393471](https://jules.google.com/task/6909172261619393471) started by @furkanisikay*