### PR TITLE
Fix accessibility on VakitKarti button

### DIFF
--- a/src/presentation/components/home/VakitKarti.tsx
+++ b/src/presentation/components/home/VakitKarti.tsx
@@ -126,6 +126,9 @@ export const VakitKarti: React.FC<VakitKartiProps> = ({
                     }}
                     onPress={onTamamla}
                     disabled={tamamlandi || kilitli}
+                    accessibilityRole="button"
+                    accessibilityState={{ disabled: tamamlandi || kilitli }}
+                    accessibilityLabel={tamamlandi ? "Kılındı" : (kilitli ? "Vakit Girmedi" : "Kılındı Olarak İşaretle")}
                 >
                     <FontAwesome5
                         name={tamamlandi ? "check-circle" : (kilitli ? "clock" : "pray")}


### PR DESCRIPTION
Ana ekrandaki namaz işaretleme butonu (VakitKarti), ekran okuyucu (screen reader) kullanan kullanıcılar için etkileşimli bir buton olduğunu ve mevcut durumunu ("Vakit Girmedi", "Kılındı", vb.) bildirmiyordu. Bu durum, görme engelli kullanıcıların ana uygulama akışını takip etmesini zorlaştırıyordu.

`src/presentation/components/home/VakitKarti.tsx` dosyasındaki ana `TouchableOpacity` bileşenine `accessibilityRole="button"`, dinamik `accessibilityState={{ disabled }}` ve duruma göre değişen Türkçe `accessibilityLabel` eklendi.

`npm run verify` komutu ile doğrulandı.

---
*PR created automatically by Jules for task [4663038750615823699](https://jules.google.com/task/4663038750615823699) started by @furkanisikay*