### PR TITLE
UX: Kaza Defteri sihirbaz modalı için arkaplan ile kapatma özelliği eklendi

### DIFF
--- a/src/presentation/screens/KazaDefteriSayfasi.tsx
+++ b/src/presentation/screens/KazaDefteriSayfasi.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
+  TouchableWithoutFeedback,
   Modal,
   TextInput,
   StyleSheet,
@@ -620,6 +621,9 @@ export const KazaDefteriSayfasi: React.FC = () => {
           style={styles.modalArkaPlan}
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
+          <TouchableWithoutFeedback onPress={() => setAktifModal(null)} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+            <View style={StyleSheet.absoluteFill} />
+          </TouchableWithoutFeedback>
           <View style={[styles.sihirbazKonteyner, { backgroundColor: renkler.kartArkaplan }]}>
             <View style={styles.sihirbazBaslikSatir}>
               <FontAwesome5 name="magic" size={18} color={renkler.birincil} />


### PR DESCRIPTION
1. Özet: Kaza Defteri sayfasındaki "Hesaplama Sihirbazı" açıldığında, kullanıcılar modalın dışındaki karanlık alana dokunarak modalı kapatamıyordu; bu da uygulamanın geri kalanındaki akıcı kullanıcı deneyimini bozuyordu (örneğin Sayı Giriş Modalı dışarıya dokunularak kapatılabiliyor).
2. Bulgu: `src/presentation/screens/KazaDefteriSayfasi.tsx:624` (Hesaplama Sihirbazı `<Modal>` içeriğinde, dış mekana tıklamayı algılayan bir `TouchableWithoutFeedback` backdrop sibling'i eksikti).
3. Kullanıcıya etkisi: Kullanıcıların modalı kapatmak için mutlaka küçük bir "İptal" butonuna basması veya donanım geri tuşunu kullanması gerekiyordu. Bu düzeltme sayesinde artık ekranın karanlık herhangi bir yerine dokunarak modal kolayca kapatılabiliyor ve genel tutarlılık (consistency) sağlanıyor. Arkaplan tıklama alanı ekran okuyuculara görünmez yapılarak erişilebilirlik (accessibility) standartlarına uygun hale getirildi.
4. Düzeltme: Modal içindeki `KeyboardAvoidingView` altına, asıl içerik (`sihirbazKonteyner`) ile kardeş olacak şekilde, `StyleSheet.absoluteFill` kullanan ve dokunulduğunda `setAktifModal(null)` tetikleyen bir `TouchableWithoutFeedback` eklendi. Ortak stil olan `styles.modalArkaPlan` içindeki arkaplan rengi aynı şekilde korundu.
5. Doğrulama: `npm run verify` komutu başarıyla çalıştırıldı ve testler geçti.

---
*PR created automatically by Jules for task [18404575674012996430](https://jules.google.com/task/18404575674012996430) started by @furkanisikay*