### PR TITLE
refactor(presentation): Ramazan ayarlarındaki sabit renkleri tema değişkenlerine taşı

### DIFF
--- a/src/presentation/screens/RamazanAyarlariSayfasi.tsx
+++ b/src/presentation/screens/RamazanAyarlariSayfasi.tsx
@@ -83,10 +83,10 @@ export const RamazanAyarlariSayfasi: React.FC<any> = () => {
     }
   };
 
-  const iftarRenk = '#E65100';
-  const iftarRenkAcik = '#FFF3E0';
-  const sahurRenk = '#3F51B5'; // İftar turuncu, Sahur lacivert/mavi
-  const sahurRenkAcik = '#E8EAF6';
+  const iftarRenk = renkler.durum.uyari;
+  const iftarRenkAcik = `${renkler.durum.uyari}15`;
+  const sahurRenk = renkler.durum.bilgi; // İftar turuncu, Sahur lacivert/mavi
+  const sahurRenkAcik = `${renkler.durum.bilgi}15`;
 
   return (
     <ScrollView
@@ -296,12 +296,12 @@ export const RamazanAyarlariSayfasi: React.FC<any> = () => {
         >
           <View
             className="w-8 h-8 rounded-full items-center justify-center mr-3"
-            style={{ backgroundColor: '#FF980015' }}
+            style={{ backgroundColor: `${renkler.durum.uyari}15` }}
           >
             <FontAwesome5
               name="exclamation-triangle"
               size={14}
-              color="#FF9800"
+              color={renkler.durum.uyari}
             />
           </View>
           <Text


### PR DESCRIPTION
**1. Özet:** Ramazan ayarları sayfasında, aydınlık/karanlık tema değişimlerine yanıt vermeyen sabit renk tanımları, uygulamanın tema sistemiyle uyumlu hale getirilmiştir.
**2. Bulgu:** `src/presentation/screens/RamazanAyarlariSayfasi.tsx` dosyası 86-89 ve 299-304 satırları arasında, iftar ve sahur sayaçları ile uyarı kutuları için doğrudan `#E65100`, `#3F51B5` ve `#FF9800` gibi sabit onaltılık (hex) renk kodları kullanıldığı tespit edildi.
**3. Neden önemli:** Sabit renk kullanımı (hardcoded colors), farklı tema tercihlerinde (örneğin karanlık modda) renk karşıtlığı (contrast) sorunlarına yol açarak içeriğin okunmasını zorlaştırır ve uygulamanın genel görsel tutarlılığını bozar.
**4. Değişiklik:** Sabit renk kodları, tasarım sisteminden gelen tema değişkenleri (theme tokens) olan `renkler.durum.uyari` ve `renkler.durum.bilgi` ile değiştirildi. Arkaplan vurguları için gerekli olan açık tonlar ise mevcut tema değişkenlerine opaklık değeri eklenerek (örneğin `${renkler.durum.uyari}15`) sağlandı.
**5. Doğrulama:** Değişiklik sonrasında `npm run verify` komutu hatasız tamamlanmış, tüm testlerin (1669 test) ve lint süreçlerinin başarıyla geçtiği görülmüştür. Arayüzün doğru çizildiği Playwright üzerinden görsel olarak doğrulanmıştır.

---
*PR created automatically by Jules for task [10304731947334718117](https://jules.google.com/task/10304731947334718117) started by @furkanisikay*