### PR TITLE
Erişilebilirlik: Kurulum Sihirbazı Butonlarına Role Eklemesi

### DIFF
--- a/src/presentation/screens/KurulumSihirbaziSayfasi.tsx
+++ b/src/presentation/screens/KurulumSihirbaziSayfasi.tsx
@@ -322,6 +322,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
         <TouchableOpacity
           style={[styles.buton, styles.butonBirincil, { backgroundColor: palet.birincil }]}
           onPress={ilerle}
+          accessibilityRole="button"
         >
           <Text style={styles.butonMetin}>Kuruluma Başla</Text>
           <FontAwesome5 name="arrow-right" size={16} color="#fff" />
@@ -335,6 +336,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
           <TouchableOpacity
             style={[styles.buton, styles.butonBirincil, { backgroundColor: palet.birincil }]}
             onPress={ilerle}
+            accessibilityRole="button"
           >
             <FontAwesome5 name="arrow-right" size={16} color="#fff" />
             <Text style={styles.butonMetin}>Şimdilik Geç</Text>
@@ -346,11 +348,12 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
           <TouchableOpacity
             style={[styles.buton, styles.butonBirincil, { backgroundColor: palet.birincil }]}
             onPress={bildirimIzniIste}
+            accessibilityRole="button"
           >
             <FontAwesome5 name="bell" size={16} color="#fff" />
             <Text style={styles.butonMetin}>Bildirimlere İzin Ver</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.atlaButon} onPress={ilerle}>
+          <TouchableOpacity style={styles.atlaButon} onPress={ilerle} accessibilityRole="button">
             <Text style={styles.atlaButonMetin}>Şimdilik geç</Text>
           </TouchableOpacity>
         </>
@@ -363,11 +366,12 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
             <TouchableOpacity
               style={[styles.buton, styles.butonBirincil, { backgroundColor: palet.birincil }]}
               onPress={konumIzniIste}
+              accessibilityRole="button"
             >
               <FontAwesome5 name="map-marker-alt" size={16} color="#fff" />
               <Text style={styles.butonMetin}>Konum İznini Ver</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.atlaButon} onPress={() => setKonumDurumu('gpsReddedildi')}>
+            <TouchableOpacity style={styles.atlaButon} onPress={() => setKonumDurumu('gpsReddedildi')} accessibilityRole="button">
               <Text style={styles.atlaButonMetin}>Manuel seçeceğim</Text>
             </TouchableOpacity>
           </>
@@ -379,6 +383,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
             style={[styles.buton, styles.butonBirincil, { backgroundColor: manuelIl ? palet.birincil : '#9ca3af' }]}
             onPress={manuelKonumKaydet}
             disabled={!manuelIl}
+            accessibilityRole="button"
           >
             <FontAwesome5 name="check" size={16} color="#fff" />
             <Text style={styles.butonMetin}>
@@ -397,6 +402,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
           style={[styles.buton, styles.butonYesil]}
           onPress={kurulumTamamla}
           disabled={yukleniyor}
+          accessibilityRole="button"
         >
           {yukleniyor
             ? <ActivityIndicator color="#fff" />
@@ -409,6 +415,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
       <TouchableOpacity
         style={[styles.buton, styles.butonBirincil, { backgroundColor: palet.birincil }]}
         onPress={ilerle}
+        accessibilityRole="button"
       >
         <Text style={styles.butonMetin}>Devam Et</Text>
         <FontAwesome5 name="arrow-right" size={16} color="#fff" />
@@ -459,7 +466,7 @@ export const KurulumSihirbaziSayfasi: React.FC<Props> = ({ navigation }) => {
 
       <View style={styles.ustBar}>
         {geriGoster
-          ? <TouchableOpacity onPress={geriDon} style={styles.geriButon}>
+          ? <TouchableOpacity onPress={geriDon} style={styles.geriButon} accessibilityRole="button" accessibilityLabel="Geri">
               <FontAwesome5 name="arrow-left" size={16} color="#6b7280" />
             </TouchableOpacity>
           : <View style={styles.geriButon} />}


### PR DESCRIPTION
Kurulum sihirbazı sayfasındaki etkileşimli butonların ekran okuyucular tarafından doğru algılanamaması sorunu çözüldü ve bu sayede uygulamanın erişilebilirliği artırıldı.

`src/presentation/screens/KurulumSihirbaziSayfasi.tsx`: 320-470 satırları arasında bulunan "Kuruluma Başla", "Şimdilik Geç", "Bildirimlere İzin Ver", "Konum İznini Ver", "Manuel seçeceğim", "Devam Et" ve geri dönüş butonlarına `accessibilityRole="button"` (ve geri butonu için `accessibilityLabel="Geri"`) eklendi.

Kullanıcıya etkisi: Görme engelli veya ekran okuyucu kullanan kullanıcılar kurulum sihirbazındaki butonlara odaklandıklarında, artık bu öğelerin birer buton (düğme) olduğunu duyacaklar. Özellikle sadece ikon içeren geri tuşunun işlevi ekran okuyucu tarafından açıkça okunabilecektir.

Düzeltme: Uygulamada `KurulumSihirbaziSayfasi.tsx` dosyasında bulunan çeşitli `<TouchableOpacity>` etiketlerine `accessibilityRole="button"` propertysi ve geri ikonuna `accessibilityLabel="Geri"` eklendi.

Doğrulama: `npm run verify` komutu çalıştırıldı ve tüm tip kontrolleri, lint ve test işlemleri başarıyla tamamlandı.

---
*PR created automatically by Jules for task [8243242441212283059](https://jules.google.com/task/8243242441212283059) started by @furkanisikay*