### PR TITLE
fix(ux): Hesaplama Sihirbazı modalına eksik dışa tıklama alanı eklendi

### DIFF
--- a/src/presentation/screens/KazaDefteriSayfasi.tsx
+++ b/src/presentation/screens/KazaDefteriSayfasi.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
+  TouchableWithoutFeedback,
   Modal,
   TextInput,
   StyleSheet,
@@ -620,6 +621,14 @@ export const KazaDefteriSayfasi: React.FC = () => {
           style={styles.modalArkaPlan}
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
+          {/* Backdrop: içeriği saran değil, absoluteFill ile kardeş → scroll/etkileşim bozulmaz */}
+          <TouchableWithoutFeedback
+            onPress={() => setAktifModal(null)}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          >
+            <View style={StyleSheet.absoluteFill} />
+          </TouchableWithoutFeedback>
           <View style={[styles.sihirbazKonteyner, { backgroundColor: renkler.kartArkaplan }]}>
             <View style={styles.sihirbazBaslikSatir}>
               <FontAwesome5 name="magic" size={18} color={renkler.birincil} />


### PR DESCRIPTION
1. **Özet:** Kullanıcıların "Hesaplama Sihirbazı" ekranını dışarıya tıklayarak kapatabilmelerini (dismiss) sağlamak için eksik olan arka plan dokunma alanı (backdrop) eklendi.
2. **Bulgu:** `src/presentation/screens/KazaDefteriSayfasi.tsx:624` (Hesaplama Sihirbazı modalı içinde `KeyboardAvoidingView` doğrudan içeriği render ediyordu, dış tıklamaları yakalayan bir katman yoktu).
3. **Kullanıcıya etkisi:** Kullanıcı modalı kapatmak istediğinde mutlaka "İptal" butonuna basmak zorunda kalıyordu; standart alt-sayfa (bottom-sheet) davranışına uygun olarak modal dışına tıklanarak kapatılabilmesi sağlandı. Bu değişiklik, içerideki kaydırma (scroll) işlemlerini bozmamak adına sarmalayıcı olarak değil, kardeş eleman (`StyleSheet.absoluteFill`) olarak eklendi.
4. **Düzeltme:** Modal içeriğinden hemen önce kardeş (sibling) eleman olarak `<TouchableWithoutFeedback>` eklendi. İçinde `StyleSheet.absoluteFill` stiline sahip boş bir `<View>` kullanılarak ebeveynin (`modalArkaPlan`) paylaşılan yarı saydam arka plan rengi korundu.
5. **Doğrulama:** `npm run verify` komutu başarıyla tamamlandı (lint, typecheck ve testler yeşil).

---
*PR created automatically by Jules for task [17878292919306955376](https://jules.google.com/task/17878292919306955376) started by @furkanisikay*