### PR TITLE
fix: VakitAkisi bileşenindeki gereksiz re-render sorunu çözüldü

### DIFF
--- a/src/presentation/components/home/VakitAkisi.tsx
+++ b/src/presentation/components/home/VakitAkisi.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { FontAwesome5 } from '@expo/vector-icons';
 import { useRenkler } from '../../../core/theme';
@@ -6,6 +6,7 @@ import { Namaz } from '../../../core/types';
 import { NamazAdi } from '../../../core/constants/UygulamaSabitleri';
 import { PUAN_DEGERLERI } from '../../../core/types/SeriTipleri';
 import { namazGorunenAdi } from '../../../core/utils/cumaYardimcisi';
+import { ISOTarihiDateNesnesiNeCevir } from '../../../core/utils/TarihYardimcisi';
 
 interface VakitAkisiProps {
     namazlar: (Namaz & { saat: string })[];
@@ -16,8 +17,8 @@ interface VakitAkisiProps {
     aktifGunMu?: boolean;
     /** Aktif vakit kilitli mi (orn: gunes/kerahat vaktinde ogle kilitleniyor) */
     kilitli?: boolean;
-    /** GOSTERILEN gunun tarihi — cuma etiketi buna gore hesaplanir (`new Date()` DEGIL). */
-    gunTarihi?: Date;
+    /** GOSTERILEN gunun tarihi (ISO string) — cuma etiketi buna gore hesaplanir (`new Date()` DEGIL). */
+    gunTarihiStr?: string;
     /** Cuma hatirlatmasi acikken cuma gunu ogle "Cuma" olarak GOSTERILIR (salt etiket). */
     cumaEtiketi?: boolean;
 }
@@ -42,10 +43,12 @@ export const VakitAkisi = React.memo<VakitAkisiProps>(({
     onVakitTikla,
     aktifGunMu = false,
     kilitli = false,
-    gunTarihi,
+    gunTarihiStr,
     cumaEtiketi = false
 }) => {
     const renkler = useRenkler();
+
+    const gunTarihi = useMemo(() => gunTarihiStr ? ISOTarihiDateNesnesiNeCevir(gunTarihiStr) : undefined, [gunTarihiStr]);
 
     // Vaktin gecip gecmedigini kontrol eder
     const vakitGectiMi = (vakitSaati: string): boolean => {

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -702,7 +702,7 @@ export const AnaSayfa: React.FC = () => {
           onVakitTikla={handleVakitTikla}
           aktifGunMu={aktifGunKontrol}
           kilitli={kilitli}
-          gunTarihi={sayfaTarihiDate}
+          gunTarihiStr={sayfaTarihi}
           cumaEtiketi={cumaEtiketi}
         />
         {/* ScrollView sonu için boşluk */}


### PR DESCRIPTION
Ana Sayfa (AnaSayfa) üzerindeki günlük akış listesinin her saniye gereksiz yere yeniden çizilmesine (re-render) neden olan bir performans sorunu giderildi.

**Bulgu:**
`src/presentation/components/home/VakitAkisi.tsx:46`
`src/presentation/screens/AnaSayfa.tsx:705`

`VakitAkisi` bileşeni `React.memo` ile sarılmış olmasına rağmen, `AnaSayfa` her saniye çalıştığında `sayfaTarihiDate` (her defasında `new Date()` ile oluşturulan yeni bir obje) prop'u yüzünden yeniden çiziliyordu.

**Kullanıcıya etkisi:**
Bu durum her saniye gereksiz UI hesaplamalarına (re-render) neden oluyor, batarya tüketimini artırıyor ve düşük donanımlı cihazlarda takılmalara yol açabiliyordu. 

**Düzeltme:**
`VakitAkisi` bileşenine dinamik `Date` objesi yerine stabil `string` (sayfaTarihi) primitive değeri `gunTarihiStr` prop'uyla gönderildi. Bileşen içinde `Date` dönüşümü `useMemo` kullanılarak sadece tarih değiştiğinde hesaplanacak şekilde izole edildi. Bu sayede `React.memo`'nun sığ karşılaştırma (shallow compare) yapabilmesi sağlandı.

**Doğrulama:**
`npm run verify` komutu başarıyla çalıştırılarak tüm tip kontrollerinin (typecheck), statik kod analizlerinin (lint) ve testlerin hatasız geçtiği doğrulandı.

---
*PR created automatically by Jules for task [16839023157515570444](https://jules.google.com/task/16839023157515570444) started by @furkanisikay*