### PR TITLE
Ana sayfadaki namaz kartları ve günlük akış öğeleri için erişilebilirlik (a11y) iyileştirmesi

### DIFF
--- a/src/presentation/components/home/VakitAkisi.tsx
+++ b/src/presentation/components/home/VakitAkisi.tsx
@@ -113,6 +113,8 @@ export const VakitAkisi = React.memo<VakitAkisiProps>(({
                             activeOpacity={0.7}
                             onPress={() => onVakitTikla(namaz.namazAdi, !namaz.tamamlandi)}
                             disabled={pasifMi}
+                            accessibilityRole="button"
+                            accessibilityLabel={`${namaz.namazAdi} vakti${tamamlandi ? ', kılındı' : (aktifMi ? ', vakti geldi' : (pasifMi ? ', vakit girmedi' : ', vakti bekleniyor'))}`}
                         >
                             {aktifMi && (
                                 <View className="absolute right-0 top-0 bottom-0 w-24 opacity-5 pointer-events-none z-0"

--- a/src/presentation/components/home/VakitKarti.tsx
+++ b/src/presentation/components/home/VakitKarti.tsx
@@ -126,6 +126,8 @@ export const VakitKarti: React.FC<VakitKartiProps> = ({
                     }}
                     onPress={onTamamla}
                     disabled={tamamlandi || kilitli}
+                    accessibilityRole="button"
+                    accessibilityLabel={tamamlandi ? "Namaz kılındı" : (kilitli ? "Vakit girmedi" : "Kılındı olarak işaretle")}
                 >
                     <FontAwesome5
                         name={tamamlandi ? "check-circle" : (kilitli ? "clock" : "pray")}


### PR DESCRIPTION
Ekran okuyucu (screen reader) kullanan kullanıcılar için ana sayfadaki namaz vakti kartları ve günlük akış listesindeki butonlar anlamsız okunuyordu; bu durumu iyileştirmek için dinamik durum etiketleri (accessibilityLabel) ve buton rolleri eklendi.

`src/presentation/components/home/VakitAkisi.tsx` ve `src/presentation/components/home/VakitKarti.tsx` dosyalarındaki etkileşimli alanlara (TouchableOpacity) namazın o anki durumunu (vakit geldi, kılındı, bekleniyor) bildiren etiketler yerleştirildi. Düzeltmeler sonrasında `npm run verify` komutu başarıyla geçmiştir.

---
*PR created automatically by Jules for task [7195795700546043362](https://jules.google.com/task/7195795700546043362) started by @furkanisikay*