### PR TITLE
fix: Debug log paylaşımında konum ve PII sızıntısı (log leakage) giderildi

### DIFF
--- a/src/presentation/screens/DebugLogsSayfasi.tsx
+++ b/src/presentation/screens/DebugLogsSayfasi.tsx
@@ -19,6 +19,7 @@ import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useRenkler } from '../../core/theme';
 import { Logger, LogLevel, LogEntry } from '../../core/utils/Logger';
+import { loglariMaskele } from '../../domain/services/TaniRaporuServisi';
 import { BildirimModali, BildirimTipi } from '../components/common/BildirimModali';
 
 /**
@@ -243,7 +244,7 @@ export const DebugLogsSayfasi: React.FC = () => {
     }
 
     try {
-      const content = Logger.exportLogs();
+      const content = loglariMaskele(Logger.exportLogs(), { konumDahil: false });
       const fileName = `namazakisi_logs_${Date.now()}.txt`;
       const file = new File(Paths.cache, fileName);
 


### PR DESCRIPTION
Hata ayıklama logları paylaşıldığında hassas kişisel veriler (PII) ve yüksek çözünürlüklü koordinatların maskelenmeden dışa aktarıldığı tespit edilmiştir. Bu durum, kullanıcının cihaz dışına gönderdiği dosyalarda gizlilik sızıntısına yol açmaktadır (Log leakage).

`src/presentation/screens/DebugLogsSayfasi.tsx:246` satırında çağrılan `Logger.exportLogs()` fonksiyonu, `TaniRaporuServisi` içindeki `loglariMaskele` filtresinden geçirilerek konum verileri `[konum gizlendi]` şeklinde tamamen redakte edilmiştir.

`npm run verify` komutu ile değişiklik doğrulanmış ve tüm testlerin başarılı olduğu görülmüştür.

---
*PR created automatically by Jules for task [13687979931763797315](https://jules.google.com/task/13687979931763797315) started by @furkanisikay*