### PR TITLE
refactor: AnaSayfa PagerView inline array allocation iyileştirmesi

### DIFF
--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -44,6 +44,8 @@ const GELECEK_GUN_SAYISI = 1; // 1 gun ileri (yarin)
 const TOPLAM_SAYFA_SAYISI = GECMIS_GUN_SAYISI + 1 + GELECEK_GUN_SAYISI; // 3 ay geri + bugun + yarin
 const BASLANGIC_SAYFA_INDEKSI = GECMIS_GUN_SAYISI; // bugun
 
+const SAYFA_INDEKSLERI = Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i);
+
 export const AnaSayfa: React.FC = () => {
   const navigation = useNavigation<RootNavigationProp>();
   const dispatch = useAppDispatch();
@@ -678,7 +680,7 @@ export const AnaSayfa: React.FC = () => {
           oncekiTamamlananRef.current = 0;
         }}
       >
-        {Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(sayfaIndeksi => (
+        {SAYFA_INDEKSLERI.map(sayfaIndeksi => (
           <View key={sayfaIndeksi}>
             {Math.abs(sayfaIndeksi - mevcutSayfaIndeksi) <= 1 ? sayfaIcerigiOlustur(sayfaIndeksi) : <View className="flex-1" />}
           </View>


### PR DESCRIPTION
AnaSayfa bileşeninde PagerView içindeki sayfa haritalaması için kullanılan dizi (`Array.from({ length: TOPLAM_SAYFA_SAYISI })`), saniyede bir tetiklenen (geri sayım sayacı yüzünden) her yeniden çizimde (re-render) baştan oluşturuluyordu. Bu işlem, JS iş parçacığında gereksiz bellek tahsisine ve çöp toplamaya (garbage collection) neden olmaktaydı.

Bu dizi üretimi, bileşen dışına `SAYFA_INDEKSLERI` adında sabit bir değer olarak taşındı. Böylece performans iyileştirildi ve gereksiz tahsisler engellendi.

**Bulgu:** `src/presentation/screens/AnaSayfa.tsx:683`
`Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i)` çağrısı her render'da yeni bir dizi oluşturuyordu.

**Neden önemli:** `AnaSayfa`, uygulamanın merkezidir ve saniyede bir güncellenen geri sayım sayacı nedeniyle çok sık re-render almaktadır. Bu durum her renderda yaklaşık 92 elemanlı yeni bir dizinin oluşturulmasına ve GC yüküne sebep oluyordu, bu açıkça sıcak yoldaki (hot path) bir gereksiz tahsisti.

**Değişiklik:** Dizi oluşturma işlemi bileşen dışına statik bir sabit (`SAYFA_INDEKSLERI`) olarak taşındı ve haritalama bu sabit üzerinden yapıldı. Bu sayede bellek tahsisi bir keze indirildi.

**Doğrulama:** `npm run verify` komutu başarıyla çalıştırıldı ve tüm testler (typecheck + lint + test) geçti. Performans iyileşmesi, bellek tahsisinde net bir mantıksal azalma ile sağlanmıştır (ilave bir süre ölçümüne gerek duyulmamıştır).

---
*PR created automatically by Jules for task [8043008760383094760](https://jules.google.com/task/8043008760383094760) started by @furkanisikay*