### PR TITLE
feat: add accessibility props to missing presentation components

### DIFF
--- a/src/presentation/components/Sharing/PaylasimModal.tsx
+++ b/src/presentation/components/Sharing/PaylasimModal.tsx
@@ -161,6 +161,8 @@ export const PaylasimModal: React.FC<PaylasimModalProps> = ({
               style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
               onPress={onKapat}
               disabled={paylasiliyor}
+              accessibilityRole="button"
+              accessibilityLabel="Kapat"
             >
               <Text className="font-semibold" style={{ color: renkler.metin }}>Kapat</Text>
             </TouchableOpacity>
@@ -170,6 +172,8 @@ export const PaylasimModal: React.FC<PaylasimModalProps> = ({
               style={{ backgroundColor: renkler.birincil }}
               onPress={paylas}
               disabled={paylasiliyor}
+              accessibilityRole="button"
+              accessibilityLabel="Hikayene ekle"
             >
               {paylasiliyor ? (
                 <ActivityIndicator color="white" />

--- a/src/presentation/components/home/HomeHeader.tsx
+++ b/src/presentation/components/home/HomeHeader.tsx
@@ -72,6 +72,8 @@ export const HomeHeader = React.memo<HomeHeaderProps>(({
                 className="flex-row items-center gap-3"
                 onPress={onTarihTikla}
                 activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel="Tarih seçiciyi aç"
             >
                 <View
                     className="p-2 rounded-lg items-center min-w-[3.5rem] border"

--- a/src/presentation/components/home/SeriKartiModal.tsx
+++ b/src/presentation/components/home/SeriKartiModal.tsx
@@ -128,6 +128,8 @@ export const SeriKartiModal: React.FC<SeriKartiModalProps> = ({
                             onPress={() => setPaylasimModalGorunur(true)}
                             className="bg-white/20 py-3 rounded-xl flex-row items-center justify-center space-x-2 border border-white/30"
                             activeOpacity={0.8}
+                            accessibilityRole="button"
+                            accessibilityLabel="Başarımı paylaş"
                         >
                             <FontAwesome5 name="share-alt" size={16} color="white" style={{ marginRight: 8 }} />
                             <Text className="text-white font-bold text-sm">BAŞARIMI PAYLAŞ</Text>


### PR DESCRIPTION
**Özet:** Uygulamayı kullanan görme engelli veya ekran okuyucu kullanan bireylerin etkileşimli öğeleri daha rahat kullanabilmesi için ana sayfa ve paylaşım modallarındaki düğmelere erişilebilirlik etiketleri eklendi.

**Bulgu:** 
- `src/presentation/components/home/HomeHeader.tsx:71`: Tarih seçme alanı etkileşimli olmasına rağmen ekran okuyucular için bir rol ve etiket içermiyordu.
- `src/presentation/components/home/SeriKartiModal.tsx:127`: Başarımı paylaşma butonu ekran okuyuculara bir metin veya görev belirtmiyordu.
- `src/presentation/components/Sharing/PaylasimModal.tsx:159, 168`: Paylaşım ekranındaki "Kapat" ve "Hikayene Ekle" butonlarında rol ve etiket eksikti.

**Kullanıcıya etkisi:** Ekran okuyucu (screen reader) kullanan kişiler bu öğelerin üzerine geldiklerinde bunların birer düğme (button) olduğunu ve ne işe yaradıklarını anlayabilecek, uygulamada daha rahat gezinebilecekler.

**Düzeltme:** 
Eksik olan `<TouchableOpacity>` bileşenlerine `accessibilityRole="button"` ile uygun, açıklayıcı ve kibar Türkçe `accessibilityLabel` (erişilebilirlik etiketi) tanımlamaları eklendi. (Örn: "Kapat", "Tarih seçiciyi aç").

**Doğrulama:** 
`npm run verify` komutu başarıyla çalıştırıldı ve geçti (tüm testler, linting ve tip kontrolleri başarılı).

---
*PR created automatically by Jules for task [9951049747002444886](https://jules.google.com/task/9951049747002444886) started by @furkanisikay*