### PR TITLE
refactor(ayarlar): Tanı ve Geri Bildirim'i Hakkında içine taşı

### DIFF
--- a/docs/superpowers/plans/2026-07-17-muhafiz-bildirim-basligi.md
+++ b/docs/superpowers/plans/2026-07-17-muhafiz-bildirim-basligi.md
@@ -312,9 +312,14 @@ Döngüde (~245-274) `aktifBaslik` değişkeni ve 4 atamasını sil. Sonuç:
                 aktifSeviye = 4;
                 aktifSiklik = esikler.seviye4Siklik;
             }
+
+            // ⚠️ SNIPPET BURADA BİTİYOR — döngünün geri kalanı (`if (aktifSeviye > 0)`
+            // bloğu: seviyeBaslangic switch'i, `fark % aktifSiklik` sıklık kontrolü,
+            // bildirimZamani hesabı, geçmiş-zaman elemesi) **DEĞİŞMEDEN KALIR**.
+            // Onları silme — sıklık/modulo mantığı kaybolur ve 3 test kırılır.
 ```
 
-`dakikaGruplari.set(...)` çağrısından `baslik` alanını çıkar (~308-312):
+`dakikaGruplari.set(...)` çağrısından `baslik` alanını çıkar (~308-312) — bu satırlar `if (aktifSeviye > 0)` bloğunun **içinde**, yerinde duruyor:
 
 ```typescript
                         dakikaGruplari.set(k, {
@@ -460,20 +465,50 @@ Expected: PASS. (Bu testler `stringContaining` kullanıyor ve tuttukları ifadel
         if (uygunIcerikler.length === 0) return "Şeytana uymayın, namazı kılın.";
 ```
 
-- [ ] **Step 3: Testleri çalıştır**
+- [ ] **Step 3: Banner için "sen" dili nöbetçi testi ekle**
+
+Mevcut testler `stringContaining('VAKİT ÇIKIYOR')` gibi **parça** kontrol ediyor → biri "kapanın"ı "kapan"a geri döndürürse **sessizce geçerler**. Regresyonu yakalayan bir nöbetçi gerekiyor (Task 1'deki `senKaliplari` testinin banner karşılığı).
+
+`src/domain/services/__tests__/NamazMuhafiziServisi.test.ts` içine, mevcut seviye testlerinin yanına ekle:
+
+```typescript
+    // NÖBETÇİ: banner metinleri kibar "siz" dilinde kalmalı (AGENTS.md zorunlu).
+    // Mevcut testler stringContaining ile PARÇA kontrol ettiği için "kapanın" ->
+    // "kapan" regresyonunu yakalayamaz; bu test onu yakalar.
+    test.each([
+        [45 * 60 * 1000, 1],
+        [30 * 60 * 1000, 2],
+        [3 * 60 * 1000, 4],
+    ])('banner mesajı "sen" dili kullanmaz (kalan %i ms, seviye %i)', (kalanSureMs) => {
+        mockHesaplayici.getSuankiVakitBilgisi.mockReturnValue({
+            vakit: 'ogle',
+            kalanSureMs,
+        });
+
+        muhafiz.baslat(bildirimSpx);
+
+        const [mesaj] = bildirimSpx.mock.calls[0];
+        // "kapan/bırakma/uyma/kıl" tek başına = sen dili; "-ın/-ınız/-ayın" ekli hâli siz dili.
+        expect(mesaj).not.toMatch(/\b(kapan|bırakma|uyma|kıl)\b(?!ın|ınız|ayın)/u);
+    });
+```
+
+> Seviye 3 bilinçli olarak DIŞARIDA: gövdesi `SeytanlaMucadeleIcerigi.ts` havuzundan geliyor ve havuz bu planın kapsamı dışında — s4 metni hâlâ "sana… dinleme!" diyor. Havuza test yazmak kırmızı verirdi. Havuz, içerik işinde düzeltilecek.
+
+- [ ] **Step 4: Testleri çalıştır**
 
 Run: `npx jest NamazMuhafiziServisi`
-Expected: PASS — hiçbir test kırılmamalı.
+Expected: PASS — mevcut testlerin hiçbiri kırılmamalı, yeni nöbetçi geçmeli.
 
-- [ ] **Step 4: Doğrulama kapısı**
+- [ ] **Step 5: Doğrulama kapısı**
 
 Run: `npm run verify`
 Expected: typecheck + lint + test **üçü de** geçer. Lint'te **yeni warning yok**.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/domain/services/NamazMuhafiziServisi.ts
+git add src/domain/services/NamazMuhafiziServisi.ts src/domain/services/__tests__/NamazMuhafiziServisi.test.ts
 git commit -m "fix(muhafiz): banner metinlerini kibar 'siz' diline cevir
 
 AGENTS.md zorunlu kurali: kullaniciya gorunen TUM metin kibar 'siz'

--- a/docs/superpowers/plans/2026-07-17-muhafiz-bildirim-basligi.md
+++ b/docs/superpowers/plans/2026-07-17-muhafiz-bildirim-basligi.md
@@ -1,0 +1,511 @@
+# Muhafız Bildirim Başlığı — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Muhafız bildiriminde kalan süreyi gövdenin sonundan alıp başlığın başına taşımak, böylece daraltılmış bildirimde açmadan görünmesini sağlamak.
+
+**Architecture:** Başlık üretimi şu an `ArkaplanMuhafizServisi`'nin planlama döngüsünde inline sabit atamalar hâlinde; test edilemez. Saf bir `muhafizMetinYardimcisi` modülü çıkarılıp başlık/gövde metinleri oraya taşınır, servis yalnız onu çağırır. Banner yüzeyi (`NamazMuhafiziServisi`) kendi mesaj şeklini korur; orada sadece "sen" dili düzeltilir.
+
+**Tech Stack:** TypeScript 5.9 (strict), Jest + jest-expo, expo-notifications.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-muhafiz-bildirim-basligi-design.md`
+
+## Global Constraints
+
+- Kod isimleri **Türkçe** (`basligiOlustur`, `VAKIT_ADLARI`).
+- Kullanıcıya görünen **TÜM** metin kibar **"siz"** dilinde. Sertlik korunur, kabalık değil.
+- **`toUpperCase()` KULLANMA.** `'İkindi'.toUpperCase()` → `'İKINDI'` (noktalı İ kaybolur). Sabit `VAKIT_ADLARI_BUYUK` haritası kullanılacak — `toLocaleUpperCase('tr-TR')` de **kullanılmayacak** (Hermes'te Intl/ICU ortama bağlı).
+- Başlık kalıbı: `<ikon> <süre> dk · <vakit adı> vakti <durum>` — süre daima ikondan hemen sonra, ilk sözcük.
+- Bildirim gövdesi başlığı **birebir tekrarlamaz** ve sonunda `(N dk kaldı)` **taşımaz**. Banner mesajı süreyi **korur**.
+- Bitmeden `npm run verify` (typecheck + lint + test) **geçmeli**.
+- Dokunulmaz: seviye eşikleri/sıklıkları, bildirim ID'leri/gruplama, kanallar/sesler, `SeytanlaMucadeleIcerigi.ts` havuzu, `AnaSayfa.tsx`.
+
+---
+
+### Task 1: Saf metin modülü (`muhafizMetinYardimcisi`)
+
+**Files:**
+- Create: `src/core/utils/muhafizMetinYardimcisi.ts`
+- Test: `src/core/utils/__tests__/muhafizMetinYardimcisi.test.ts`
+
+**Interfaces:**
+- Consumes: `VakitAdi` — `src/core/types/index.ts` (`'imsak' | 'gunes' | 'ogle' | 'ikindi' | 'aksam' | 'yatsi'`)
+- Produces (Task 2 bunlara dayanır):
+  - `MuhafizSeviye = 1 | 2 | 3 | 4`
+  - `VAKIT_ADLARI: Record<VakitAdi, string>`
+  - `VAKIT_ADLARI_BUYUK: Record<VakitAdi, string>`
+  - `basligiOlustur(vakit: VakitAdi, seviye: MuhafizSeviye, kalanDk: number): string`
+  - `bildirimGovdesiOlustur(seviye: MuhafizSeviye): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/utils/__tests__/muhafizMetinYardimcisi.test.ts`:
+
+```typescript
+import {
+  basligiOlustur,
+  bildirimGovdesiOlustur,
+  VAKIT_ADLARI_BUYUK,
+} from '../muhafizMetinYardimcisi';
+
+describe('basligiOlustur', () => {
+  test('seviye 1: süre + vakit adı', () => {
+    expect(basligiOlustur('imsak', 1, 30)).toBe('⏰ 30 dk · Sabah vakti');
+  });
+
+  test('seviye 2: daralıyor', () => {
+    expect(basligiOlustur('ogle', 2, 15)).toBe('⚠️ 15 dk · Öğle vakti daralıyor');
+  });
+
+  test('seviye 3: kaçıyor', () => {
+    expect(basligiOlustur('aksam', 3, 8)).toBe('🔥 8 dk · Akşam vakti kaçıyor');
+  });
+
+  test('seviye 4: büyük harf + ÇIKIYOR', () => {
+    expect(basligiOlustur('yatsi', 4, 3)).toBe('🚨 3 dk · YATSI VAKTİ ÇIKIYOR');
+  });
+
+  // NÖBETÇİ TEST — bu testin sebebi:
+  // 'İkindi'.toUpperCase() => 'İKINDI' (noktalı İ kaybolur, i -> I).
+  // Sabit harita kullanılmazsa kullanıcıya yanlış yazılmış namaz adı gider.
+  // Diğer dört vakitte harf tuzağı YOK, o yüzden yalnız bu test koruyor.
+  test('İkindi seviye 4 başlığı noktalı İKİNDİ üretir (toUpperCase tuzağı)', () => {
+    expect(basligiOlustur('ikindi', 4, 5)).toBe('🚨 5 dk · İKİNDİ VAKTİ ÇIKIYOR');
+    expect(basligiOlustur('ikindi', 4, 5)).not.toContain('İKINDI');
+  });
+
+  test('VAKIT_ADLARI_BUYUK ham toUpperCase ile aynı DEĞİL (regresyon nöbetçisi)', () => {
+    expect(VAKIT_ADLARI_BUYUK.ikindi).toBe('İKİNDİ');
+    expect('İkindi'.toUpperCase()).toBe('İKINDI'); // tuzağın kanıtı
+  });
+
+  test('süre daima ikondan sonraki ilk sözcük', () => {
+    const seviyeler: Array<1 | 2 | 3 | 4> = [1, 2, 3, 4];
+    for (const s of seviyeler) {
+      expect(basligiOlustur('aksam', s, 7)).toMatch(/^\S+ 7 dk · /u);
+    }
+  });
+
+  test('beş vaktin beşi de doğru ada çözülür', () => {
+    expect(basligiOlustur('imsak', 1, 1)).toContain('Sabah');
+    expect(basligiOlustur('ogle', 1, 1)).toContain('Öğle');
+    expect(basligiOlustur('ikindi', 1, 1)).toContain('İkindi');
+    expect(basligiOlustur('aksam', 1, 1)).toContain('Akşam');
+    expect(basligiOlustur('yatsi', 1, 1)).toContain('Yatsı');
+  });
+});
+
+describe('bildirimGovdesiOlustur', () => {
+  test('gövde sondaki kalan süreyi TAŞIMAZ (süre başlıkta)', () => {
+    for (const s of [1, 2, 3, 4] as const) {
+      expect(bildirimGovdesiOlustur(s)).not.toMatch(/dk kaldı|dakika kaldı/u);
+    }
+  });
+
+  test('gövde başlığın durum ifadesini birebir tekrarlamaz', () => {
+    // Seviye 4 başlığı "... VAKTİ ÇIKIYOR" diyor; gövde bunu tekrar etmemeli.
+    expect(bildirimGovdesiOlustur(4)).not.toContain('ÇIKIYOR');
+    expect(bildirimGovdesiOlustur(4)).not.toContain('çıkmak üzere');
+    // Seviye 2 başlığı "daralıyor" diyor.
+    expect(bildirimGovdesiOlustur(2)).not.toContain('daralıyor');
+  });
+
+  test('kibar "siz" dili — emir kipinde "sen" kalıbı yok', () => {
+    const senKaliplari = /\b(kapan|bırakma|uyma|kıl)\b(?!ın|ınız|ayın)/u;
+    for (const s of [1, 2, 3, 4] as const) {
+      expect(bildirimGovdesiOlustur(s)).not.toMatch(senKaliplari);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest muhafizMetinYardimcisi`
+Expected: FAIL — `Cannot find module '../muhafizMetinYardimcisi'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/core/utils/muhafizMetinYardimcisi.ts`:
+
+```typescript
+/**
+ * Muhafiz bildirim metinleri (saf).
+ *
+ * Baslik uretimi eskiden ArkaplanMuhafizServisi'nin planlama dongusunde inline
+ * sabit atamalardaydi -> test edilemiyordu. Buraya cikarildi.
+ *
+ * Kalan sure BASLIKTA ve daima ikondan hemen sonra: Android daraltilmis
+ * bildirimde basligi + govdenin basini gosterir; sure sonda olursa kirpilir.
+ */
+import type { VakitAdi } from '../types';
+
+export type MuhafizSeviye = 1 | 2 | 3 | 4;
+
+export const VAKIT_ADLARI: Record<VakitAdi, string> = {
+    imsak: 'Sabah',
+    gunes: 'Güneş',
+    ogle: 'Öğle',
+    ikindi: 'İkindi',
+    aksam: 'Akşam',
+    yatsi: 'Yatsı',
+};
+
+/**
+ * DIKKAT: toUpperCase() KULLANMA.
+ * 'İkindi'.toUpperCase() -> 'İKINDI' (noktali İ kaybolur, i -> I).
+ * toLocaleUpperCase('tr-TR') dogru sonuc verir ama Hermes'te Intl/ICU
+ * varligina baglidir -> sabit harita motordan bagimsiz ve kesindir.
+ */
+export const VAKIT_ADLARI_BUYUK: Record<VakitAdi, string> = {
+    imsak: 'SABAH',
+    gunes: 'GÜNEŞ',
+    ogle: 'ÖĞLE',
+    ikindi: 'İKİNDİ',
+    aksam: 'AKŞAM',
+    yatsi: 'YATSI',
+};
+
+/**
+ * Bildirim basligi: <ikon> <sure> dk · <vakit adi> vakti <durum>
+ */
+export function basligiOlustur(vakit: VakitAdi, seviye: MuhafizSeviye, kalanDk: number): string {
+    const ad = VAKIT_ADLARI[vakit];
+    switch (seviye) {
+        case 1:
+            return `⏰ ${kalanDk} dk · ${ad} vakti`;
+        case 2:
+            return `⚠️ ${kalanDk} dk · ${ad} vakti daralıyor`;
+        case 3:
+            return `🔥 ${kalanDk} dk · ${ad} vakti kaçıyor`;
+        case 4:
+            return `🚨 ${kalanDk} dk · ${VAKIT_ADLARI_BUYUK[vakit]} VAKTİ ÇIKIYOR`;
+    }
+}
+
+/**
+ * Bildirim govdesi. Vakit adi ve kalan sure ALMAZ - ikisi de baslikta.
+ * Seviye 3'un govdesi havuzdan gelir (bkz. ArkaplanMuhafizServisi); buradaki
+ * seviye 3 metni yalnizca havuz bos oldugunda kullanilan YEDEKtir.
+ */
+export function bildirimGovdesiOlustur(seviye: MuhafizSeviye): string {
+    switch (seviye) {
+        case 1:
+            return 'Vakit daralmaya başladı, fırsat varken kılabilirsiniz.';
+        case 2:
+            return 'Namazı sona bırakmayın; şimdi kılmak için vakit uygun.';
+        case 3:
+            return 'Şeytana uymayın, namazı kılın!';
+        case 4:
+            return 'Hemen secdeye kapanın — sonra kaza etmek zorunda kalırsınız.';
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest muhafizMetinYardimcisi`
+Expected: PASS — 11 test
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/utils/muhafizMetinYardimcisi.ts src/core/utils/__tests__/muhafizMetinYardimcisi.test.ts
+git commit -m "feat(muhafiz): saf metin modulu -- sure basliga tasindi
+
+Baslik uretimi ArkaplanMuhafizServisi'nin dongusunden cikarilip saf
+basligiOlustur() fonksiyonuna alindi (eskiden test edilemiyordu).
+
+VAKIT_ADLARI_BUYUK sabit haritasi: 'İkindi'.toUpperCase() -> 'İKINDI'
+(noktali İ kaybolur) tuzagi icin. toLocaleUpperCase('tr-TR') de
+kullanilmadi -- Hermes'te Intl/ICU ortama bagli. Nobetci test eklendi."
+```
+
+---
+
+### Task 2: `ArkaplanMuhafizServisi`'ni yeni modüle bağla (bildirim yüzeyi)
+
+**Files:**
+- Modify: `src/domain/services/ArkaplanMuhafizServisi.ts` (import; döngü ~245-318; planlama döngüsü ~321-337; `bildirimMesajiOlustur` ~405-435)
+- Modify (test): `src/domain/services/__tests__/ArkaplanMuhafizServisi.test.ts` (satır 152, 190, 238, 240, 242, 246)
+
+**Interfaces:**
+- Consumes: Task 1'den `basligiOlustur`, `bildirimGovdesiOlustur`, `MuhafizSeviye`
+- Produces: davranış değişikliği yok — yalnız bildirim `title`/`body` metinleri değişir. ID'ler, gruplama, kanallar, tetik zamanları **aynı kalır**.
+
+> **Bağlam:** Bu testlerin hepsi `aksam` vakti üzerinden çalışır (mock'ta yalnız akşamın çıkışı gelecekte). Beklenen başlıklarda vakit adı bu yüzden **Akşam/AKŞAM**'dır. `'Akşam'.toUpperCase()` doğru sonuç verdiği için **bu testler harf tuzağını yakalamaz** — onu Task 1'deki İkindi nöbetçi testi koruyor.
+
+- [ ] **Step 1: Önce testleri yeni formata çevir (kırmızı)**
+
+Testler şu an eski başlıkları assert ediyor. TDD sırası: **önce testi yeni beklentiye çevir**, kırmızıya düşür, sonra uygula.
+
+`src/domain/services/__tests__/ArkaplanMuhafizServisi.test.ts`:
+
+Satır 152 (`Aynı dakikaya düşen bildirimler birleştirilmeli`, k=25, seviye 4):
+```typescript
+        expect(tekBildirim.content.title).toBe('🚨 25 dk · AKŞAM VAKTİ ÇIKIYOR');
+```
+
+Satır 190 (`Çakışan dakikada en yüksek seviye kazanmalı`, k=10, seviye 4):
+```typescript
+        expect(onDkBildirimleri[0].content.title).toBe('🚨 10 dk · AKŞAM VAKTİ ÇIKIYOR');
+```
+
+Satır 238/240/242 (`Farklı dakikalara düşen bildirimler ayrı planlanmalı`):
+```typescript
+        expect(dkToBildirim.get(25)!.content.title).toBe('⏰ 25 dk · Akşam vakti');
+        expect(dkToBildirim.get(20)!.content.data.seviye).toBe(2);
+        expect(dkToBildirim.get(20)!.content.title).toBe('⚠️ 20 dk · Akşam vakti daralıyor');
+        expect(dkToBildirim.get(15)!.content.data.seviye).toBe(3);
+        expect(dkToBildirim.get(15)!.content.title).toBe('🔥 15 dk · Akşam vakti kaçıyor');
+```
+
+Satır 246 (döngü, k ∈ {10,8,6,4,2}) — başlık artık **k'ya göre değişiyor**:
+```typescript
+        for (const k of [10, 8, 6, 4, 2]) {
+            expect(dkToBildirim.get(k)!.content.data.seviye).toBe(4);
+            expect(dkToBildirim.get(k)!.content.title).toBe(`🚨 ${k} dk · AKŞAM VAKTİ ÇIKIYOR`);
+        }
+```
+
+- [ ] **Step 2: Testleri çalıştır, kırmızı olduğunu gör**
+
+Run: `npx jest ArkaplanMuhafizServisi`
+Expected: FAIL — 6 assertion. `Expected: "🚨 25 dk · AKŞAM VAKTİ ÇIKIYOR"` / `Received: "🚨 VAKİT ÇIKIYOR!"`
+
+- [ ] **Step 3: Import ekle**
+
+`src/domain/services/ArkaplanMuhafizServisi.ts` — mevcut `import type { VakitAdi } from '../../core/types';` satırının altına:
+
+```typescript
+import { basligiOlustur, bildirimGovdesiOlustur, type MuhafizSeviye } from '../../core/utils/muhafizMetinYardimcisi';
+```
+
+- [ ] **Step 4: `aktifBaslik`'i döngüden tamamen kaldır**
+
+Döngüde (~245-274) `aktifBaslik` değişkeni ve 4 atamasını sil. Sonuç:
+
+```typescript
+        // 1 dakikaya kadar geri say
+        for (let k = baslangicDk; k > 0; k--) {
+            let aktifSeviye = 0;
+            let aktifSiklik = 0;
+
+            // Hangi seviye araligindayiz? (Kucukten buyuge kontrol et ki overwrite etsin)
+            // Seviye 1
+            if (k <= esikler.seviye1) {
+                aktifSeviye = 1;
+                aktifSiklik = esikler.seviye1Siklik;
+            }
+            // Seviye 2
+            if (k <= esikler.seviye2) {
+                aktifSeviye = 2;
+                aktifSiklik = esikler.seviye2Siklik;
+            }
+            // Seviye 3
+            if (k <= esikler.seviye3) {
+                aktifSeviye = 3;
+                aktifSiklik = esikler.seviye3Siklik;
+            }
+            // Seviye 4
+            if (k <= esikler.seviye4) {
+                aktifSeviye = 4;
+                aktifSiklik = esikler.seviye4Siklik;
+            }
+```
+
+`dakikaGruplari.set(...)` çağrısından `baslik` alanını çıkar (~308-312):
+
+```typescript
+                        dakikaGruplari.set(k, {
+                            seviye: aktifSeviye,
+                            dakika: k,
+                        });
+```
+
+- [ ] **Step 5: Map tipinden `baslik`'i çıkar**
+
+~230. satırdaki tanım:
+
+```typescript
+        const dakikaGruplari: Map<number, { seviye: number, dakika: number }> = new Map();
+```
+
+- [ ] **Step 6: Başlığı planlama döngüsünde üret**
+
+~321-337 arasını şu hâle getir (`veri.dakika` zaten kalan dakikadır):
+
+```typescript
+        // Gruplanan bildirimleri planla
+        for (const [kalanDk, veri] of dakikaGruplari) {
+            const bildirimZamani = new Date(cikisSuresi - kalanDk * 60 * 1000);
+            const seviye = veri.seviye as MuhafizSeviye;
+            const baslik = basligiOlustur(vakit.vakit, seviye, veri.dakika);
+            const mesaj = this.bildirimMesajiOlustur(seviye);
+            // ID'ye dakikayi da ekleyelim ki uniqueness bozulmasin
+            // Vakit tarihini kullan (yatsi icin onceki gun olabilir)
+            const bildirimId = this.bildirimIdOlustur(vakit.vakit, veri.seviye, vakit.tarih) + BILDIRIM_SABITLERI.ONEKLEME.DAKIKA + kalanDk;
+
+            await this.tekBildirimPlanla(
+                bildirimId,
+                baslik,
+                mesaj,
+                bildirimZamani,
+                veri.seviye,
+                vakit.vakit,
+                vakit.tarih
+            );
+        }
+```
+
+- [ ] **Step 7: `bildirimMesajiOlustur`'u sadeleştir**
+
+~405-435 arasındaki metodu tamamen şununla değiştir. Artık `vakit` ve `kalanDakika` **almıyor** — ikisi de başlıkta (kullanılmayan parametre = yeni lint warning; AGENTS.md yasaklıyor):
+
+```typescript
+    /**
+     * Bildirim govdesi.
+     * Vakit adi ve kalan sure ALMAZ -> ikisi de baslikta (bkz. basligiOlustur).
+     * Seviye 3 govdesi mucadele havuzundan rastgele secilir; havuz bossa yedek metin.
+     */
+    private bildirimMesajiOlustur(seviye: MuhafizSeviye): string {
+        if (seviye === 3) {
+            const icerikler = SEYTANLA_MUCADELE_ICERIGI.filter(i => i.siddetSeviyesi === 3);
+            if (icerikler.length > 0) {
+                const rastgele = Math.floor(Math.random() * icerikler.length);
+                return icerikler[rastgele].metin;
+            }
+        }
+        return bildirimGovdesiOlustur(seviye);
+    }
+```
+
+- [ ] **Step 8: Kullanılmayan kalıntıları temizle**
+
+`vakitAdlari` haritası `bildirimMesajiOlustur` içinden kalktı. Dosyada başka kullanımı yoksa sil; `VakitAdi` importu hâlâ gerekiyorsa bırak.
+
+Run: `npm run lint`
+Expected: yeni **warning yok** (mevcut warning sayısı artmamalı).
+
+- [ ] **Step 9: Testleri çalıştır — yeşile dön**
+
+Run: `npx jest ArkaplanMuhafizServisi`
+Expected: PASS — Step 1'de kırmızıya döndürdüğün 6 assertion dahil tüm suite yeşil.
+
+> Gövde assertion'ı yok (doğrulandı) → `bildirimMesajiOlustur` değişikliği mevcut testleri kırmaz.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/domain/services/ArkaplanMuhafizServisi.ts src/domain/services/__tests__/ArkaplanMuhafizServisi.test.ts
+git commit -m "fix(muhafiz): bildirim basliginda kalan sureyi basa al
+
+Eskiden baslik sabitti ('🚨 VAKİT ÇIKIYOR!') ve kalan sure govdenin
+SONUNDAYDI -> Android daraltilmis bildirimde kirpiliyordu, kullanici
+bildirimi acmak zorunda kaliyordu.
+
+Ayrica baslik ve govde ayni seyi soyluyordu ('VAKİT ÇIKIYOR' iki kez);
+sureyi disari iten asil sebep buydu. Govde artik basligi tekrarlamiyor
+ve sondaki '(N dk kaldi)' kalkti (sure baslikta).
+
+aktifBaslik degiskeni dongudan tamamen kalkti; baslik planlama
+dongusunde saf basligiOlustur() ile uretiliyor.
+
+6 mevcut test assertion'i yeni formata guncellendi."
+```
+
+---
+
+### Task 3: `NamazMuhafiziServisi` (banner yüzeyi) — "siz" dili
+
+**Files:**
+- Modify: `src/domain/services/NamazMuhafiziServisi.ts` (satır ~172, ~178, ~213)
+
+**Interfaces:**
+- Consumes: yok (bu yüzey Task 1 modülünü kullanmaz — mesaj şekli farklı)
+- Produces: banner metinleri; **süre gövdede kalır** (banner başlığı `AnaSayfa.tsx`'te sabit ve kırpılma yok)
+
+> **Neden bu yüzey farklı:** Bildirimde süre başlığa taşındı çünkü orada kırpılma var. Banner'da başlık ayrı bir bileşen ve `numberOfLines` yok → sarıyor, kırpılmıyor. Süreyi oradan kaldırmak **bilgi kaybı** olurdu. Bu yüzeyde tek sorun "sen" dili.
+>
+> **Drift uyarısı:** Bu iki servis aynı mesaj mantığının kopyası. Bu turda ikisi **aynı PR'da** düzeltiliyor ki ton ve sözcük dağarcığı ayrışmasın (bu repoda "Kıldım" handler drift'i olarak yaşandı — `docs/repo-denetim-2026-06-06.md`).
+
+- [ ] **Step 1: Mevcut testlerin geçtiğini doğrula (baseline)**
+
+Run: `npx jest NamazMuhafiziServisi`
+Expected: PASS. (Bu testler `stringContaining` kullanıyor ve tuttukları ifadeler — `'Namaz vaktinin bitmesine 45 dakika kaldı'`, `'Vakit daralıyor'`, `'VAKİT ÇIKIYOR'` — değişmeyecek. Değişiklikten sonra da geçmeleri **beklenir**; geçmezlerse metni fazla değiştirmişsindir.)
+
+- [ ] **Step 2: "sen" dilini düzelt (3 metin)**
+
+`src/domain/services/NamazMuhafiziServisi.ts` ~170-182:
+
+```typescript
+        if (kalanDk <= this.config.seviye4BaslangicDk) {
+            aktifSeviye = 4;
+            mesaj = `VAKİT ÇIKIYOR! Hemen secdeye kapanın! (${kalanDk} dk kaldı)`;
+        } else if (kalanDk <= this.config.seviye3BaslangicDk) {
+            aktifSeviye = 3;
+            mesaj = this.getRandomIcerik(3);
+        } else if (kalanDk <= this.config.seviye2BaslangicDk) {
+            aktifSeviye = 2;
+            mesaj = `Vakit daralıyor, namazı sona bırakmayın. (${kalanDk} dk kaldı)`;
+        } else if (kalanDk <= this.config.seviye1BaslangicDk) {
+            aktifSeviye = 1;
+            mesaj = `Namaz vaktinin bitmesine ${kalanDk} dakika kaldı.`;
+        }
+```
+
+~213'teki yedek metin:
+
+```typescript
+        if (uygunIcerikler.length === 0) return "Şeytana uymayın, namazı kılın.";
+```
+
+- [ ] **Step 3: Testleri çalıştır**
+
+Run: `npx jest NamazMuhafiziServisi`
+Expected: PASS — hiçbir test kırılmamalı.
+
+- [ ] **Step 4: Doğrulama kapısı**
+
+Run: `npm run verify`
+Expected: typecheck + lint + test **üçü de** geçer. Lint'te **yeni warning yok**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/services/NamazMuhafiziServisi.ts
+git commit -m "fix(muhafiz): banner metinlerini kibar 'siz' diline cevir
+
+AGENTS.md zorunlu kurali: kullaniciya gorunen TUM metin kibar 'siz'
+dilinde. Uc metin 'sen' dilindeydi:
+  'Hemen secdeye kapan!'      -> 'Hemen secdeye kapanin!'
+  'namazi sona birakma'       -> 'namazi sona birakmayin'
+  'Şeytana uyma, namazini kil'-> 'Şeytana uymayin, namazi kilin'
+
+Sertlik korundu. Banner'da kalan sure GOVDEDE kaliyor (bildirimden
+farkli olarak): banner basligi ayri bir bilesen ve kirpilma yok ->
+sureyi kaldirmak bilgi kaybi olurdu.
+
+Bildirim yuzeyiyle ayni PR'da duzeltildi ki ton ayrismasin."
+```
+
+---
+
+## Kapsam dışı (bu planda YOK — bilinçli)
+
+| Konu | Nereye ait |
+|---|---|
+| Seviye 3 içerik havuzu (`SeytanlaMucadeleIcerigi.ts`) | İçerik işi — 2. araştırma turu bekliyor |
+| `siddetSeviyesi` 1 ve 2 ölü verisi (t1/t2/u1/u2 hiç gösterilmiyor) | İçerik işi |
+| Buhârî Ezân 34'ün yanlış vakitte çıkması | İçerik işi |
+| Mevcut meal metinlerinin telif riski (FSEK m.6/1) | İçerik işi — karar: meal gömülmeyecek |
+| TTS ("son 3 dakika" sesli) | Ayrı iş — `expo-speech` + cihaz doğrulaması |
+| `AnaSayfa.tsx` banner'ının hardcoded renkleri | Ayrı iş — görsel doğrulama ister |
+| `MuhafizAyarlariSayfasi.tsx:43` "Şeytanla Mücadele" adı | İçerik işi — bildirim başlığıyla kopuyor, kabul edildi |
+
+## Cihaz doğrulaması (birleştirmeden önce önerilir)
+
+Metin değişikliği olduğu için unit test yeterli değil:
+1. Muhafızı aç, bir vaktin çıkışına ~30 dk kala uygulamayı kapat.
+2. Bildirim düştüğünde **daraltılmış** hâlde bak: süre görünüyor mu, açmadan okunabiliyor mu?
+3. **İkindi** vaktinde seviye 4'ü gör: `İKİNDİ` (noktalı) yazıyor mu, `İKINDI` değil?

--- a/docs/superpowers/specs/2026-07-17-muhafiz-bildirim-basligi-design.md
+++ b/docs/superpowers/specs/2026-07-17-muhafiz-bildirim-basligi-design.md
@@ -30,16 +30,26 @@ Kalan süre, her seviyede, **başlıkta ve sabit konumda** görünsün; kullanı
 <ikon> <süre> · <vakit adı> vakti <durum>
 ```
 
-Süre daima 3. karakterde → göz, metni okumadan sayıyı yakalar.
+Süre **daima aynı yerde: ikondan hemen sonra, ilk sözcük** → göz, metni okumadan sayıyı yakalar. (Karakter indeksi vermiyoruz: `⚠️`/`🚨` iki UTF-16 birimi, `⏰` bir birim; sabit olan **görsel konum**, indeks değil.)
 
 | Seviye | Başlık | Gövde |
 |---|---|---|
 | 1 | `⏰ 30 dk · Sabah vakti` | Vakit daralmaya başladı, fırsat varken kılabilirsiniz. |
 | 2 | `⚠️ 15 dk · Sabah vakti daralıyor` | Namazı sona bırakmayın; şimdi kılmak için vakit uygun. |
 | 3 | `🔥 8 dk · Sabah vakti kaçıyor` | *(içerik havuzundan — bu spec'te değişmiyor)* |
-| 4 | `🚨 3 dk · SABAH VAKTİ ÇIKIYOR` | Vakit çıkmak üzere! Hemen secdeye kapanın. |
+| 4 | `🚨 3 dk · SABAH VAKTİ ÇIKIYOR` | Hemen secdeye kapanın — sonra kaza etmek zorunda kalırsınız. |
 
 Vakit adları: Sabah · Öğle · İkindi · Akşam · Yatsı. (`gunes` isim haritasında var ama muhafız onun için **planlama yapmıyor** — doğrulandı; ölü kayıt, dokunulmuyor.)
+
+### Büyük harf: `toUpperCase()` KULLANMA (Türkçe tuzağı)
+
+Seviye 4 başlığı büyük harf ister. **`'İkindi'.toUpperCase()` → `İKINDI`** üretir (noktalı `İ` kaybolur, `i`→`I`) → kullanıcıya **yanlış yazılmış namaz adı** gider. Ölçüldü:
+
+| Girdi | `toUpperCase()` | `toLocaleUpperCase('tr-TR')` |
+|---|---|---|
+| İkindi | `İKINDI` ❌ | `İKİNDİ` ✅ |
+
+**Karar: sabit büyük-harf haritası** (`VAKIT_ADLARI_BUYUK`), `toLocaleUpperCase('tr-TR')` değil. Gerekçe: locale-tabanlı çözüm Hermes'te Intl/ICU varlığına bağlıdır ve ortama göre değişebilir; sabit harita motordan **bağımsız ve kesin**. Yalnız `İkindi` etkilenir, ama görünür bir hatadır.
 
 ### Kırpılma değerlendirmesi
 
@@ -56,7 +66,11 @@ En uzun hâl `⚠️ 15 dk · İkindi vakti daralıyor` ≈ 33 karakter. Kırpı
    - "namazını sona bırakma" → "namazı sona bırakmayın"
    - "Şeytana uyma, namazını kıl!" → "Şeytana uymayın, namazı kılın!" *(seviye 3 **fallback**'i — havuz boşken kullanılır)*
 
-> **Sınır:** Seviye 3'ün **fallback** metni bu spec'in kapsamındadır (servis dosyasında, `bildirimMesajiOlustur` içinde). `SeytanlaMucadeleIcerigi.ts`'teki **havuz** metinleri kapsam dışıdır — onlar içerik işine aittir ve orada "sen" dili ayrıca düzeltilecektir.
+> **Sınır — dosya sahipliğine göre:** **Servis dosyalarındaki** metinler kapsamdadır; **havuz dosyasındaki** (`SeytanlaMucadeleIcerigi.ts`) metinler değildir. Kapsama giren iki seviye-3 fallback'i vardır ve **ikisi de** düzeltilir:
+> - `ArkaplanMuhafizServisi.bildirimMesajiOlustur` içindeki fallback (bildirim yüzeyi)
+> - `NamazMuhafiziServisi.getRandomIcerik` içindeki `"Şeytana uyma, namazını kıl."` (banner yüzeyi)
+>
+> İkisinden yalnız birini düzeltmek, spec'in kendi drift önlemi ilkesini çiğnerdi.
 
 ### İki yüzey, iki kural (drift önlemi)
 
@@ -69,7 +83,7 @@ Aynı mesaj mantığının **iki kopyası** var:
 
 Banner'da başlık sabittir (`AnaSayfa.tsx`, hardcoded) ve kırpılma yoktur → oradaki kalan süre (`(3 dk kaldı)`) **korunur**; yalnız "sen" dili düzeltilir.
 
-İkisi ayrı ayrı düzeltilirse **kayarlar** — AGENTS.md'de "Kıldım handler drift'i" olarak yaşanmış bir bug. Bu yüzden ikisi **aynı commit'te**, tutarlı ton ve sözcük dağarcığıyla düzeltilir.
+İkisi ayrı ayrı düzeltilirse **kayarlar** — bu repoda yaşanmış bir kalıp ("Kıldım" handler drift'i, `docs/repo-denetim-2026-06-06.md`). Bu yüzden ikisi **aynı commit'te**, tutarlı ton ve sözcük dağarcığıyla düzeltilir.
 
 ## Kapsam dışı (bilinçli)
 
@@ -79,6 +93,7 @@ Banner'da başlık sabittir (`AnaSayfa.tsx`, hardcoded) ve kırpılma yoktur →
 | TTS ("son 3 dakika" sesli) | Ayrı iş: yeni bağımlılık (`expo-speech`) + cihaz doğrulaması. |
 | `siddetSeviyesi` 1 ve 2 ölü verisi | İçerik işine ait yapısal sorun (aşağıda "Bilinen borç"). |
 | Banner'ın hardcoded renkleri | `AnaSayfa.tsx`'te `#FEE2E2`/`#DC2626` vb. var; ayrı iş, görsel doğrulama ister. |
+| Ayarlar'daki seviye adları | `MuhafizAyarlariSayfasi.tsx:43` seviye 3'ü "Şeytanla Mücadele" diye adlandırıyor. Bildirim başlığı artık `🔥 8 dk · <vakit> vakti kaçıyor` olacağı için ayar adı ile bildirim görünümü **kopuyor**. Bilinçli kabul: seviye 3'ün kimliği gövdede (havuz içeriğinde) yaşamaya devam ediyor; ayar adı içerik işinde yeniden ele alınacak. |
 | Eşikler / sıklıklar / kanallar / sesler | Davranış değişmiyor. |
 | Vakit sayacı bildirimi | Ayrı bildirim; muhafız açıkken zaten bastırılıyor (#90). |
 
@@ -89,15 +104,39 @@ Banner'da başlık sabittir (`AnaSayfa.tsx`, hardcoded) ve kırpılma yoktur →
 3. **Vakte uymayan hadis.** `s1` (Buhârî, Ezân 34) *yatsı ve sabah*a özgüdür ama rastgele seçildiği için **öğlede de çıkabiliyor**.
 4. **Telif riski (mevcut).** Dosyada kaynağı belirsiz meal metinleri var (Meryem 59, Alak 19). Türkçe mealler FSEK m.6/1 uyarınca **işlenme eser**; Kur'an'ın kamu malı olması meali serbestleştirmez. Karar: içerik işinde meal **gömülmeyecek**, kendi özgün metnimiz + künye kullanılacak.
 
+## Gerekli refactor (test edilebilirlik için)
+
+Başlık üretimi şu an **fonksiyon bile değil**: `ArkaplanMuhafizServisi`'nin planlama döngüsü içinde inline sabit atamalar (`aktifBaslik = '🚨 VAKİT ÇIKIYOR!'` vb.). `bildirimMesajiOlustur` ise `private` ve seviye 3'te `Math.random()` içeriyor → **saf değil**.
+
+Bu yüzden metinleri doğrudan test edebilmek için küçük bir **extract** şart:
+
+- Saf `basligiOlustur(vakit: VakitAdi, seviye: 1|2|3|4, kalanDk: number): string` çıkarılır.
+- `vakitAdlari` haritası `bildirimMesajiOlustur` içinden **çıkarılıp paylaşılır** (başlık da aynı adlara ihtiyaç duyuyor) + `VAKIT_ADLARI_BUYUK` eklenir.
+- `kalanDk` erişilebilir — doğrulandı: planlama döngüsünde `k` / `veri.dakika` mevcut.
+- Rastgelelik (`Math.random`) `basligiOlustur`'a **girmez**; başlık deterministik kalır.
+
+Bu refactor kapsamın parçasıdır, ayrı iş değildir — onsuz spec'in test maddeleri yazılamaz.
+
 ## Test
 
-`bildirimMesajiOlustur` ve başlık üretimi saf → metinler doğrudan test edilir:
-
-- Her seviyede başlık `<ikon> <süre> dk · ` ile başlar (süre konumu sabit).
-- Gövde, başlığın durum ifadesini **tekrarlamaz**.
+**Yeni testler:**
+- Her seviyede başlık `<ikon> <süre> dk · ` öneki ile başlar (regex; karakter indeksi değil).
+- Gövde, başlığın durum ifadesini **birebir tekrarlamaz**.
 - Gövdede (bildirim) sondaki `(N dk kaldı)` **yoktur**; banner mesajında **vardır**.
 - Beş vaktin beşi de doğru ada çözülür.
-- Hiçbir kullanıcı metninde "sen" dili kalıbı geçmez.
+- **`İkindi` → `İKİNDİ`** (noktalı) — `İKINDI` **değil**. Bu testi yazmak zorunlu; tuzağın nöbetçisi budur.
+- Bu spec'te değiştirilen metinlerde "sen" dili kalıbı geçmez. *(Havuz metinleri hariç — s4 hâlâ "sana… dinleme!" diyor ve seviye 3 gövdesi olarak gösterilmeye devam edecek; içerik işinde düzeltilecek.)*
+
+**Güncellenmesi gereken MEVCUT testler** — eski başlıkları birebir assert ediyorlar, yeni format hepsini kırar:
+
+| Dosya | Satır | Assert |
+|---|---|---|
+| `ArkaplanMuhafizServisi.test.ts` | 152, 190, 246 | `'🚨 VAKİT ÇIKIYOR!'` |
+| `ArkaplanMuhafizServisi.test.ts` | 238 | `'⏰ Namaz Hatırlatıcı'` |
+| `ArkaplanMuhafizServisi.test.ts` | 240 | `'⚠️ Vakit Daralıyor'` |
+| `ArkaplanMuhafizServisi.test.ts` | 242 | `'🔥 Şeytanla Mücadele!'` |
+
+`NamazMuhafiziServisi.test.ts` **kırılmaz** (`stringContaining` kullanıyor ve banner'da süre + "VAKİT ÇIKIYOR" korunuyor) — doğrulandı.
 
 **Tuzak:** muhafız bildirim ID'leri tarih içerir; testlerde sabit tarih yazma — `bugunuAl()`/`dunuAl()` kullan (AGENTS.md).
 

--- a/docs/superpowers/specs/2026-07-17-muhafiz-bildirim-basligi-design.md
+++ b/docs/superpowers/specs/2026-07-17-muhafiz-bildirim-basligi-design.md
@@ -1,0 +1,106 @@
+# Muhafız bildirim başlığı — kalan süreyi başa al
+
+> **Durum:** Onaylandı · **Tarih:** 2026-07-17
+> **Kapsam:** Muhafız uyarı metinleri (bildirim başlığı/gövdesi + banner gövdesi)
+
+## Problem
+
+Muhafız bildirimi, vaktin çıkmasına kaç dakika kaldığını **gövdenin sonunda** yazıyor. Android daraltılmış bildirimde başlık + gövdenin başını gösterir; kalan süre kırpılma bölgesine düşüyor → kullanıcı **saniyeler içinde karar vermesi gereken** bilgiyi görmek için bildirimi açmak zorunda kalıyor.
+
+Mevcut seviye 4 (en kritik an):
+
+```
+🚨 VAKİT ÇIKIYOR!
+VAKİT ÇIKIYOR! Hemen secdeye kapan! İkindi namazına 3 dakika kaldı!
+```
+
+Görünen iki satırın **ikisi de** "VAKİT ÇIKIYOR" ile açılıyor. Yani sorun yalnızca "süre sonda" değil — **başlık ve gövde aynı şeyi söylediği için** süre dışarı itiliyor.
+
+Ek olarak, seviye 3'te kalan süre **hiç yok** (rastgele mücadele içeriği gösteriliyor).
+
+## Hedef
+
+Kalan süre, her seviyede, **başlıkta ve sabit konumda** görünsün; kullanıcı bildirimi açmadan "kaç dakikam var" sorusunu yanıtlasın.
+
+## Tasarım
+
+### Başlık kalıbı
+
+```
+<ikon> <süre> · <vakit adı> vakti <durum>
+```
+
+Süre daima 3. karakterde → göz, metni okumadan sayıyı yakalar.
+
+| Seviye | Başlık | Gövde |
+|---|---|---|
+| 1 | `⏰ 30 dk · Sabah vakti` | Vakit daralmaya başladı, fırsat varken kılabilirsiniz. |
+| 2 | `⚠️ 15 dk · Sabah vakti daralıyor` | Namazı sona bırakmayın; şimdi kılmak için vakit uygun. |
+| 3 | `🔥 8 dk · Sabah vakti kaçıyor` | *(içerik havuzundan — bu spec'te değişmiyor)* |
+| 4 | `🚨 3 dk · SABAH VAKTİ ÇIKIYOR` | Vakit çıkmak üzere! Hemen secdeye kapanın. |
+
+Vakit adları: Sabah · Öğle · İkindi · Akşam · Yatsı. (`gunes` isim haritasında var ama muhafız onun için **planlama yapmıyor** — doğrulandı; ölü kayıt, dokunulmuyor.)
+
+### Kırpılma değerlendirmesi
+
+En uzun hâl `⚠️ 15 dk · İkindi vakti daralıyor` ≈ 33 karakter. Kırpılma artık **zararsız**: kesilen "daralıyor" ⚠️ ikonuyla zaten söyleniyor; kritik bilgi (süre) başta. Eski tasarımın kusuru uzunluk değil, **sıra**ydı.
+
+> Bu, tasarım turunda elenen "çıkış saati" varyasyonundan (`🚨 3 dk · İkindi 17:42'de çıkıyor`) ayrılır: orada kesilen şey **yeni bilgi** (17:42) olurdu, burada **fazlalık**.
+
+### Gövde kuralları
+
+1. **Başlığı tekrarlama.** Başlık aciliyeti söyler; gövde ne yapılacağını söyler.
+2. **Sondaki kalan süre kalkar** (bildirimde). Süre başlıkta; sonda tekrarlaması yer yiyor.
+3. **Kibar "siz" dili** (AGENTS.md zorunlu kuralı). Sertlik korunur, kabalık değil:
+   - "Hemen secdeye kapan!" → "Hemen secdeye kapanın."
+   - "namazını sona bırakma" → "namazı sona bırakmayın"
+   - "Şeytana uyma, namazını kıl!" → "Şeytana uymayın, namazı kılın!" *(seviye 3 **fallback**'i — havuz boşken kullanılır)*
+
+> **Sınır:** Seviye 3'ün **fallback** metni bu spec'in kapsamındadır (servis dosyasında, `bildirimMesajiOlustur` içinde). `SeytanlaMucadeleIcerigi.ts`'teki **havuz** metinleri kapsam dışıdır — onlar içerik işine aittir ve orada "sen" dili ayrıca düzeltilecektir.
+
+### İki yüzey, iki kural (drift önlemi)
+
+Aynı mesaj mantığının **iki kopyası** var:
+
+| Yüzey | Dosya | Süre nerede? |
+|---|---|---|
+| Sistem bildirimi | `ArkaplanMuhafizServisi` | **Başlıkta** (gövdeden kalkar) |
+| Uygulama içi banner | `NamazMuhafiziServisi` → `AnaSayfa` | **Gövdede kalır** |
+
+Banner'da başlık sabittir (`AnaSayfa.tsx`, hardcoded) ve kırpılma yoktur → oradaki kalan süre (`(3 dk kaldı)`) **korunur**; yalnız "sen" dili düzeltilir.
+
+İkisi ayrı ayrı düzeltilirse **kayarlar** — AGENTS.md'de "Kıldım handler drift'i" olarak yaşanmış bir bug. Bu yüzden ikisi **aynı commit'te**, tutarlı ton ve sözcük dağarcığıyla düzeltilir.
+
+## Kapsam dışı (bilinçli)
+
+| Konu | Neden |
+|---|---|
+| Seviye 3 içerik havuzu | Ayrı iş: içerik modeli + kaynaklı havuz. Bu spec yalnız **başlığını** değiştirir. |
+| TTS ("son 3 dakika" sesli) | Ayrı iş: yeni bağımlılık (`expo-speech`) + cihaz doğrulaması. |
+| `siddetSeviyesi` 1 ve 2 ölü verisi | İçerik işine ait yapısal sorun (aşağıda "Bilinen borç"). |
+| Banner'ın hardcoded renkleri | `AnaSayfa.tsx`'te `#FEE2E2`/`#DC2626` vb. var; ayrı iş, görsel doğrulama ister. |
+| Eşikler / sıklıklar / kanallar / sesler | Davranış değişmiyor. |
+| Vakit sayacı bildirimi | Ayrı bildirim; muhafız açıkken zaten bastırılıyor (#90). |
+
+## Bilinen borç (bu turda düzeltilmiyor, kayda geçiyor)
+
+1. **İçeriğin yarısı ölü.** Her iki servis de `siddetSeviyesi === 3` filtreliyor → `siddetSeviyesi: 1` ve `2` maddeleri (t1, t2, u1, u2) **hiç gösterilmiyor**. Uygulama 8 değil **4 metin** döndürüyor.
+2. **Model uyumsuz.** İçerik ekseni 3 kademeli, muhafız 4 seviyeli; seviye 1/2/4 metinleri servislere gömülü sabitler.
+3. **Vakte uymayan hadis.** `s1` (Buhârî, Ezân 34) *yatsı ve sabah*a özgüdür ama rastgele seçildiği için **öğlede de çıkabiliyor**.
+4. **Telif riski (mevcut).** Dosyada kaynağı belirsiz meal metinleri var (Meryem 59, Alak 19). Türkçe mealler FSEK m.6/1 uyarınca **işlenme eser**; Kur'an'ın kamu malı olması meali serbestleştirmez. Karar: içerik işinde meal **gömülmeyecek**, kendi özgün metnimiz + künye kullanılacak.
+
+## Test
+
+`bildirimMesajiOlustur` ve başlık üretimi saf → metinler doğrudan test edilir:
+
+- Her seviyede başlık `<ikon> <süre> dk · ` ile başlar (süre konumu sabit).
+- Gövde, başlığın durum ifadesini **tekrarlamaz**.
+- Gövdede (bildirim) sondaki `(N dk kaldı)` **yoktur**; banner mesajında **vardır**.
+- Beş vaktin beşi de doğru ada çözülür.
+- Hiçbir kullanıcı metninde "sen" dili kalıbı geçmez.
+
+**Tuzak:** muhafız bildirim ID'leri tarih içerir; testlerde sabit tarih yazma — `bugunuAl()`/`dunuAl()` kullan (AGENTS.md).
+
+## Doğrulama
+
+`npm run verify` (typecheck + lint + test) geçmeli. Metin değişikliği olduğu için cihazda görsel teyit önerilir: daraltılmış bildirimde sürenin göründüğü doğrulanmalı.

--- a/src/presentation/screens/AyarlarSayfasi.tsx
+++ b/src/presentation/screens/AyarlarSayfasi.tsx
@@ -300,15 +300,9 @@ export const AyarlarSayfasi: React.FC<any> = ({ navigation }) => {
     },
     {
       baslik: 'Hakkında',
-      aciklama: 'Uygulama bilgileri ve versiyon',
+      aciklama: 'Uygulama bilgileri, sürüm ve geri bildirim',
       ikonAdi: 'hakkinda',
       sayfa: 'Hakkinda',
-    },
-    {
-      baslik: 'Tanı ve Geri Bildirim',
-      aciklama: 'Sorun bildirin, tanı kaydını paylaşın',
-      ikonAdi: 'taniGeriBildirim',
-      sayfa: 'TaniGeriBildirim',
     },
   ];
 

--- a/src/presentation/screens/HakkindaSayfasi.tsx
+++ b/src/presentation/screens/HakkindaSayfasi.tsx
@@ -304,6 +304,56 @@ export const HakkindaSayfasi: React.FC = () => {
           </TouchableOpacity>
         </View>
 
+        {/* Tanı ve Geri Bildirim */}
+        <View className="mb-6">
+          <Text
+            className="text-xs font-bold tracking-wider mb-3"
+            style={{ color: renkler.metinIkincil }}
+          >
+            DESTEK
+          </Text>
+
+          <TouchableOpacity
+            onPress={() => navigation.navigate('TaniGeriBildirim' as never)}
+            activeOpacity={0.7}
+            className="flex-row items-center py-3.5 px-4 rounded-xl"
+            style={{ backgroundColor: renkler.kartArkaplan }}
+            accessibilityRole="button"
+            accessibilityLabel="Tanı ve geri bildirim"
+          >
+            <View
+              className="w-11 h-11 rounded-xl items-center justify-center mr-3.5"
+              style={{ backgroundColor: `${renkler.birincil}26` }}
+            >
+              <FontAwesome5
+                name="comment-dots"
+                size={20}
+                color={renkler.birincil}
+                solid
+              />
+            </View>
+            <View className="flex-1">
+              <Text
+                className="text-base font-semibold"
+                style={{ color: renkler.metin }}
+              >
+                Tanı ve Geri Bildirim
+              </Text>
+              <Text
+                className="text-xs mt-0.5"
+                style={{ color: renkler.metinIkincil }}
+              >
+                Sorun bildirin, tanı kaydını paylaşın
+              </Text>
+            </View>
+            <FontAwesome5
+              name="chevron-right"
+              size={14}
+              color={renkler.metinIkincil}
+            />
+          </TouchableOpacity>
+        </View>
+
         {/* Debug Logs */}
         <View className="mb-6">
           <Text


### PR DESCRIPTION
Ayarlar menüsünde ayrı bir satır olan **Tanı ve Geri Bildirim**, Hakkında sayfasının içine taşındı.

## Neden
Ayarlar menüsünü sadeleştirmek. Tanı/geri bildirim, uygulama bilgileri (sürüm, güncelleme) ile aynı yere — Hakkında'ya — daha doğal oturuyor.

## Ne değişti
- **Ayarlar menüsü:** "Tanı ve Geri Bildirim" satırı kaldırıldı; "Hakkında" açıklaması "geri bildirim"i de kapsayacak şekilde güncellendi.
- **Hakkında sayfası:** GÜNCELLEME ile GELİŞTİRİCİ arasına **DESTEK** bölümü + tıklanabilir "Tanı ve Geri Bildirim" satırı eklendi. Mevcut kart desenine birebir uyuyor (aynı `comment-dots` ikonu, aynı layout, a11y etiketi dahil).
- **Sayfa ve tanı mantığı değişmedi** — yalnız giriş noktası değişti. `TaniGeriBildirimSayfasi` aynen korundu.

## Doğrulama
- Navigasyon zinciri: `TaniGeriBildirim` rotası AppNavigator'da kayıtlı, artık **yalnız** Hakkında'dan erişiliyor (tek giriş noktası, öksüz değil), Ayarlar'dan temiz kalktı.
- `npm run verify` → 83 suite / 1299 test.
- **Cihazda görsel teyit önerilir** (emülatör bu ortamda yok): Ayarlar → Hakkında → DESTEK bölümünde satırın göründüğü ve tıklayınca tanı sayfasına gittiği.

Bağımsız iş — PR #172 (muhafız) ile çakışmaz, farklı dosyalar.