### PR TITLE
AnaSayfa üst bilgisi (HomeHeader) için gereksiz re-render optimizasyonu

### DIFF
--- a/src/presentation/components/home/HomeHeader.tsx
+++ b/src/presentation/components/home/HomeHeader.tsx
@@ -26,7 +26,7 @@ interface HomeHeaderProps {
  * @param {HomeHeaderProps} props - Component props.
  * @returns {React.JSX.Element} Header with date info, qibla and streak buttons.
  */
-export const HomeHeader: React.FC<HomeHeaderProps> = ({
+export const HomeHeader = React.memo<HomeHeaderProps>(({
     tarih,
     streakGun,
     bugunMu,
@@ -160,4 +160,6 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             </View>
         </View>
     );
-};
+});
+
+HomeHeader.displayName = 'HomeHeader';

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -460,6 +460,11 @@ export const AnaSayfa: React.FC = () => {
     namazToggleRef.current(namazAdi as NamazAdi, val);
   }, []);
 
+  // HomeHeader (React.memo) icin referans-kararli callback'ler
+  const handleTarihTikla = useCallback(() => setTarihSeciciGorunur(true), []);
+  const handleSeriTikla = useCallback(() => setSeriModalGorunur(true), []);
+  const handleKibleTikla = useCallback(() => navigation?.navigate('KibleSayfasi'), [navigation]);
+
   const suankiVakitTamamla = () => {
     if (vakitBilgisi && vakitBilgisi.vakit) {
       const namazAdi = servisToNamazAdi[vakitBilgisi.vakit];
@@ -608,9 +613,9 @@ export const AnaSayfa: React.FC = () => {
         streakGun={seriOzeti ? seriOzeti.mevcutSeri : 0}
         bugunMu={bugunMu(mevcutTarih)}
         aktifGunMu={mevcutTarih === aktifGun}
-        onTarihTikla={() => setTarihSeciciGorunur(true)}
-        onSeriTikla={() => setSeriModalGorunur(true)}
-        onKibleTikla={() => navigation?.navigate('KibleSayfasi')}
+        onTarihTikla={handleTarihTikla}
+        onSeriTikla={handleSeriTikla}
+        onKibleTikla={handleKibleTikla}
         toparlanmaModu={seriOzeti?.toparlanmaModu}
         toparlanmaIlerleme={seriOzeti?.toparlanmaIlerleme}
       />


### PR DESCRIPTION
AnaSayfa ekranındaki geri sayım sayacı her saniye güncellendiğinde, HomeHeader bileşeni gereksiz yere yeniden çiziliyordu (re-render). Bu değişiklik ile HomeHeader bileşenini `React.memo` içine aldım ve AnaSayfa'dan gönderilen fonksiyonları (onTarihTikla vb.) `useCallback` ile sarmalayarak referans stabilitesi sağladım. Böylece, aktif saniyeler boyunca JS iş parçacığındaki gereksiz render maliyeti ortadan kaldırıldı.

**Bulgu:** 
`src/presentation/components/home/HomeHeader.tsx:29`
`export const HomeHeader = React.memo<HomeHeaderProps>(({ ... })`

`src/presentation/screens/AnaSayfa.tsx:463`
```typescript
  // HomeHeader (React.memo) icin referans-kararli callback'ler
  const handleTarihTikla = useCallback(() => setTarihSeciciGorunur(true), []);
  const handleSeriTikla = useCallback(() => setSeriModalGorunur(true), []);
  const handleKibleTikla = useCallback(() => navigation?.navigate('KibleSayfasi'), [navigation]);
```

**Neden önemli:** `AnaSayfa` üzerinde her saniye güncellenen bir geri sayım sayacı (timer) var. Bu durum sayfanın saniyede bir kez render edilmesine yol açar; `HomeHeader` gibi statik işlevi olan üst bileşenler memoize edilmediğinde gereksiz yere baştan çizilir ve bu durum ana iş parçacığında yük oluşturur (JS-thread blocking).

**Değişiklik:** 
* `HomeHeader.tsx` bileşeni `React.memo` ile sarmalandı.
* `AnaSayfa.tsx` içerisindeki inline `() => setX(true)` fonksiyon çağrıları `useCallback` ile önbelleğe alındı.

**Doğrulama:** `npm run verify` komutu tüm kod tabanında sıfır hatayla geçti. Yapılan değişiklikler HomeHeader testleri tarafından kırılmadan çalıştı.

---
*PR created automatically by Jules for task [969866485973406521](https://jules.google.com/task/969866485973406521) started by @furkanisikay*