### PR TITLE
Performans: AnaSayfa üzerinde gereksiz yeniden çizimleri azaltma

### DIFF
--- a/src/presentation/components/home/HomeHeader.tsx
+++ b/src/presentation/components/home/HomeHeader.tsx
@@ -26,7 +26,7 @@ interface HomeHeaderProps {
  * @param {HomeHeaderProps} props - Component props.
  * @returns {React.JSX.Element} Header with date info, qibla and streak buttons.
  */
-export const HomeHeader: React.FC<HomeHeaderProps> = ({
+export const HomeHeader: React.FC<HomeHeaderProps> = React.memo(({
     tarih,
     streakGun,
     bugunMu,
@@ -160,4 +160,6 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             </View>
         </View>
     );
-};
+});
+
+HomeHeader.displayName = 'HomeHeader';

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -43,6 +43,7 @@ const GECMIS_GUN_SAYISI = 90; // 3 ay geri
 const GELECEK_GUN_SAYISI = 1; // 1 gun ileri (yarin)
 const TOPLAM_SAYFA_SAYISI = GECMIS_GUN_SAYISI + 1 + GELECEK_GUN_SAYISI; // 3 ay geri + bugun + yarin
 const BASLANGIC_SAYFA_INDEKSI = GECMIS_GUN_SAYISI; // bugun
+const SAYFA_INDEKSLERI = Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i);
 
 export const AnaSayfa: React.FC = () => {
   const navigation = useNavigation<RootNavigationProp>();
@@ -473,6 +474,11 @@ export const AnaSayfa: React.FC = () => {
   const tumunuTamamla = () => dispatch(tumNamazlariTamamla({ tarih: mevcutTarih }));
   const tumunuSifirla = () => dispatch(tumNamazlariSifirla({ tarih: mevcutTarih }));
 
+  // Memoized handlers for HomeHeader to prevent unnecessary re-renders
+  const handleTarihTikla = useCallback(() => setTarihSeciciGorunur(true), []);
+  const handleSeriTikla = useCallback(() => setSeriModalGorunur(true), []);
+  const handleKibleTikla = useCallback(() => navigation?.navigate('KibleSayfasi'), [navigation]);
+
   // Sayfa içeriği render
   const sayfaIcerigiOlustur = (sayfaIndeksi: number) => {
     const sayfaTarihi = sayfaIndeksiniTariheCevir(sayfaIndeksi);
@@ -608,9 +614,9 @@ export const AnaSayfa: React.FC = () => {
         streakGun={seriOzeti ? seriOzeti.mevcutSeri : 0}
         bugunMu={bugunMu(mevcutTarih)}
         aktifGunMu={mevcutTarih === aktifGun}
-        onTarihTikla={() => setTarihSeciciGorunur(true)}
-        onSeriTikla={() => setSeriModalGorunur(true)}
-        onKibleTikla={() => navigation?.navigate('KibleSayfasi')}
+        onTarihTikla={handleTarihTikla}
+        onSeriTikla={handleSeriTikla}
+        onKibleTikla={handleKibleTikla}
         toparlanmaModu={seriOzeti?.toparlanmaModu}
         toparlanmaIlerleme={seriOzeti?.toparlanmaIlerleme}
       />
@@ -678,7 +684,7 @@ export const AnaSayfa: React.FC = () => {
           oncekiTamamlananRef.current = 0;
         }}
       >
-        {Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(sayfaIndeksi => (
+        {SAYFA_INDEKSLERI.map(sayfaIndeksi => (
           <View key={sayfaIndeksi}>
             {Math.abs(sayfaIndeksi - mevcutSayfaIndeksi) <= 1 ? sayfaIcerigiOlustur(sayfaIndeksi) : <View className="flex-1" />}
           </View>


### PR DESCRIPTION
AnaSayfa (Ana Ekran) üzerinde gereksiz yeniden çizim (re-render) tetiklenmesini engelleyerek JS-thread performansını artırdım.

- **Bulgu:** `src/presentation/screens/AnaSayfa.tsx:681` (PagerView içerisindeki `Array.from` dizisi) ve `src/presentation/components/home/HomeHeader.tsx:29` (Memoize edilmemiş başlık bileşeni).
- **Neden önemli:** `AnaSayfa` geri sayım sayacı yüzünden sık sık render edilir (saniyede bir). Her renderda inline `Array.from` yeni bir dizi referansı yaratıyordu (gereksiz allocation) ve `HomeHeader` kendisine iletilen `onTarihTikla`, `onSeriTikla` gibi fonksiyonların referansı her renderda değiştiği için gereksiz yere tamamen yeniden çiziliyordu (gereksiz re-render). Bu, kaydırma (scroll) ve animasyonlarda (hot path) drop framelere neden olabilir.
- **Değişiklik:** `HomeHeader` bileşeni `React.memo` ile sarmalandı. `AnaSayfa.tsx` içinde `HomeHeader`'a aktarılan callback'ler `useCallback` ile stabilize edildi. PagerView'e verilen 92 elemanlı liste de fonksiyon dışında tanımlanan `SAYFA_INDEKSLERI` sabitine alındı, böylece render başına yeni liste üretimi önlendi.
- **Doğrulama:** `npm run verify` komutu (typecheck, lint, test) başarıyla geçti (1300 test passed). Ayrıca ölçülmedi.

---
*PR created automatically by Jules for task [2201886168776295809](https://jules.google.com/task/2201886168776295809) started by @furkanisikay*