### PR TITLE
perf: AnaSayfa üzerinde gereksiz dizi belleğe ayırma işlemini düzelt

### DIFF
--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -43,6 +43,7 @@ const GECMIS_GUN_SAYISI = 90; // 3 ay geri
 const GELECEK_GUN_SAYISI = 1; // 1 gun ileri (yarin)
 const TOPLAM_SAYFA_SAYISI = GECMIS_GUN_SAYISI + 1 + GELECEK_GUN_SAYISI; // 3 ay geri + bugun + yarin
 const BASLANGIC_SAYFA_INDEKSI = GECMIS_GUN_SAYISI; // bugun
+const SAYFA_INDEKSLERI = Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i);
 
 export const AnaSayfa: React.FC = () => {
   const navigation = useNavigation<RootNavigationProp>();
@@ -678,7 +679,7 @@ export const AnaSayfa: React.FC = () => {
           oncekiTamamlananRef.current = 0;
         }}
       >
-        {Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(sayfaIndeksi => (
+        {SAYFA_INDEKSLERI.map(sayfaIndeksi => (
           <View key={sayfaIndeksi}>
             {Math.abs(sayfaIndeksi - mevcutSayfaIndeksi) <= 1 ? sayfaIcerigiOlustur(sayfaIndeksi) : <View className="flex-1" />}
           </View>


### PR DESCRIPTION
- **Özet:** Ana ekranda her saniye güncellenen geri sayım sayacı yüzünden sürekli yeniden oluşturulan 92 elemanlı sayfa dizisini, bileşen dışına statik bir sabit olarak taşıyarak gereksiz bellek kullanımını önledim.
- **Bulgu:** `src/presentation/screens/AnaSayfa.tsx:681` (eski hali: `{Array.from({ length: TOPLAM_SAYFA_SAYISI }, (_, i) => i).map(...)}`).
- **Neden önemli:** `AnaSayfa` bileşeni (component), içindeki geri sayım sayacı nedeniyle sıklıkla yeniden çizilir (re-render). Her çizimde 92 elemanlı yeni bir dizinin bellek üzerinde satıriçi (inline) olarak ayrılması, gereksiz çöp toplama (garbage collection) yükü oluşturup uygulamanın ana iş parçacığında (JS-thread) takılmalara yol açabilen gerçek bir sıcak yol (hot path) sorunuydu.
- **Değişiklik:** `TOPLAM_SAYFA_SAYISI` sabiti hesaplandıktan hemen sonra modül seviyesinde statik bir `SAYFA_INDEKSLERI` dizisi tanımlandı. `PagerView` içindeki haritalama (map) işleminde, her render döngüsünde yeniden yaratılmak yerine bu statik sabit dizi kullanıldı.
- **Doğrulama:** `npm run verify` komutu başarıyla çalıştırıldı ve tüm tip kontrolleri (typecheck), kod kalitesi testleri (lint) ve birim testler (test) yeşil geçti; ayrıca ek bir performans düşüşü yaratmadığı sağlandı.

---
*PR created automatically by Jules for task [11766907595961132147](https://jules.google.com/task/11766907595961132147) started by @furkanisikay*