### PR TITLE
perf(AnaSayfa): Optimize AnaSayfa re-renders and PrayerTimes calculations

### DIFF
--- a/src/presentation/components/home/VakitAkisi.tsx
+++ b/src/presentation/components/home/VakitAkisi.tsx
@@ -6,6 +6,7 @@ import { Namaz } from '../../../core/types';
 import { NamazAdi } from '../../../core/constants/UygulamaSabitleri';
 import { PUAN_DEGERLERI } from '../../../core/types/SeriTipleri';
 import { namazGorunenAdi } from '../../../core/utils/cumaYardimcisi';
+import { ISOTarihiDateNesnesiNeCevir } from '../../../core/utils/TarihYardimcisi';
 
 interface VakitAkisiProps {
     namazlar: (Namaz & { saat: string })[];
@@ -17,7 +18,7 @@ interface VakitAkisiProps {
     /** Aktif vakit kilitli mi (orn: gunes/kerahat vaktinde ogle kilitleniyor) */
     kilitli?: boolean;
     /** GOSTERILEN gunun tarihi — cuma etiketi buna gore hesaplanir (`new Date()` DEGIL). */
-    gunTarihi?: Date;
+    gunTarihi?: string;
     /** Cuma hatirlatmasi acikken cuma gunu ogle "Cuma" olarak GOSTERILIR (salt etiket). */
     cumaEtiketi?: boolean;
 }
@@ -46,6 +47,11 @@ export const VakitAkisi = React.memo<VakitAkisiProps>(({
     cumaEtiketi = false
 }) => {
     const renkler = useRenkler();
+
+    // Memoize the Date object parsing to avoid breaking React.memo when a primitive is passed
+    const gunTarihiDate = React.useMemo(() =>
+        gunTarihi ? ISOTarihiDateNesnesiNeCevir(gunTarihi) : undefined
+    , [gunTarihi]);
 
     // Vaktin gecip gecmedigini kontrol eder
     const vakitGectiMi = (vakitSaati: string): boolean => {
@@ -107,8 +113,8 @@ export const VakitAkisi = React.memo<VakitAkisiProps>(({
 
                     // SALT GORUNUM: kimlik (`namaz.namazAdi`) her yerde ayni kalir —
                     // key, aktif-vakit eslesmesi ve toggle ham adi kullanir.
-                    const gorunenAd = gunTarihi
-                        ? namazGorunenAdi(namaz.namazAdi, gunTarihi, cumaEtiketi)
+                    const gorunenAd = gunTarihiDate
+                        ? namazGorunenAdi(namaz.namazAdi, gunTarihiDate, cumaEtiketi)
                         : namaz.namazAdi;
 
                     return (

--- a/src/presentation/screens/AnaSayfa.tsx
+++ b/src/presentation/screens/AnaSayfa.tsx
@@ -155,9 +155,11 @@ export const AnaSayfa: React.FC = () => {
     dispatch(namazlariYukle({ tarih }));
   }, [dispatch]);
 
-  // Günlük namazları saat bilgisi ile zenginleştir
-  const uiNamazlar = useMemo(() => {
-    if (!gunlukNamazlar || !konumAyarlari.koordinatlar) return [];
+  // Namaz vakit saatlerini ayri bir memo'da hesaplayalim
+  // Boylece gunlukNamazlar (namazlarin tamamlama durumu) degistiginde
+  // pahali PrayerTimes hesaplamasi tekrar yapilmaz
+  const vakitSaatleri = useMemo(() => {
+    if (!konumAyarlari.koordinatlar) return null;
 
     const date = new Date(mevcutTarih);
     const coordinates = new Coordinates(konumAyarlari.koordinatlar.lat, konumAyarlari.koordinatlar.lng);
@@ -168,20 +170,25 @@ export const AnaSayfa: React.FC = () => {
       return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
     };
 
-    const vakitSaatleri: Record<NamazAdi, string> = {
+    return {
       [NamazAdi.Sabah]: zamanFormatla(prayerTimes.fajr),
       [NamazAdi.Gunes]: zamanFormatla(prayerTimes.sunrise),
       [NamazAdi.Ogle]: zamanFormatla(prayerTimes.dhuhr),
       [NamazAdi.Ikindi]: zamanFormatla(prayerTimes.asr),
       [NamazAdi.Aksam]: zamanFormatla(prayerTimes.maghrib),
       [NamazAdi.Yatsi]: zamanFormatla(prayerTimes.isha),
-    };
+    } as Record<NamazAdi, string>;
+  }, [konumAyarlari.koordinatlar, mevcutTarih]);
+
+  // Günlük namazları saat bilgisi ile zenginleştir
+  const uiNamazlar = useMemo(() => {
+    if (!gunlukNamazlar) return [];
 
     return gunlukNamazlar.namazlar.map(namaz => ({
       ...namaz,
-      saat: vakitSaatleri[namaz.namazAdi] || ''
+      saat: vakitSaatleri ? (vakitSaatleri[namaz.namazAdi] || '') : ''
     }));
-  }, [gunlukNamazlar, konumAyarlari.koordinatlar, mevcutTarih]);
+  }, [gunlukNamazlar, vakitSaatleri]);
 
 
   // Aktif Gün Hesaplama (İmsak öncesi ise önceki gün — yatsı süreci devam ediyor).
@@ -467,7 +474,12 @@ export const AnaSayfa: React.FC = () => {
       const { lat, lng } = konumAyarlari.koordinatlar || {};
       if (lat && lng) {
         const sonuc = mekruhVakitKontrolEt(lat, lng, 'farz');
-        setMekruhBilgi({ mekruhMu: sonuc.mekruhMu, aciklama: sonuc.aciklama });
+        setMekruhBilgi(prev => {
+          if (prev.mekruhMu === sonuc.mekruhMu && prev.aciklama === sonuc.aciklama) {
+            return prev;
+          }
+          return { mekruhMu: sonuc.mekruhMu, aciklama: sonuc.aciklama };
+        });
       }
     };
     kontrol();
@@ -702,7 +714,7 @@ export const AnaSayfa: React.FC = () => {
           onVakitTikla={handleVakitTikla}
           aktifGunMu={aktifGunKontrol}
           kilitli={kilitli}
-          gunTarihi={sayfaTarihiDate}
+          gunTarihi={sayfaTarihi}
           cumaEtiketi={cumaEtiketi}
         />
         {/* ScrollView sonu için boşluk */}


### PR DESCRIPTION
**Özet (sade dil):** Ana sayfadaki saat ve sayaç güncellemelerinin tüm ekranı ve vakit listesini gereksiz yere saniyede bir yeniden çizmesini (re-render) engelledim ve pahalı namaz vakti hesaplamalarının sadece tarih/konum değiştiğinde yapılmasını sağladım.

**Bulgu:** 
`src/presentation/screens/AnaSayfa.tsx:158` (uiNamazlar) ve `src/presentation/components/home/VakitAkisi.tsx:44`. 
AnaSayfa saniyede bir tetiklenen `setKalanSureStr` ile güncelleniyordu. Bu durum, `<VakitAkisi gunTarihi={sayfaTarihiDate} />` bileşenine her saniye yeni bir `Date` referansı gönderilmesine ve `React.memo`'nun bozulmasına neden oluyordu. Ayrıca namaz kılındı/kılınmadı işaretlemesi yapıldığında `uiNamazlar` baştan çalışıyor ve içerisinde 6 vakit için `new PrayerTimes(...)` gibi çok pahalı (trigonometrik) gökbilimsel hesaplamaları tekrarlıyordu. Son olarak `setMekruhBilgi` 60 saniyede bir aynı değeri set etse bile referans değiştiği için re-render'a neden oluyordu.

**Neden önemli:** Ana ekran uygulamanın en çok çalışan sıcak yoludur (hot path). Özellikle `AnaSayfa`'da timer yüzünden saniyede bir çalışan bir döngünün pahalı alt bileşenleri (vakit akışı kartlarını) yeniden çizmesi (gereksiz re-render) cihaz pilini tüketir ve ana sayfada donmalara/takılmalara sebep olabilir.

**Değişiklik:** 
1. `PrayerTimes` hesabı `uiNamazlar` içerisinden çıkartılarak kendi bağımsız `useMemo`'suna (`vakitSaatleri`) alındı. Böylece namazın tamamlanma durumu güncellendiğinde ağır hesaplama tekrar etmiyor.
2. `VakitAkisi` bileşenine `gunTarihi` prop'u olarak `Date` referansı yerine primitif `string` değeri olan `sayfaTarihi` geçirildi ve tarih nesnesi `VakitAkisi` içerisinde `useMemo` ile güvenle parçalandı (parse edildi). Bu sayede `React.memo` düzgün çalışır hale geldi ve saniyelik re-render sızıntısı engellendi.
3. `setMekruhBilgi` içerisindeki objenin mevcut değerle (prev) aynı olması durumunda güncellemeden erken çıkış (bailout) yapması sağlandı.

**Doğrulama:** `npm run verify` geçti. Değişiklikler incelendi ve linting, typecheck, ve test komutlarında bir sorun görülmedi.

---
*PR created automatically by Jules for task [11071606385071597776](https://jules.google.com/task/11071606385071597776) started by @furkanisikay*