### PR TITLE
Design System Fix: Use theme token for confirmation button text in SayiGirisModali

### DIFF
--- a/src/presentation/components/common/SayiGirisModali.tsx
+++ b/src/presentation/components/common/SayiGirisModali.tsx
@@ -79,7 +79,7 @@ export const SayiGirisModali: React.FC<SayiGirisModaliProps> = ({
               accessibilityRole="button"
               accessibilityLabel={onayMetni}
             >
-              <Text style={styles.modalOnayMetin}>{onayMetni}</Text>
+              <Text style={[styles.modalOnayMetin, { color: renkler.birincilMetin }]}>{onayMetni}</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -142,6 +142,5 @@ const styles = StyleSheet.create({
   modalOnayMetin: {
     fontSize: 15,
     fontWeight: '700',
-    color: '#fff',
   },
 });


### PR DESCRIPTION
SayiGirisModali bileşenindeki "Onayla" butonunda kullanılan metin rengi, temalandırma (theming) kurallarını ihlal ederek doğrudan `#fff` olarak sabitlenmişti (hardcoded). Bu durum, potansiyel tema değişikliklerinde tutarsızlıklara yol açabilirdi.
   
   Bu PR, söz konusu sabit hex renk değerini (`#fff`) kaldırmakta ve yerine tasarım sistemi kapsamında `useRenkler` kancasından (hook) sağlanan `renkler.birincilMetin` tema token'ını (belirtecini) kullanmaktadır. Bu sayede onay butonundaki metin, `birincil` arka plan rengine uyumlu biçimde mevcut temadan (açık/koyu mod ve renk paletleri) dinamik olarak değer alacaktır.
   
   `src/presentation/components/common/SayiGirisModali.tsx:145` satırındaki sabit renk kaldırılmış ve JSX render bölümünde ilgili tokene referans verilmiştir. Yapılan düzeltme sonrasında `npm run verify` komutu çalıştırılarak typecheck (tip kontrolü), lint (sözdizimi ve kural denetimi) ve mevcut tüm testlerin başarıyla geçtiği doğrulanmıştır.

---
*PR created automatically by Jules for task [1391263696222858951](https://jules.google.com/task/1391263696222858951) started by @furkanisikay*