### PR TITLE
Sabitlenmiş beyaz metin renklerini tema değerleriyle güncelle

### DIFF
--- a/src/presentation/components/YeniOzellikKarti.tsx
+++ b/src/presentation/components/YeniOzellikKarti.tsx
@@ -50,7 +50,7 @@ export const YeniOzellikKarti: React.FC<YeniOzellikKartiProps> = ({ ozellik, onA
                         className="px-2 py-0.5 rounded-full mr-2"
                         style={{ backgroundColor: renkler.birincil }}
                     >
-                        <Text style={{ color: '#FFF', fontSize: 10, fontWeight: '700', letterSpacing: 0.3 }}>
+                        <Text style={{ color: renkler.birincilMetin, fontSize: 10, fontWeight: '700', letterSpacing: 0.3 }}>
                             YENİ
                         </Text>
                     </View>
@@ -89,8 +89,8 @@ export const YeniOzellikKarti: React.FC<YeniOzellikKartiProps> = ({ ozellik, onA
                     onPress={onAc}
                     activeOpacity={0.85}
                 >
-                    <FontAwesome5 name="arrow-right" size={13} color="#FFF" style={{ marginRight: 8 }} />
-                    <Text className="text-sm font-semibold" style={{ color: '#FFF' }}>
+                    <FontAwesome5 name="arrow-right" size={13} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                    <Text className="text-sm font-semibold" style={{ color: renkler.birincilMetin }}>
                         {ozellik.ctaEtiketi ?? 'İncele'}
                     </Text>
                 </TouchableOpacity>

--- a/src/presentation/components/YeniRozet.tsx
+++ b/src/presentation/components/YeniRozet.tsx
@@ -36,7 +36,7 @@ export const YeniRozet: React.FC<YeniRozetProps> = ({ etiket = 'Yeni' }) => {
                 transform: [{ scale: nabiz }],
             }}
         >
-            <Text style={{ color: '#FFF', fontSize: 10, fontWeight: '700', letterSpacing: 0.3 }}>
+            <Text style={{ color: renkler.birincilMetin, fontSize: 10, fontWeight: '700', letterSpacing: 0.3 }}>
                 {etiket}
             </Text>
         </Animated.View>

--- a/src/presentation/components/common/BildirimModali.tsx
+++ b/src/presentation/components/common/BildirimModali.tsx
@@ -149,9 +149,9 @@ export const BildirimModali: React.FC<BildirimModaliProps> = ({
                                 accessibilityLabel={birincilEtiket}
                             >
                                 {!!birincilIkon && (
-                                    <FontAwesome5 name={birincilIkon} size={13} color="#FFF" style={{ marginRight: 8 }} />
+                                    <FontAwesome5 name={birincilIkon} size={13} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
                                 )}
-                                <Text className="text-sm font-bold" style={{ color: '#FFF' }}>
+                                <Text className="text-sm font-bold" style={{ color: renkler.birincilMetin }}>
                                     {birincilEtiket}
                                 </Text>
                             </TouchableOpacity>

--- a/src/presentation/components/home/KerahatOnayModal.tsx
+++ b/src/presentation/components/home/KerahatOnayModal.tsx
@@ -121,8 +121,8 @@ export const KerahatOnayModal: React.FC<KerahatOnayModalProps> = ({
                             onPress={onOnayla}
                             activeOpacity={0.85}
                         >
-                            <FontAwesome5 name="check" size={14} color="#FFF" style={{ marginRight: 8 }} />
-                            <Text className="text-sm font-bold" style={{ color: '#FFF' }}>
+                            <FontAwesome5 name="check" size={14} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                            <Text className="text-sm font-bold" style={{ color: renkler.birincilMetin }}>
                                 Yine de İşaretle
                             </Text>
                         </TouchableOpacity>

--- a/src/presentation/screens/NelerYeniSayfasi.tsx
+++ b/src/presentation/screens/NelerYeniSayfasi.tsx
@@ -126,8 +126,8 @@ const OzellikKarti: React.FC<OzellikKartiProps> = ({ ozellik, acik, onTogglePres
                             onPress={onAc}
                             activeOpacity={0.85}
                         >
-                            <FontAwesome5 name="arrow-right" size={13} color="#FFF" style={{ marginRight: 8 }} />
-                            <Text className="text-sm font-semibold" style={{ color: '#FFF' }}>
+                            <FontAwesome5 name="arrow-right" size={13} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                            <Text className="text-sm font-semibold" style={{ color: renkler.birincilMetin }}>
                                 {ozellik.ctaEtiketi ?? 'İnceleyin'}
                             </Text>
                         </TouchableOpacity>

--- a/src/presentation/screens/TakvimAyarlari/TemizleModali.tsx
+++ b/src/presentation/screens/TakvimAyarlari/TemizleModali.tsx
@@ -308,7 +308,7 @@ export const TemizleModali: React.FC<TemizleModaliProps> = ({
                                                         className="w-5 h-5 rounded-full items-center justify-center"
                                                         style={{ borderWidth: 2, borderColor: secili ? renkler.birincil : renkler.sinir, backgroundColor: secili ? renkler.birincil : 'transparent' }}
                                                     >
-                                                        {secili && <FontAwesome5 name="check" size={9} color="#FFF" />}
+                                                        {secili && <FontAwesome5 name="check" size={9} color={renkler.birincilMetin} />}
                                                     </View>
                                                 </TouchableOpacity>
                                             );
@@ -420,7 +420,7 @@ export const TemizleModali: React.FC<TemizleModaliProps> = ({
                                                             borderColor: secili ? renkler.birincil : renkler.sinir,
                                                         }}
                                                     >
-                                                        {secili && <FontAwesome5 name="check" size={10} color="#FFF" />}
+                                                        {secili && <FontAwesome5 name="check" size={10} color={renkler.birincilMetin} />}
                                                     </View>
                                                     <Text className="text-sm" style={{ color: renkler.metin, fontWeight: secili ? '600' : '400' }}>
                                                         {VAKIT_GORUNTU_ADLARI[vakit]} Namazı
@@ -443,8 +443,8 @@ export const TemizleModali: React.FC<TemizleModaliProps> = ({
                                         disabled={!taraButonuAktif}
                                         activeOpacity={0.8}
                                     >
-                                        <FontAwesome5 name="search" size={14} color="#FFF" style={{ marginRight: 8 }} />
-                                        <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                        <FontAwesome5 name="search" size={14} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                                        <Text className="text-base font-semibold" style={{ color: renkler.birincilMetin }}>
                                             Etkinlikleri Tara
                                         </Text>
                                     </TouchableOpacity>
@@ -538,11 +538,11 @@ export const TemizleModali: React.FC<TemizleModaliProps> = ({
                                             activeOpacity={0.8}
                                         >
                                             {siliniyor ? (
-                                                <ActivityIndicator size="small" color="#FFF" />
+                                                <ActivityIndicator size="small" color={renkler.birincilMetin} />
                                             ) : (
                                                 <>
-                                                    <FontAwesome5 name="trash-alt" size={14} color="#FFF" style={{ marginRight: 8 }} />
-                                                    <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                                    <FontAwesome5 name="trash-alt" size={14} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                                                    <Text className="text-base font-semibold" style={{ color: renkler.birincilMetin }}>
                                                         {bulunanEtkinlikler.length > 0
                                                             ? `${bulunanEtkinlikler.length} Etkinliği Sil`
                                                             : 'Silinecek Etkinlik Yok'}

--- a/src/presentation/screens/TakvimAyarlari/bilesenler.tsx
+++ b/src/presentation/screens/TakvimAyarlari/bilesenler.tsx
@@ -210,7 +210,7 @@ export const BasariIcerigi: React.FC<BasariIcerigiProps> = ({
                             alignItems: 'center', justifyContent: 'center',
                         }}
                     >
-                        <FontAwesome5 name="check" size={24} color="#FFF" />
+                        <FontAwesome5 name="check" size={24} color={renkler.birincilMetin} />
                     </View>
                 </Animated.View>
             </View>
@@ -262,8 +262,8 @@ export const BasariIcerigi: React.FC<BasariIcerigiProps> = ({
                     onPress={onTakvimiAc}
                     activeOpacity={0.85}
                 >
-                    <FontAwesome5 name="external-link-alt" size={14} color="#FFF" style={{ marginRight: 8 }} />
-                    <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                    <FontAwesome5 name="external-link-alt" size={14} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                    <Text className="text-base font-semibold" style={{ color: renkler.birincilMetin }}>
                         Takvim Uygulamasını Aç
                     </Text>
                 </TouchableOpacity>

--- a/src/presentation/screens/TakvimAyarlariSayfasi.tsx
+++ b/src/presentation/screens/TakvimAyarlariSayfasi.tsx
@@ -372,7 +372,7 @@ const VakitEditorModali: React.FC<VakitEditorModaliProps> = ({
                                 onPress={onKapat}
                                 activeOpacity={0.85}
                             >
-                                <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                <Text className="text-base font-semibold" style={{ color: renkler.birincilMetin }}>
                                     Tamam
                                 </Text>
                             </TouchableOpacity>
@@ -751,11 +751,11 @@ export const TakvimAyarlariSayfasi: React.FC<any> = () => {
                                 activeOpacity={0.8}
                             >
                                 {olayOlusturuluyor ? (
-                                    <ActivityIndicator color="#FFF" />
+                                    <ActivityIndicator color={renkler.birincilMetin} />
                                 ) : (
                                     <>
-                                        <FontAwesome5 name="calendar-plus" size={16} color="#FFF" solid style={{ marginRight: 8 }} />
-                                        <Text className="text-base font-semibold" style={{ color: '#FFF' }}>
+                                        <FontAwesome5 name="calendar-plus" size={16} color={renkler.birincilMetin} solid style={{ marginRight: 8 }} />
+                                        <Text className="text-base font-semibold" style={{ color: renkler.birincilMetin }}>
                                             Olayları Oluştur ({ayarlar.kaciGunIlerisi} gün)
                                         </Text>
                                     </>


### PR DESCRIPTION
1. **Özet:** Sabitlenmiş beyaz renkler yerine tasarım sistemine uygun renk teması (renkler.birincilMetin) kullanılarak, farklı temalarda (karanlık/aydınlık) okunabilirlik sorunu yaşanması engellendi.
2. **Bulgu:** `src/presentation/components/common/BildirimModali.tsx`, `src/presentation/components/home/KerahatOnayModal.tsx`, `src/presentation/components/YeniRozet.tsx`, `src/presentation/components/YeniOzellikKarti.tsx`, `src/presentation/screens/TakvimAyarlari/bilesenler.tsx`, `src/presentation/screens/TakvimAyarlari/TemizleModali.tsx`, `src/presentation/screens/TakvimAyarlariSayfasi.tsx`, `src/presentation/screens/NelerYeniSayfasi.tsx` dosyalarında metinler ve ikonlar için doğrudan `#FFF` rengi atanmıştı.
3. **Kullanıcıya etkisi:** Temalar arası geçiş yapıldığında veya arka plan rengi değiştiğinde, sabitlenmiş (hardcoded) beyaz metinlerin contrast (renk karşıtlığı) oranı yetersiz kalabilir, uygulamanın tutarlı tasarım kuralları bozulmuş olabilirdi.
4. **Değişiklik:** Belirtilen tüm dosyalardaki sabit `#FFF` renk atamaları, `renkler.birincilMetin` tema belirteci ile değiştirildi.
5. **Doğrulama:** `npm run verify` komutu çalıştırılarak tüm tip kontrolü, lint ve test adımlarının başarıyla geçtiği doğrulandı.

---
*PR created automatically by Jules for task [17211643205420165738](https://jules.google.com/task/17211643205420165738) started by @furkanisikay*