### PR TITLE
fix: PaylasimModal renkleri ve erişilebilirlik iyileştirmesi

### DIFF
--- a/src/presentation/components/Sharing/PaylasimModal.tsx
+++ b/src/presentation/components/Sharing/PaylasimModal.tsx
@@ -161,6 +161,7 @@ export const PaylasimModal: React.FC<PaylasimModalProps> = ({
               style={{ backgroundColor: renkler.kartArkaplan, borderWidth: 1, borderColor: renkler.sinir }}
               onPress={onKapat}
               disabled={paylasiliyor}
+              accessibilityRole="button"
             >
               <Text className="font-semibold" style={{ color: renkler.metin }}>Kapat</Text>
             </TouchableOpacity>
@@ -170,13 +171,14 @@ export const PaylasimModal: React.FC<PaylasimModalProps> = ({
               style={{ backgroundColor: renkler.birincil }}
               onPress={paylas}
               disabled={paylasiliyor}
+              accessibilityRole="button"
             >
               {paylasiliyor ? (
-                <ActivityIndicator color="white" />
+                <ActivityIndicator color={renkler.birincilMetin} />
               ) : (
                 <>
-                  <FontAwesome5 name="share-alt" size={18} color="white" style={{ marginRight: 8 }} />
-                  <Text className="font-bold text-white">Hikayene Ekle</Text>
+                  <FontAwesome5 name="share-alt" size={18} color={renkler.birincilMetin} style={{ marginRight: 8 }} />
+                  <Text className="font-bold" style={{ color: renkler.birincilMetin }}>Hikayene Ekle</Text>
                 </>
               )}
             </TouchableOpacity>


### PR DESCRIPTION
1. **Özet:** Paylaşım Modalı içerisindeki butonlarda ekran okuyucular (screen reader) için gerekli olan rol tanımı eksikti ve sabit "white" (beyaz) renkler kullanılarak tema tutarlılığı bozuluyordu; bunlar düzeltildi.
2. **Bulgu:** `src/presentation/components/Sharing/PaylasimModal.tsx` içindeki "Kapat" (satır 161) ve "Hikayene Ekle" (satır 171) butonları, ikon (satır 178) ve `ActivityIndicator` (satır 176).
3. **Kullanıcıya etkisi:** Ekran okuyucu (screen reader) kullanan bir kullanıcı bu öğelerin buton (düğme) olduğunu bilemiyordu. Ayrıca, farklı temalar seçildiğinde buton içerisindeki sabit beyaz metin okunamaz hale (düşük contrast / renk karşıtlığı) gelebilirdi. Bu değişiklik bu tutarsızlığı önler.
4. **Düzeltme:** İlgili `TouchableOpacity` (dokunulabilir alan) öğelerine `accessibilityRole="button"` eklendi. `color="white"` olan tanımlamalar ve `text-white` sınıfı (CSS class'ı) doğrudan `renkler.birincilMetin` (tema belirteci) ile değiştirildi.
5. **Doğrulama:** `npm run verify` başarıyla geçti.

---
*PR created automatically by Jules for task [17623057549866184626](https://jules.google.com/task/17623057549866184626) started by @furkanisikay*