### PR TITLE
Rozet Kartı Erişilebilirlik (A11y) İyileştirmesi

### DIFF
--- a/src/presentation/components/RozetKarti.tsx
+++ b/src/presentation/components/RozetKarti.tsx
@@ -111,6 +111,8 @@ export const RozetKarti: React.FC<RozetKartiProps> = ({
         }}
         onPress={onPress}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel={`${rozet.ad} rozeti, ${rozet.kazanildiMi ? 'kazanıldı' : 'kilitli'}`}
       >
         <View className="mb-1">
           {rozet.kazanildiMi ? (
@@ -155,6 +157,8 @@ export const RozetKarti: React.FC<RozetKartiProps> = ({
       }}
       onPress={onPress}
       activeOpacity={0.8}
+      accessibilityRole="button"
+      accessibilityLabel={`${rozet.ad} rozeti, ${rozet.kazanildiMi ? 'kazanıldı' : 'kilitli'}`}
     >
       {/* Parlama efekti */}
       {rozet.kazanildiMi && (


### PR DESCRIPTION
Ekran okuyucu kullanan birisi için rozetlerin üzerine gelindiğinde sadece bir nesne olduğu söyleniyor ve rozetin ne olduğu, kazanılıp kazanılmadığı anlaşılamıyordu; bu düzeltmeyle rozetler doğru şekilde "buton" olarak tanınıyor ve durumu okunuyor.

**Bulgu:** `src/presentation/components/RozetKarti.tsx:111` ve `src/presentation/components/RozetKarti.tsx:157`. `TouchableOpacity` bileşenlerinde `accessibilityRole` ve `accessibilityLabel` özellikleri eksikti.

**Kullanıcıya etkisi:** Görme engelli veya ekran okuyucu kullanan kullanıcılar, rozetler sayfasında gezinirken hangi rozetin üzerinde olduklarını ve rozetin kilitli mi yoksa kazanılmış mı olduğunu artık net bir şekilde duyabilecekler. Bu, uygulamanın erişilebilirliğini (accessibility) artırır.

**Değişiklik:** `RozetKarti.tsx` içerisindeki kompakt ve normal görünümde kullanılan `TouchableOpacity` elemanlarına `accessibilityRole="button"` eklendi ve `accessibilityLabel` özelliği dinamik olarak `` `${rozet.ad} rozeti, ${rozet.kazanildiMi ? 'kazanıldı' : 'kilitli'}` `` şeklinde tanımlandı.

**Doğrulama:** `npm run verify` komutu başarıyla çalıştırıldı (typecheck, linting ve testler hatasız geçti).

---
*PR created automatically by Jules for task [5794263517237402016](https://jules.google.com/task/5794263517237402016) started by @furkanisikay*