### PR TITLE
VakitAkisi bileşeni için React.memo optimizasyonu

### DIFF
--- a/src/presentation/components/home/VakitAkisi.tsx
+++ b/src/presentation/components/home/VakitAkisi.tsx
@@ -3,9 +3,11 @@ import { View, Text, TouchableOpacity } from 'react-native';
 import { FontAwesome5 } from '@expo/vector-icons';
 import { useRenkler } from '../../../core/theme';
 import { Namaz } from '../../../core/types';
+import { useMemo } from 'react';
 import { NamazAdi } from '../../../core/constants/UygulamaSabitleri';
 import { PUAN_DEGERLERI } from '../../../core/types/SeriTipleri';
 import { namazGorunenAdi } from '../../../core/utils/cumaYardimcisi';
+import { ISOTarihiDateNesnesiNeCevir } from '../../../core/utils/TarihYardimcisi';
 
 interface VakitAkisiProps {
     namazlar: (Namaz & { saat: string })[];
@@ -16,8 +18,8 @@ interface VakitAkisiProps {
     aktifGunMu?: boolean;
     /** Aktif vakit kilitli mi (orn: gunes/kerahat vaktinde ogle kilitleniyor) */
     kilitli?: boolean;
-    /** GOSTERILEN gunun tarihi — cuma etiketi buna gore hesaplanir (`new Date()` DEGIL). */
-    gunTarihi?: Date;
+    /** GOSTERILEN gunun tarihi (string formatında). `React.memo` için stabil prop olarak kullanılır. */
+    gunTarihiStr?: string;
     /** Cuma hatirlatmasi acikken cuma gunu ogle "Cuma" olarak GOSTERILIR (salt etiket). */
     cumaEtiketi?: boolean;
 }
@@ -42,10 +44,14 @@ export const VakitAkisi = React.memo<VakitAkisiProps>(({
     onVakitTikla,
     aktifGunMu = false,
     kilitli = false,
-    gunTarihi,
+    gunTarihiStr,
     cumaEtiketi = false
 }) => {
     const renkler = useRenkler();
+
+    const gunTarihi = useMemo(() => {
+        return gunTarihiStr ? ISOTarihiDateNesnesiNeCevir(gunTarihiStr) : undefined;
+    }, [gunTarihiStr]);
 
     // Vaktin gecip gecmedigini kontrol eder
     const vakitGectiMi = (vakitSaati: string): boolean => {

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -702,7 +702,7 @@ export const AnaSayfa: React.FC = () => {
           onVakitTikla={handleVakitTikla}
           aktifGunMu={aktifGunKontrol}
           kilitli={kilitli}
-          gunTarihi={sayfaTarihiDate}
+          gunTarihiStr={sayfaTarihi}
           cumaEtiketi={cumaEtiketi}
         />
         {/* ScrollView sonu için boşluk */}


### PR DESCRIPTION
Ana sayfada (AnaSayfa.tsx) bulunan sayaç (timer) her saniye çalışarak bir state güncellemesine ve dolayısıyla tüm AnaSayfa bileşeninin yeniden çizilmesine (re-render) neden olmaktadır. AnaSayfa'nın içindeki VakitAkisi bileşeni `React.memo` ile sarmalanmış olsa da, AnaSayfa her çizildiğinde `gunTarihi={sayfaTarihiDate}` özelliği (prop) için yeni bir Date nesnesi oluşturulup geçildiği için (referans eşitliği kırılarak) `React.memo` işlevsiz kalmakta ve tüm namaz listesi her saniye tekrar çizilmekteydi.

Bu değişiklikle VakitAkisi'ne dinamik Date nesnesi yerine stabil olan `sayfaTarihi` (string) değeri geçilmiş ve Date dönüşümü bileşen içerisinde `useMemo` ile yapılarak bu ciddi performans sorunu (JS-thread re-render döngüsü) çözülmüştür. `npm run verify` başarıyla geçmiştir.

---
*PR created automatically by Jules for task [2814661558348978788](https://jules.google.com/task/2814661558348978788) started by @furkanisikay*